### PR TITLE
chore(supabase): add Deno formatting and linting for Supabase edge functions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,17 @@
+repos:
+  - repo: local
+    hooks:
+      - id: deno-fmt
+        name: Deno fmt (Edge Functions)
+        entry: deno fmt --config supabase/deno.jsonc --check
+        language: system
+        types_or: [ts, tsx, js, jsx]
+        pass_filenames: false
+        files: ^supabase/functions/
+      - id: deno-lint
+        name: Deno lint (Edge Functions)
+        entry: deno lint --config supabase/deno.jsonc
+        language: system
+        types_or: [ts, tsx, js, jsx]
+        pass_filenames: false
+        files: ^supabase/functions/

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,19 @@
+{
+  "deno.enable": true,
+  "deno.lint": true,
+  "deno.unstable": false,
+  "deno.config": "./supabase/deno.jsonc",
+  "deno.enablePaths": [
+    "supabase/functions"
+  ],
+  "editor.formatOnSave": true,
+  "editor.codeActionsOnSave": {
+    "source.fixAll": "always"
+  },
+  "[typescript]": {
+    "editor.defaultFormatter": "denoland.vscode-deno"
+  },
+  "[typescriptreact]": {
+    "editor.defaultFormatter": "denoland.vscode-deno"
+  }
+}

--- a/README.md
+++ b/README.md
@@ -38,6 +38,23 @@ These configuration files are intentionally excluded from version control, so ea
      ```
    You can also rely on the supplied GitHub Actions for CI/CD if preferred.
 
+## Edge Function formatting & linting
+
+Supabase Edge Functions are written in TypeScript (Deno). A minimal toolchain is provided to
+keep them consistent locally and inside pull requests:
+
+- `.pre-commit-config.yaml` runs `deno fmt --check` and `deno lint` against every
+  `supabase/functions/**` file. Install it once with `pip install pre-commit && pre-commit install`,
+  then the checks run automatically before each commit or manually via `pre-commit run --all-files`.
+- `supabase/deno.jsonc` defines the shared formatting/linting scope so every function follows the
+  same line width, quote style, and lint rule-set.
+- `.vscode/settings.json` enables the official Deno extension only for `supabase/functions`, turns on
+  format-on-save, and applies the same config while editing so you see formatter/lint feedback in the
+  editor.
+
+Ensure you have Deno installed locally (<https://deno.com/manual/getting_started/installation>) so
+that both pre-commit hooks and the VS Code extension can execute.
+
 ## Cloudflare Gateway Worker
 
 The repository includes `cloudflare/gateway-proxy`, a Cloudflare Worker that proxies API traffic to Supabase.

--- a/supabase/deno.jsonc
+++ b/supabase/deno.jsonc
@@ -1,0 +1,28 @@
+// Shared Deno configuration for Supabase Edge Functions
+{
+  "fmt": {
+    "files": {
+      "include": ["functions"],
+      "exclude": [
+        "functions/**/node_modules",
+        "functions/**/dist",
+        "functions/**/vendor"
+      ]
+    },
+    "options": {
+      "lineWidth": 100,
+      "indentWidth": 2,
+      "useTabs": false,
+      "singleQuote": true,
+      "proseWrap": "preserve"
+    }
+  },
+  "lint": {
+    "files": {
+      "include": ["functions"]
+    },
+    "rules": {
+      "tags": ["recommended"]
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add a minimal `.pre-commit-config.yaml` that runs `deno fmt --check` and `deno lint` for the Edge Functions tree
- introduce a shared `supabase/deno.jsonc` so formatting/linting rules stay consistent across functions and editors
- add VS Code workspace settings that enable the Deno extension for `supabase/functions` and document the workflow in the README

## Testing
- Not run (pre-commit is not available in the container image)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691bca9908bc83258381c811cf1ccda9)