### PR TITLE
fix(supabase): inline table constraints

### DIFF
--- a/supabase/schemas/03_tables/001_tasks.sql
+++ b/supabase/schemas/03_tables/001_tasks.sql
@@ -15,3 +15,6 @@ CREATE TABLE IF NOT EXISTS "public"."tasks" (
 
 ALTER TABLE "public"."tasks" OWNER TO "postgres";
 
+ALTER TABLE ONLY "public"."tasks"
+    ADD CONSTRAINT "tasks_pkey" PRIMARY KEY ("id");
+

--- a/supabase/schemas/03_tables/002_judgements.sql
+++ b/supabase/schemas/03_tables/002_judgements.sql
@@ -14,3 +14,6 @@ CREATE TABLE IF NOT EXISTS "public"."judgements" (
 
 ALTER TABLE "public"."judgements" OWNER TO "postgres";
 
+ALTER TABLE ONLY "public"."judgements"
+    ADD CONSTRAINT "judgements_pkey" PRIMARY KEY ("id");
+

--- a/supabase/schemas/03_tables/003_task_evidences.sql
+++ b/supabase/schemas/03_tables/003_task_evidences.sql
@@ -11,3 +11,6 @@ CREATE TABLE IF NOT EXISTS "public"."task_evidences" (
 
 ALTER TABLE "public"."task_evidences" OWNER TO "postgres";
 
+ALTER TABLE ONLY "public"."task_evidences"
+    ADD CONSTRAINT "task_evidences_pkey" PRIMARY KEY ("id");
+

--- a/supabase/schemas/03_tables/004_task_evidence_assets.sql
+++ b/supabase/schemas/03_tables/004_task_evidence_assets.sql
@@ -13,3 +13,6 @@ CREATE TABLE IF NOT EXISTS "public"."task_evidence_assets" (
 
 ALTER TABLE "public"."task_evidence_assets" OWNER TO "postgres";
 
+ALTER TABLE ONLY "public"."task_evidence_assets"
+    ADD CONSTRAINT "task_evidence_assets_pkey" PRIMARY KEY ("id");
+

--- a/supabase/schemas/03_tables/005_task_referee_requests.sql
+++ b/supabase/schemas/03_tables/005_task_referee_requests.sql
@@ -15,3 +15,6 @@ CREATE TABLE IF NOT EXISTS "public"."task_referee_requests" (
 
 ALTER TABLE "public"."task_referee_requests" OWNER TO "postgres";
 
+ALTER TABLE ONLY "public"."task_referee_requests"
+    ADD CONSTRAINT "task_referee_requests_pkey" PRIMARY KEY ("id");
+

--- a/supabase/schemas/03_tables/006_profiles.sql
+++ b/supabase/schemas/03_tables/006_profiles.sql
@@ -11,3 +11,9 @@ CREATE TABLE IF NOT EXISTS "public"."profiles" (
 
 ALTER TABLE "public"."profiles" OWNER TO "postgres";
 
+ALTER TABLE ONLY "public"."profiles"
+    ADD CONSTRAINT "profiles_pkey" PRIMARY KEY ("id");
+
+ALTER TABLE ONLY "public"."profiles"
+    ADD CONSTRAINT "profiles_username_key" UNIQUE ("username");
+

--- a/supabase/schemas/03_tables/007_rating_histories.sql
+++ b/supabase/schemas/03_tables/007_rating_histories.sql
@@ -15,3 +15,9 @@ CREATE TABLE IF NOT EXISTS "public"."rating_histories" (
 
 ALTER TABLE "public"."rating_histories" OWNER TO "postgres";
 
+ALTER TABLE ONLY "public"."rating_histories"
+    ADD CONSTRAINT "rating_history_pkey" PRIMARY KEY ("id");
+
+ALTER TABLE ONLY "public"."rating_histories"
+    ADD CONSTRAINT "unique_rating_per_judgement" UNIQUE ("rater_id", "ratee_id", "judgement_id");
+

--- a/supabase/schemas/03_tables/008_user_ratings.sql
+++ b/supabase/schemas/03_tables/008_user_ratings.sql
@@ -11,3 +11,6 @@ CREATE TABLE IF NOT EXISTS "public"."user_ratings" (
 
 ALTER TABLE "public"."user_ratings" OWNER TO "postgres";
 
+ALTER TABLE ONLY "public"."user_ratings"
+    ADD CONSTRAINT "user_ratings_pkey" PRIMARY KEY ("user_id");
+

--- a/supabase/schemas/03_tables/009_referee_available_time_slots.sql
+++ b/supabase/schemas/03_tables/009_referee_available_time_slots.sql
@@ -16,3 +16,9 @@ CREATE TABLE IF NOT EXISTS "public"."referee_available_time_slots" (
 
 ALTER TABLE "public"."referee_available_time_slots" OWNER TO "postgres";
 
+ALTER TABLE ONLY "public"."referee_available_time_slots"
+    ADD CONSTRAINT "referee_available_time_slots_pkey" PRIMARY KEY ("id");
+
+ALTER TABLE ONLY "public"."referee_available_time_slots"
+    ADD CONSTRAINT "referee_available_time_slots_user_id_dow_start_min_key" UNIQUE ("user_id", "dow", "start_min");
+

--- a/supabase/schemas/03_tables/010_judgement_threads.sql
+++ b/supabase/schemas/03_tables/010_judgement_threads.sql
@@ -10,3 +10,6 @@ CREATE TABLE IF NOT EXISTS "public"."judgement_threads" (
 
 ALTER TABLE "public"."judgement_threads" OWNER TO "postgres";
 
+ALTER TABLE ONLY "public"."judgement_threads"
+    ADD CONSTRAINT "judgement_threads_pkey" PRIMARY KEY ("id");
+

--- a/supabase/schemas/03_tables/011_judgement_thread_assets.sql
+++ b/supabase/schemas/03_tables/011_judgement_thread_assets.sql
@@ -9,3 +9,6 @@ CREATE TABLE IF NOT EXISTS "public"."judgement_thread_assets" (
 
 ALTER TABLE "public"."judgement_thread_assets" OWNER TO "postgres";
 
+ALTER TABLE ONLY "public"."judgement_thread_assets"
+    ADD CONSTRAINT "judgement_thread_assets_pkey" PRIMARY KEY ("id");
+

--- a/supabase/schemas/03_tables/012_stripe_accounts.sql
+++ b/supabase/schemas/03_tables/012_stripe_accounts.sql
@@ -16,3 +16,12 @@ CREATE TABLE IF NOT EXISTS "public"."stripe_accounts" (
 );
 
 ALTER TABLE "public"."stripe_accounts" OWNER TO "postgres";
+
+ALTER TABLE ONLY "public"."stripe_accounts"
+    ADD CONSTRAINT "stripe_accounts_pkey" PRIMARY KEY ("profile_id");
+
+ALTER TABLE ONLY "public"."stripe_accounts"
+    ADD CONSTRAINT "stripe_accounts_stripe_customer_id_key" UNIQUE ("stripe_customer_id");
+
+ALTER TABLE ONLY "public"."stripe_accounts"
+    ADD CONSTRAINT "stripe_accounts_stripe_connect_account_id_key" UNIQUE ("stripe_connect_account_id");

--- a/supabase/schemas/04_constraints_indexes.sql
+++ b/supabase/schemas/04_constraints_indexes.sql
@@ -1,49 +1,4 @@
 -- Constraints
-ALTER TABLE ONLY "public"."judgement_thread_assets"
-    ADD CONSTRAINT "judgement_thread_assets_pkey" PRIMARY KEY ("id");
-
-ALTER TABLE ONLY "public"."judgement_threads"
-    ADD CONSTRAINT "judgement_threads_pkey" PRIMARY KEY ("id");
-
-ALTER TABLE ONLY "public"."judgements"
-    ADD CONSTRAINT "judgements_pkey" PRIMARY KEY ("id");
-
-ALTER TABLE ONLY "public"."profiles"
-    ADD CONSTRAINT "profiles_pkey" PRIMARY KEY ("id");
-
-ALTER TABLE ONLY "public"."profiles"
-    ADD CONSTRAINT "profiles_username_key" UNIQUE ("username");
-
-ALTER TABLE ONLY "public"."rating_histories"
-    ADD CONSTRAINT "rating_history_pkey" PRIMARY KEY ("id");
-
-ALTER TABLE ONLY "public"."referee_available_time_slots"
-    ADD CONSTRAINT "referee_available_time_slots_pkey" PRIMARY KEY ("id");
-
-ALTER TABLE ONLY "public"."referee_available_time_slots"
-    ADD CONSTRAINT "referee_available_time_slots_user_id_dow_start_min_key" UNIQUE ("user_id", "dow", "start_min");
-
-ALTER TABLE ONLY "public"."task_evidence_assets"
-    ADD CONSTRAINT "task_evidence_assets_pkey" PRIMARY KEY ("id");
-
-ALTER TABLE ONLY "public"."task_evidences"
-    ADD CONSTRAINT "task_evidences_pkey" PRIMARY KEY ("id");
-
-ALTER TABLE ONLY "public"."task_referee_requests"
-    ADD CONSTRAINT "task_referee_requests_pkey" PRIMARY KEY ("id");
-
-ALTER TABLE ONLY "public"."tasks"
-    ADD CONSTRAINT "tasks_pkey" PRIMARY KEY ("id");
-
-
-ALTER TABLE ONLY "public"."rating_histories"
-    ADD CONSTRAINT "unique_rating_per_judgement" UNIQUE ("rater_id", "ratee_id", "judgement_id");
-
-
-ALTER TABLE ONLY "public"."user_ratings"
-    ADD CONSTRAINT "user_ratings_pkey" PRIMARY KEY ("user_id");
-
-
 ALTER TABLE ONLY "public"."rating_histories"
     ADD CONSTRAINT "fk_rating_histories_judgement_id" FOREIGN KEY ("judgement_id") REFERENCES "public"."judgements"("id");
 
@@ -94,15 +49,6 @@ ALTER TABLE ONLY "public"."task_referee_requests"
 
 ALTER TABLE ONLY "public"."tasks"
     ADD CONSTRAINT "tasks_tasker_id_fkey" FOREIGN KEY ("tasker_id") REFERENCES "public"."profiles"("id") ON DELETE SET NULL;
-
-ALTER TABLE ONLY "public"."stripe_accounts"
-    ADD CONSTRAINT "stripe_accounts_pkey" PRIMARY KEY ("profile_id");
-
-ALTER TABLE ONLY "public"."stripe_accounts"
-    ADD CONSTRAINT "stripe_accounts_stripe_customer_id_key" UNIQUE ("stripe_customer_id");
-
-ALTER TABLE ONLY "public"."stripe_accounts"
-    ADD CONSTRAINT "stripe_accounts_stripe_connect_account_id_key" UNIQUE ("stripe_connect_account_id");
 
 ALTER TABLE ONLY "public"."stripe_accounts"
     ADD CONSTRAINT "stripe_accounts_profile_id_fkey" FOREIGN KEY ("profile_id") REFERENCES "public"."profiles"("id") ON DELETE CASCADE;


### PR DESCRIPTION
## Summary
- inline each table's primary key and unique constraints alongside the table definition
- keep `04_constraints_indexes.sql` focused on cross-table dependencies such as foreign keys and indexes

## Testing
- Confirmed that a migration file is not generated with `supabase db diff`

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691c6d32f6388325a864fb0fac713833)