### PR TITLE
feat(supabase): add billing jobs retry flow

### DIFF
--- a/.github/workflows/supabase-data-check.yml
+++ b/.github/workflows/supabase-data-check.yml
@@ -34,6 +34,7 @@ jobs:
           declare -A queries
           queries["currencies"]="SELECT code, kind, exponent, description FROM public.currencies ORDER BY code"
           queries["billing_prices"]="SELECT currency_code, matching_strategy, amount_minor FROM public.billing_prices ORDER BY currency_code, matching_strategy"
+          queries["billing_settings"]="SELECT id, max_retry_attempts FROM public.billing_settings ORDER BY id"
 
           for name in "${!queries[@]}"; do
             out="/tmp/${name}_out.csv"

--- a/docs/stripe/billing-retry.md
+++ b/docs/stripe/billing-retry.md
@@ -1,0 +1,25 @@
+# Billing Retry Policy (MVP)
+
+## Scope
+- Applies to `billing_jobs` processed by the Stripe billing worker.
+- Covers automatic retries for payment failures (no error-type-specific handling).
+
+## Retry rule
+- `max_retry_attempts` is stored in `public.billing_settings` (singleton row id=1).
+- Default value: 3. Changeable by updating the row; both SQL functions and the Edge Function read from the same table.
+- A job is considered permanently failed when `attempt_count >= max_retry_attempts` **and** `status = 'failed'`.
+
+## Execution flow
+1) **Cron trigger (hourly)**: `retry_failed_billing_jobs()` selects jobs where `status='failed'` AND `attempt_count < max_retry_attempts`, then posts each job id to the billing worker HTTP endpoint via `pg_net`.
+2) **Claim & increment**: `claim_billing_job(p_job_id)` locks the job, sets `status='processing'`, increments `attempt_count`, and returns the row only if it is `pending` or `failed` and still under the retry limit.
+3) **PaymentIntent**: Billing worker recreates/uses the same PaymentIntent with idempotency key `billing_job_{id}`. Stripe webhook (`finalize_billing_job`) sets the final status (`succeeded` or `failed`) and records the latest error code/message.
+
+## Idempotency & safety
+- Claim function guards against double-processing by status filter + attempt limit + row lock.
+- Cron query excludes `processing`/`succeeded` jobs.
+- Missing `billing_settings` or `max_retry_attempts` causes functions/worker to fail fast (no silent fallback).
+
+## Operational notes
+- Ensure `billing_worker_url` and `service_role_key` secrets are present for cron-triggered HTTP calls.
+- To adjust retries, update `public.billing_settings.max_retry_attempts` (id=1) and redeploy if needed.
+- Manual retry kick: `SELECT public.retry_failed_billing_jobs();` (requires proper secrets).

--- a/supabase/data/billing_settings.csv
+++ b/supabase/data/billing_settings.csv
@@ -1,0 +1,2 @@
+id,max_retry_attempts
+1,3

--- a/supabase/migrations/20251124135306_add_billing_jobs_retry.sql
+++ b/supabase/migrations/20251124135306_add_billing_jobs_retry.sql
@@ -1,0 +1,141 @@
+create extension if not exists "pg_cron" with schema "pg_catalog";
+
+
+  create table "public"."billing_settings" (
+    "id" smallint not null default 1,
+    "max_retry_attempts" integer not null default 3,
+    "created_at" timestamp with time zone not null default now(),
+    "updated_at" timestamp with time zone not null default now()
+      );
+
+
+CREATE UNIQUE INDEX billing_settings_pkey ON public.billing_settings USING btree (id);
+
+alter table "public"."billing_settings" add constraint "billing_settings_pkey" PRIMARY KEY using index "billing_settings_pkey";
+
+alter table "public"."billing_settings" add constraint "billing_settings_singleton" CHECK ((id = 1)) not valid;
+
+alter table "public"."billing_settings" validate constraint "billing_settings_singleton";
+
+set check_function_bodies = off;
+
+CREATE OR REPLACE FUNCTION public.retry_failed_billing_jobs()
+ RETURNS void
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO ''
+AS $function$
+DECLARE
+  v_url text;
+  v_service_role_key text;
+  v_headers jsonb;
+  v_payload jsonb;
+  v_max_attempts integer;
+  v_limit integer := 50;
+  v_count integer := 0;
+  r record;
+BEGIN
+  SELECT decrypted_secret
+    INTO v_url
+    FROM vault.decrypted_secrets
+   WHERE name = 'billing_worker_url';
+
+  SELECT decrypted_secret
+    INTO v_service_role_key
+    FROM vault.decrypted_secrets
+   WHERE name = 'service_role_key';
+
+  IF v_url IS NULL OR v_service_role_key IS NULL THEN
+    RAISE WARNING 'retry_failed_billing_jobs: missing secret (url:%, service_role_key:%)', v_url IS NULL, v_service_role_key IS NULL;
+    RETURN;
+  END IF;
+
+  SELECT max_retry_attempts
+    INTO v_max_attempts
+    FROM public.billing_settings
+   WHERE id = 1;
+
+  IF v_max_attempts IS NULL THEN
+    RAISE EXCEPTION 'retry_failed_billing_jobs: billing_settings not found or max_retry_attempts is null';
+  END IF;
+
+  v_headers := jsonb_build_object(
+    'Content-Type', 'application/json',
+    'Authorization', 'Bearer ' || v_service_role_key,
+    'apikey', v_service_role_key
+  );
+
+  FOR r IN
+    SELECT id
+      FROM public.billing_jobs
+     WHERE status = 'failed'
+       AND attempt_count < v_max_attempts
+     ORDER BY updated_at ASC
+     LIMIT v_limit
+     FOR UPDATE SKIP LOCKED
+  LOOP
+    v_payload := jsonb_build_object('id', r.id);
+
+    PERFORM net.http_post(
+      url => v_url,
+      body => v_payload,
+      headers => v_headers,
+      timeout_milliseconds => 8000
+    );
+
+    v_count := v_count + 1;
+  END LOOP;
+
+  RAISE NOTICE 'retry_failed_billing_jobs: enqueued % jobs', v_count;
+END;
+$function$
+;
+
+CREATE OR REPLACE FUNCTION public.claim_billing_job(p_job_id uuid)
+ RETURNS SETOF public.billing_jobs
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO ''
+AS $function$
+DECLARE
+  v_max_attempts integer;
+BEGIN
+  SELECT max_retry_attempts
+    INTO v_max_attempts
+    FROM public.billing_settings
+   WHERE id = 1;
+
+  IF v_max_attempts IS NULL THEN
+    RAISE EXCEPTION 'claim_billing_job: billing_settings not found or max_retry_attempts is null';
+  END IF;
+
+  RETURN QUERY
+    UPDATE public.billing_jobs
+       SET status = 'processing',
+           attempt_count = attempt_count + 1,
+           updated_at = now()
+     WHERE id = p_job_id
+       AND status IN ('pending', 'failed')
+       AND attempt_count < v_max_attempts
+    RETURNING *;
+END;
+$function$
+;
+
+grant delete on table "public"."billing_settings" to "service_role";
+
+grant insert on table "public"."billing_settings" to "service_role";
+
+grant references on table "public"."billing_settings" to "service_role";
+
+grant select on table "public"."billing_settings" to "service_role";
+
+grant trigger on table "public"."billing_settings" to "service_role";
+
+grant truncate on table "public"."billing_settings" to "service_role";
+
+grant update on table "public"."billing_settings" to "service_role";
+
+CREATE TRIGGER set_billing_settings_updated_at BEFORE UPDATE ON public.billing_settings FOR EACH ROW EXECUTE FUNCTION public.handle_updated_at();
+
+

--- a/supabase/migrations/20251124141000_seed_billing_settings.sql
+++ b/supabase/migrations/20251124141000_seed_billing_settings.sql
@@ -1,0 +1,8 @@
+-- Seed initial billing_settings singleton row
+BEGIN;
+
+INSERT INTO public.billing_settings (id, max_retry_attempts)
+VALUES (1, 3)
+ON CONFLICT (id) DO NOTHING;
+
+COMMIT;

--- a/supabase/schemas/00_extensions.sql
+++ b/supabase/schemas/00_extensions.sql
@@ -4,3 +4,5 @@ CREATE EXTENSION IF NOT EXISTS pgcrypto WITH SCHEMA extensions;
 CREATE EXTENSION IF NOT EXISTS pg_net WITH SCHEMA net;
 -- Secret management for Postgres-side access to Supabase secrets
 CREATE EXTENSION IF NOT EXISTS supabase_vault WITH SCHEMA vault;
+-- Job scheduling for retries
+CREATE EXTENSION IF NOT EXISTS pg_cron WITH SCHEMA pg_catalog;

--- a/supabase/schemas/03_tables/017_billing_settings.sql
+++ b/supabase/schemas/03_tables/017_billing_settings.sql
@@ -1,0 +1,11 @@
+-- Table: billing_settings
+CREATE TABLE IF NOT EXISTS public.billing_settings (
+    id smallint PRIMARY KEY DEFAULT 1,
+    max_retry_attempts integer NOT NULL DEFAULT 3,
+    created_at timestamp with time zone NOT NULL DEFAULT now(),
+    updated_at timestamp with time zone NOT NULL DEFAULT now(),
+    CONSTRAINT billing_settings_singleton CHECK (id = 1)
+);
+
+COMMENT ON TABLE public.billing_settings IS 'Singleton configuration for billing behavior (e.g., retry limits).';
+COMMENT ON COLUMN public.billing_settings.max_retry_attempts IS 'Maximum automatic retry attempts for billing_jobs before permanent failure.';

--- a/supabase/schemas/06_functions/011_retry_billing_jobs.sql
+++ b/supabase/schemas/06_functions/011_retry_billing_jobs.sql
@@ -1,0 +1,73 @@
+-- Enqueue failed billing jobs for retry via pg_cron.
+CREATE OR REPLACE FUNCTION public.retry_failed_billing_jobs()
+RETURNS void
+    LANGUAGE plpgsql
+    SECURITY DEFINER
+    SET search_path = ''
+AS $$
+DECLARE
+  v_url text;
+  v_service_role_key text;
+  v_headers jsonb;
+  v_payload jsonb;
+  v_max_attempts integer;
+  v_limit integer := 50;
+  v_count integer := 0;
+  r record;
+BEGIN
+  SELECT decrypted_secret
+    INTO v_url
+    FROM vault.decrypted_secrets
+   WHERE name = 'billing_worker_url';
+
+  SELECT decrypted_secret
+    INTO v_service_role_key
+    FROM vault.decrypted_secrets
+   WHERE name = 'service_role_key';
+
+  IF v_url IS NULL OR v_service_role_key IS NULL THEN
+    RAISE WARNING 'retry_failed_billing_jobs: missing secret (url:%, service_role_key:%)', v_url IS NULL, v_service_role_key IS NULL;
+    RETURN;
+  END IF;
+
+  SELECT max_retry_attempts
+    INTO v_max_attempts
+    FROM public.billing_settings
+   WHERE id = 1;
+
+  IF v_max_attempts IS NULL THEN
+    RAISE EXCEPTION 'retry_failed_billing_jobs: billing_settings not found or max_retry_attempts is null';
+  END IF;
+
+  v_headers := jsonb_build_object(
+    'Content-Type', 'application/json',
+    'Authorization', 'Bearer ' || v_service_role_key,
+    'apikey', v_service_role_key
+  );
+
+  FOR r IN
+    SELECT id
+      FROM public.billing_jobs
+     WHERE status = 'failed'
+       AND attempt_count < v_max_attempts
+     ORDER BY updated_at ASC
+     LIMIT v_limit
+     FOR UPDATE SKIP LOCKED
+  LOOP
+    v_payload := jsonb_build_object('id', r.id);
+
+    PERFORM net.http_post(
+      url => v_url,
+      body => v_payload,
+      headers => v_headers,
+      timeout_milliseconds => 8000
+    );
+
+    v_count := v_count + 1;
+  END LOOP;
+
+  RAISE NOTICE 'retry_failed_billing_jobs: enqueued % jobs', v_count;
+END;
+$$;
+
+COMMENT ON FUNCTION public.retry_failed_billing_jobs() IS 'Enqueues failed billing_jobs (under retry limit) to the billing-worker Edge Function.';

--- a/supabase/schemas/07_triggers.sql
+++ b/supabase/schemas/07_triggers.sql
@@ -88,6 +88,11 @@ CREATE OR REPLACE TRIGGER set_stripe_accounts_updated_at
 BEFORE UPDATE ON public.stripe_accounts
 FOR EACH ROW EXECUTE FUNCTION public.handle_updated_at();
 
+-- billing_settings -------------------------------------------------
+CREATE OR REPLACE TRIGGER set_billing_settings_updated_at
+BEFORE UPDATE ON public.billing_settings
+FOR EACH ROW EXECUTE FUNCTION public.handle_updated_at();
+
 -- billing_jobs ----------------------------------------------------
 CREATE OR REPLACE TRIGGER set_billing_jobs_updated_at
 BEFORE UPDATE ON public.billing_jobs

--- a/supabase/schemas/09_grants.sql
+++ b/supabase/schemas/09_grants.sql
@@ -3,3 +3,8 @@
 REVOKE ALL ON public.billing_prices FROM anon;
 REVOKE ALL ON public.billing_prices FROM authenticated;
 GRANT SELECT ON public.billing_prices TO service_role;
+
+-- Billing settings are admin-only; no anon/authenticated access
+REVOKE ALL ON public.billing_settings FROM anon;
+REVOKE ALL ON public.billing_settings FROM authenticated;
+GRANT SELECT, UPDATE ON public.billing_settings TO service_role;

--- a/supabase/schemas/10_cron_jobs.sql
+++ b/supabase/schemas/10_cron_jobs.sql
@@ -1,1 +1,8 @@
--- No pg_cron jobs defined
+-- pg_cron jobs
+
+-- Retries failed billing_jobs up to max_retry_attempts every hour.
+SELECT cron.schedule(
+  'billing_retry_hourly',
+  '0 * * * *',
+  $$SELECT public.retry_failed_billing_jobs();$$
+);


### PR DESCRIPTION
## Description

- Add billing_settings singleton table and wire retry limit lookup across SQL functions and billing worker.
- Enable pg_cron (pg_catalog) and hourly retry enqueue via retry_failed_billing_jobs(); worker claim now gates by retry limit and fails fast if settings missing.
- Add retry policy doc (docs/stripe/billing-retry.md) and CI CSV check for billing_settings; seed migration for initial row.
- Issues: closes #55, closes #56, closes #57.

## Test performed
- Manual SQL: SELECT public.retry_failed_billing_jobs();
- Verified failed job with wrong payment id increments attempts to limit; corrected payment id then succeeds on retry.
