### PR TITLE
chore(gitignore): add .worktrees/ directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@
 
 # slang i18n generated analysis files
 peppercheck_flutter/assets/i18n/_*.json
+
+# Git worktrees
+.worktrees/


### PR DESCRIPTION
## Summary
- Add `.worktrees/` to `.gitignore` to prevent git worktree contents from being tracked

## Test plan
- [x] Verify `.worktrees/` is ignored by `git check-ignore`

🤖 Generated with [Claude Code](https://claude.com/claude-code)