### PR TITLE
chore: add Supabase CLI workflow rule

### DIFF
--- a/.claude/rules/supabase-workflow.md
+++ b/.claude/rules/supabase-workflow.md
@@ -1,0 +1,15 @@
+# Supabase CLI Workflow Rules
+
+## Migration File Creation
+
+NEVER manually create migration SQL files in `supabase/migrations/`.
+
+Always use the auto-generation workflow:
+1. Apply schema changes directly to the local database (via Studio UI, SQL editor, or direct SQL)
+2. Run `supabase db diff -f <descriptive_migration_name>` to auto-generate the migration file
+3. Review the generated migration file for correctness
+4. Run `supabase db reset` to verify the full migration history works from scratch
+
+Use descriptive snake_case names:
+- `supabase db diff -f add_user_profiles_table`
+- `supabase db diff -f add_rls_policies_to_orders`


### PR DESCRIPTION
## Summary
- Add `.claude/rules/supabase-workflow.md` to enforce the migration auto-generation workflow
- Ensures migrations are always created via `supabase db diff` instead of manual file creation
- Works together with the existing `db-reset.md` rule for emulator testing scenarios

## Test plan
- [ ] Verify the rule file is correctly picked up by Claude Code
- [ ] Confirm migration workflow guidance is applied when working with Supabase migrations

🤖 Generated with [Claude Code](https://claude.com/claude-code)