### PR TITLE
fix: improve evidence timeout section UI clarity

### DIFF
--- a/peppercheck_flutter/assets/i18n/ja.i18n.json
+++ b/peppercheck_flutter/assets/i18n/ja.i18n.json
@@ -130,9 +130,8 @@
       "success": "エビデンスを提出しました",
       "error": "エラーが発生しました: $message",
       "timeout": {
-        "title": "エビデンス未提出",
         "description": "期限を過ぎました。ポイントが支払われました。",
-        "confirm": "確認する",
+        "confirm": "確認",
         "confirmed": "確認済み",
         "success": "確認しました"
       }

--- a/peppercheck_flutter/lib/features/evidence/presentation/widgets/evidence_submission_section.dart
+++ b/peppercheck_flutter/lib/features/evidence/presentation/widgets/evidence_submission_section.dart
@@ -6,6 +6,7 @@ import 'package:image_picker/image_picker.dart';
 import 'package:peppercheck_flutter/app/theme/app_colors.dart';
 import 'package:peppercheck_flutter/app/theme/app_sizes.dart';
 import 'package:peppercheck_flutter/common_widgets/action_button.dart';
+import 'package:peppercheck_flutter/common_widgets/primary_action_button.dart';
 import 'package:peppercheck_flutter/common_widgets/base_text_field.dart';
 
 import 'package:peppercheck_flutter/features/evidence/presentation/controllers/evidence_controller.dart';
@@ -164,7 +165,7 @@ class _EvidenceSubmissionSectionState
       );
 
       return BaseSection(
-        title: t.task.evidence.timeout.title,
+        title: t.task.evidence.submit,
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
@@ -190,8 +191,9 @@ class _EvidenceSubmissionSectionState
                 ),
                 const SizedBox(height: AppSizes.spacingSmall),
               ],
-              ActionButton(
+              PrimaryActionButton(
                 text: t.task.evidence.timeout.confirm,
+                icon: Icons.check,
                 onPressed: () => _confirmTimeout(),
                 isLoading: isLoading,
               ),

--- a/peppercheck_flutter/lib/gen/slang/strings.g.dart
+++ b/peppercheck_flutter/lib/gen/slang/strings.g.dart
@@ -4,9 +4,9 @@
 /// To regenerate, run: `dart run slang`
 ///
 /// Locales: 1
-/// Strings: 130
+/// Strings: 129
 ///
-/// Built on 2026-02-15 at 09:49 UTC
+/// Built on 2026-02-15 at 10:39 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint, unused_import

--- a/peppercheck_flutter/lib/gen/slang/strings_ja.g.dart
+++ b/peppercheck_flutter/lib/gen/slang/strings_ja.g.dart
@@ -614,14 +614,11 @@ class TranslationsTaskEvidenceTimeoutJa {
 
 	// Translations
 
-	/// ja: 'エビデンス未提出'
-	String get title => 'エビデンス未提出';
-
 	/// ja: '期限を過ぎました。ポイントが支払われました。'
 	String get description => '期限を過ぎました。ポイントが支払われました。';
 
-	/// ja: '確認する'
-	String get confirm => '確認する';
+	/// ja: '確認'
+	String get confirm => '確認';
 
 	/// ja: '確認済み'
 	String get confirmed => '確認済み';
@@ -765,9 +762,8 @@ extension on Translations {
 			'task.evidence.maxImages' => '画像は最大5枚までです',
 			'task.evidence.success' => 'エビデンスを提出しました',
 			'task.evidence.error' => ({required Object message}) => 'エラーが発生しました: ${message}',
-			'task.evidence.timeout.title' => 'エビデンス未提出',
 			'task.evidence.timeout.description' => '期限を過ぎました。ポイントが支払われました。',
-			'task.evidence.timeout.confirm' => '確認する',
+			'task.evidence.timeout.confirm' => '確認',
 			'task.evidence.timeout.confirmed' => '確認済み',
 			'task.evidence.timeout.success' => '確認しました',
 			'task.judgement.title' => '判定',


### PR DESCRIPTION
## Summary
- Change timeout section title from "エビデンス未提出" to reuse "エビデンスを提出" (consistent with normal submission)
- Replace `ActionButton` (blue outline) with `PrimaryActionButton` (yellow filled) and add check icon
- Shorten confirm button text from "確認する" to "確認"
- Remove unused `task.evidence.timeout.title` translation key

## Test plan
- [x] Display a task in evidence timeout state on Android/iOS emulator
- [x] Verify section title shows "エビデンスを提出"
- [x] Verify yellow confirm button with check icon and "確認" label
- [x] Verify confirm action completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)