### PR TITLE
chore: enable Stripe plugin for Claude Code

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,6 @@
 {
   "enabledPlugins": {
-    "postgres-best-practices@supabase-agent-skills": true
+    "postgres-best-practices@supabase-agent-skills": true,
+    "stripe@claude-plugins-official": true
   }
 }


### PR DESCRIPTION
## Summary
- Enable the Stripe plugin (`stripe@claude-plugins-official`) for Claude Code

## Test plan
- [x] Verify Stripe-related tools are available in Claude Code sessions

🤖 Generated with [Claude Code](https://claude.com/claude-code)