### PR TITLE
feat: add confetti animation on approved judgement confirm

### DIFF
--- a/peppercheck_flutter/lib/features/judgement/presentation/widgets/judgement_section.dart
+++ b/peppercheck_flutter/lib/features/judgement/presentation/widgets/judgement_section.dart
@@ -1,3 +1,6 @@
+import 'dart:math';
+
+import 'package:confetti/confetti.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:peppercheck_flutter/app/theme/app_colors.dart';
@@ -24,16 +27,24 @@ class JudgementSection extends ConsumerStatefulWidget {
 class _JudgementSectionState extends ConsumerState<JudgementSection> {
   final _commentController = TextEditingController();
   final _confirmCommentController = TextEditingController();
+  late final ConfettiController _confettiLeftController;
+  late final ConfettiController _confettiRightController;
   bool? _selectedIsPositive;
 
   @override
   void initState() {
     super.initState();
+    _confettiLeftController =
+        ConfettiController(duration: const Duration(seconds: 1));
+    _confettiRightController =
+        ConfettiController(duration: const Duration(seconds: 1));
     _commentController.addListener(() => setState(() {}));
   }
 
   @override
   void dispose() {
+    _confettiLeftController.dispose();
+    _confettiRightController.dispose();
     _commentController.dispose();
     _confirmCommentController.dispose();
     super.dispose();
@@ -90,10 +101,56 @@ class _JudgementSectionState extends ConsumerState<JudgementSection> {
       return const SizedBox.shrink();
     }
 
-    return Column(
+    return Stack(
+      alignment: Alignment.bottomCenter,
       children: [
-        if (completedRequests.isNotEmpty) _buildResultView(completedRequests),
-        if (showForm) _buildFormView(),
+        Column(
+          children: [
+            if (completedRequests.isNotEmpty)
+              _buildResultView(completedRequests),
+            if (showForm) _buildFormView(),
+          ],
+        ),
+        Positioned(
+          bottom: 0,
+          left: 0,
+          child: ConfettiWidget(
+            confettiController: _confettiLeftController,
+            blastDirection: -pi / 3,
+            emissionFrequency: 0.03,
+            numberOfParticles: 12,
+            maxBlastForce: 30,
+            minBlastForce: 10,
+            gravity: 0.1,
+            shouldLoop: false,
+            colors: const [
+              AppColors.accentYellowLight,
+              AppColors.accentGreenLight,
+              AppColors.backgroundDark,
+              AppColors.accentYellow,
+            ],
+          ),
+        ),
+        Positioned(
+          bottom: 0,
+          right: 0,
+          child: ConfettiWidget(
+            confettiController: _confettiRightController,
+            blastDirection: -2 * pi / 3,
+            emissionFrequency: 0.03,
+            numberOfParticles: 12,
+            maxBlastForce: 30,
+            minBlastForce: 10,
+            gravity: 0.1,
+            shouldLoop: false,
+            colors: const [
+              AppColors.accentYellowLight,
+              AppColors.accentGreenLight,
+              AppColors.backgroundDark,
+              AppColors.accentYellow,
+            ],
+          ),
+        ),
       ],
     );
   }
@@ -331,6 +388,10 @@ class _JudgementSectionState extends ConsumerState<JudgementSection> {
               ? null
               : _confirmCommentController.text.trim(),
           onSuccess: () {
+            if (judgement.status == 'approved') {
+              _confettiLeftController.play();
+              _confettiRightController.play();
+            }
             setState(() {
               _selectedIsPositive = null;
               _confirmCommentController.clear();

--- a/peppercheck_flutter/pubspec.lock
+++ b/peppercheck_flutter/pubspec.lock
@@ -225,6 +225,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.0"
+  confetti:
+    dependency: "direct main"
+    description:
+      name: confetti
+      sha256: "79376a99648efbc3f23582f5784ced0fe239922bd1a0fb41f582051eba750751"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.8.0"
   convert:
     dependency: transitive
     description:

--- a/peppercheck_flutter/pubspec.yaml
+++ b/peppercheck_flutter/pubspec.yaml
@@ -61,6 +61,7 @@ dependencies:
   flutter_local_notifications:
   dio: ^5.9.0
   image_picker: ^1.2.1
+  confetti: ^0.8.0
   mime: ^2.0.0
 
 dev_dependencies:


### PR DESCRIPTION
## Summary
- Add celebratory confetti animation when tasker confirms an approved judgement
- Confetti shoots from bottom-left and bottom-right corners at 60° angles, meeting in the center
- Uses the app's warm color palette (yellow, green, beige) for a subtle, on-brand effect
- Only triggers on approved confirms — rejected/timeout confirms show no animation

Closes #72 (completion animation sub-task)

## Test plan
- [x] Confirm an approved judgement as tasker → confetti plays from both corners
- [x] Confirm a rejected judgement as tasker → no confetti
- [x] Confirm a review timeout as tasker → no confetti
- [x] Navigate away during confetti → no errors/crashes

🤖 Generated with [Claude Code](https://claude.com/claude-code)