### PR TITLE
refactor: rename Supabase ANON_KEY secrets to PUBLISHABLE_KEY

### DIFF
--- a/.github/workflows/deploy-beta.yml
+++ b/.github/workflows/deploy-beta.yml
@@ -70,7 +70,7 @@ jobs:
         run: |
           cat > assets/env/.env.staging <<EOF
           SUPABASE_URL=https://${{ secrets.BETA_SUPABASE_PROJECT_ID }}.supabase.co
-          SUPABASE_ANON_KEY=${{ secrets.BETA_SUPABASE_ANON_KEY }}
+          SUPABASE_ANON_KEY=${{ secrets.BETA_SUPABASE_PUBLISHABLE_KEY }}
           STRIPE_PUBLISHABLE_KEY=${{ secrets.BETA_STRIPE_PUBLISHABLE_KEY }}
           WEB_DASHBOARD_URL=https://staging.peppercheck.dev/dashboard
           EOF
@@ -127,7 +127,7 @@ jobs:
         run: |
           cat > .env.local <<EOF
           NEXT_PUBLIC_SUPABASE_URL=https://${{ secrets.BETA_SUPABASE_PROJECT_ID }}.supabase.co
-          NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY=${{ secrets.BETA_SUPABASE_ANON_KEY }}
+          NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY=${{ secrets.BETA_SUPABASE_PUBLISHABLE_KEY }}
           EOF
 
       - name: Build and deploy to Cloudflare (staging)

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -70,7 +70,7 @@ jobs:
         run: |
           cat > assets/env/.env.production <<EOF
           SUPABASE_URL=https://${{ secrets.PROD_SUPABASE_PROJECT_ID }}.supabase.co
-          SUPABASE_ANON_KEY=${{ secrets.PROD_SUPABASE_ANON_KEY }}
+          SUPABASE_ANON_KEY=${{ secrets.PROD_SUPABASE_PUBLISHABLE_KEY }}
           STRIPE_PUBLISHABLE_KEY=${{ secrets.PROD_STRIPE_PUBLISHABLE_KEY }}
           WEB_DASHBOARD_URL=https://peppercheck.dev/dashboard
           EOF
@@ -129,7 +129,7 @@ jobs:
         run: |
           cat > .env.local <<EOF
           NEXT_PUBLIC_SUPABASE_URL=https://${{ secrets.PROD_SUPABASE_PROJECT_ID }}.supabase.co
-          NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY=${{ secrets.PROD_SUPABASE_ANON_KEY }}
+          NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY=${{ secrets.PROD_SUPABASE_PUBLISHABLE_KEY }}
           EOF
 
       - name: Build and deploy to Cloudflare (production)


### PR DESCRIPTION
## Summary
Supabase renamed anon key to publishable key (anon is now legacy). Update GitHub Secret references:
- `BETA_SUPABASE_ANON_KEY` → `BETA_SUPABASE_PUBLISHABLE_KEY`
- `PROD_SUPABASE_ANON_KEY` → `PROD_SUPABASE_PUBLISHABLE_KEY`

Only the secret name references in workflows are changed. The Flutter env variable name (`SUPABASE_ANON_KEY`) is unchanged here — that requires Flutter app code changes tracked in #276.

🤖 Generated with [Claude Code](https://claude.com/claude-code)