### PR TITLE
refactor: replace googleapis with jose + fetch in verify-google-purchase

### DIFF
--- a/supabase/functions/verify-google-purchase/deno.json
+++ b/supabase/functions/verify-google-purchase/deno.json
@@ -1,6 +1,6 @@
 {
   "imports": {
-    "googleapis": "npm:googleapis@^168.0.0",
+    "jose": "npm:jose@^6",
     "@supabase/supabase-js": "jsr:@supabase/supabase-js@2"
   }
 }


### PR DESCRIPTION
## Summary
- Replace heavy `googleapis` npm package (~hundreds of MB) with lightweight `jose` library (~few KB)
- Supabase Edge Functions deployment was failing with HTTP 500 during server-side bundling due to package size
- Use direct REST API calls via `fetch` instead of Google client library wrapper
- Business logic (purchase verification, DB upsert) unchanged

## Test plan
- [ ] Verify Edge Function deploys successfully via `supabase functions deploy`
- [ ] Manual test with Google Play test purchase (when available)

🤖 Generated with [Claude Code](https://claude.com/claude-code)