### PR TITLE
fix: add placeholder env files in deploy workflows

### DIFF
--- a/.github/workflows/deploy-beta.yml
+++ b/.github/workflows/deploy-beta.yml
@@ -66,6 +66,13 @@ jobs:
       - name: Install dependencies
         run: flutter pub get
 
+      - name: Create placeholder env files
+        run: |
+          mkdir -p assets/env
+          touch assets/env/.env.debug
+          touch assets/env/.env.staging
+          touch assets/env/.env.production
+
       - name: Generate staging env file
         run: |
           cat > assets/env/.env.staging <<EOF

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -66,6 +66,13 @@ jobs:
       - name: Install dependencies
         run: flutter pub get
 
+      - name: Create placeholder env files
+        run: |
+          mkdir -p assets/env
+          touch assets/env/.env.debug
+          touch assets/env/.env.staging
+          touch assets/env/.env.production
+
       - name: Generate production env file
         run: |
           cat > assets/env/.env.production <<EOF


### PR DESCRIPTION
## Summary
- Flutter build in deploy-beta/deploy-production fails with "No file or variants found for asset: assets/env/.env.debug"
- `pubspec.yaml` declares all 3 env files as assets, but deploy workflows only generated the target environment's file
- Add placeholder creation step (matching ci-flutter) before generating the real env file
- The real env file (with secrets) is generated in the next step and overwrites the placeholder

## Test plan
- [ ] deploy-beta Flutter build passes with all env files present

🤖 Generated with [Claude Code](https://claude.com/claude-code)