### PR TITLE
fix: generate google-services.json from GitHub Secret in deploy workflows

### DIFF
--- a/.github/workflows/deploy-beta.yml
+++ b/.github/workflows/deploy-beta.yml
@@ -82,6 +82,9 @@ jobs:
           WEB_DASHBOARD_URL=https://staging.peppercheck.dev/dashboard
           EOF
 
+      - name: Generate google-services.json
+        run: echo '${{ secrets.GOOGLE_SERVICES_JSON }}' > android/app/google-services.json
+
       - name: Decode keystore
         run: echo "${{ secrets.ANDROID_KEYSTORE_BASE64 }}" | base64 -d > android/app/upload-keystore.jks
 

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -82,6 +82,9 @@ jobs:
           WEB_DASHBOARD_URL=https://peppercheck.dev/dashboard
           EOF
 
+      - name: Generate google-services.json
+        run: echo '${{ secrets.GOOGLE_SERVICES_JSON }}' > android/app/google-services.json
+
       - name: Decode keystore
         run: echo "${{ secrets.ANDROID_KEYSTORE_BASE64 }}" | base64 -d > android/app/upload-keystore.jks
 

--- a/scripts/github-secrets.example
+++ b/scripts/github-secrets.example
@@ -50,3 +50,7 @@ CLOUDFLARE_ACCOUNT_ID=
 #   gh secret set FIREBASE_SERVICE_ACCOUNT_JSON < /path/to/firebase-service-account.json
 #   (Google Cloud Console > IAM > Service Accounts > Create key > JSON)
 #   (Required role: Firebase App Distribution Admin)
+#
+# GOOGLE_SERVICES_JSON:
+#   gh secret set GOOGLE_SERVICES_JSON < peppercheck_flutter/android/app/google-services.json
+#   (Firebase Console > Project Settings > Your apps > google-services.json)


### PR DESCRIPTION
## Summary
- Flutter build in deploy workflows fails with "File google-services.json is missing"
- `google-services.json` is gitignored (public repo — avoids fork confusion with Firebase project)
- Add step to generate it from `GOOGLE_SERVICES_JSON` GitHub Secret in both deploy-beta and deploy-production
- Document the new secret in `scripts/github-secrets.example`

## Test plan
- [ ] deploy-beta Flutter build passes with google-services.json generated from secret

🤖 Generated with [Claude Code](https://claude.com/claude-code)