### PR TITLE
fix: use quoted heredocs to prevent shell expansion of secret values

### DIFF
--- a/.github/workflows/deploy-beta.yml
+++ b/.github/workflows/deploy-beta.yml
@@ -75,7 +75,7 @@ jobs:
 
       - name: Generate staging env file
         run: |
-          cat > assets/env/.env.staging <<EOF
+          cat > assets/env/.env.staging <<'EOF'
           SUPABASE_URL=https://${{ secrets.BETA_SUPABASE_PROJECT_ID }}.supabase.co
           SUPABASE_ANON_KEY=${{ secrets.BETA_SUPABASE_PUBLISHABLE_KEY }}
           STRIPE_PUBLISHABLE_KEY=${{ secrets.BETA_STRIPE_PUBLISHABLE_KEY }}
@@ -90,7 +90,7 @@ jobs:
 
       - name: Create key.properties
         run: |
-          cat > android/key.properties <<EOF
+          cat > android/key.properties <<'EOF'
           storePassword=${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
           keyPassword=${{ secrets.ANDROID_KEY_PASSWORD }}
           keyAlias=${{ secrets.ANDROID_KEY_ALIAS }}
@@ -135,7 +135,7 @@ jobs:
 
       - name: Set staging environment
         run: |
-          cat > .env.local <<EOF
+          cat > .env.local <<'EOF'
           NEXT_PUBLIC_SUPABASE_URL=https://${{ secrets.BETA_SUPABASE_PROJECT_ID }}.supabase.co
           NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY=${{ secrets.BETA_SUPABASE_PUBLISHABLE_KEY }}
           EOF

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -75,7 +75,7 @@ jobs:
 
       - name: Generate production env file
         run: |
-          cat > assets/env/.env.production <<EOF
+          cat > assets/env/.env.production <<'EOF'
           SUPABASE_URL=https://${{ secrets.PROD_SUPABASE_PROJECT_ID }}.supabase.co
           SUPABASE_ANON_KEY=${{ secrets.PROD_SUPABASE_PUBLISHABLE_KEY }}
           STRIPE_PUBLISHABLE_KEY=${{ secrets.PROD_STRIPE_PUBLISHABLE_KEY }}
@@ -90,7 +90,7 @@ jobs:
 
       - name: Create key.properties
         run: |
-          cat > android/key.properties <<EOF
+          cat > android/key.properties <<'EOF'
           storePassword=${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
           keyPassword=${{ secrets.ANDROID_KEY_PASSWORD }}
           keyAlias=${{ secrets.ANDROID_KEY_ALIAS }}
@@ -137,7 +137,7 @@ jobs:
 
       - name: Set production environment
         run: |
-          cat > .env.local <<EOF
+          cat > .env.local <<'EOF'
           NEXT_PUBLIC_SUPABASE_URL=https://${{ secrets.PROD_SUPABASE_PROJECT_ID }}.supabase.co
           NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY=${{ secrets.PROD_SUPABASE_PUBLISHABLE_KEY }}
           EOF

--- a/scripts/setup-github-secrets.sh
+++ b/scripts/setup-github-secrets.sh
@@ -53,7 +53,7 @@ while IFS= read -r line; do
   fi
 
   # Set the secret
-  if echo "$value" | gh secret set "$key" 2>/dev/null; then
+  if printf '%s' "$value" | gh secret set "$key" 2>/dev/null; then
     echo "  SET   $key"
     ((count++))
   else


### PR DESCRIPTION
## Summary
- Keystore password with special characters (`$`, `\`, etc.) was being mangled by bash shell expansion in unquoted heredocs
- Changed all `<<EOF` to `<<'EOF'` in deploy-beta and deploy-production workflows
- GitHub Actions substitutes `${{ secrets.X }}` before bash sees the script, so quoted heredocs correctly prevent double-interpretation
- Also fixed `setup-github-secrets.sh` to use `printf '%s'` instead of `echo` for the same reason

## Test plan
- [ ] Re-set keystore secrets via `gh secret set` and verify deploy-beta Flutter build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)