### PR TITLE
fix: update Firebase App Distribution group to beta-testers

### DIFF
--- a/.github/workflows/deploy-beta.yml
+++ b/.github/workflows/deploy-beta.yml
@@ -111,7 +111,7 @@ jobs:
           firebase appdistribution:distribute \
             build/app/outputs/flutter-apk/app-release.apk \
             --app "${{ secrets.FIREBASE_APP_ID }}" \
-            --groups "internal-testers" \
+            --groups "beta-testers" \
             --release-notes "Beta build from ${{ github.ref_name }} (${GITHUB_SHA::7})"
 
   webapp-deploy:


### PR DESCRIPTION
## Summary
- Change `--groups "internal-testers"` to `--groups "beta-testers"` in deploy-beta workflow
- The `beta-testers` group has been created in Firebase Console

## Test plan
- [ ] deploy-beta completes successfully including Firebase App Distribution upload

🤖 Generated with [Claude Code](https://claude.com/claude-code)