### PR TITLE
feat: derive app version from branch/tag name in deploy workflows

### DIFF
--- a/.github/workflows/deploy-beta.yml
+++ b/.github/workflows/deploy-beta.yml
@@ -97,8 +97,19 @@ jobs:
           storeFile=upload-keystore.jks
           EOF
 
+      - name: Extract version from branch name
+        id: version
+        run: |
+          # beta/v0.3 → 0.3.0-beta.N
+          BASE_VERSION="${GITHUB_REF_NAME#beta/v}"
+          echo "build_name=${BASE_VERSION}.0-beta.${{ github.run_number }}" >> "$GITHUB_OUTPUT"
+          echo "build_number=${{ github.run_number }}" >> "$GITHUB_OUTPUT"
+
       - name: Build staging APK
-        run: flutter build apk --release -t lib/main_staging.dart
+        run: |
+          flutter build apk --release -t lib/main_staging.dart \
+            --build-name=${{ steps.version.outputs.build_name }} \
+            --build-number=${{ steps.version.outputs.build_number }}
 
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v2
@@ -112,7 +123,7 @@ jobs:
             build/app/outputs/flutter-apk/app-release.apk \
             --app "${{ secrets.FIREBASE_APP_ID }}" \
             --groups "beta-testers" \
-            --release-notes "Beta build from ${{ github.ref_name }} (${GITHUB_SHA::7})"
+            --release-notes "Beta ${{ steps.version.outputs.build_name }} (${GITHUB_SHA::7})"
 
   webapp-deploy:
     needs: supabase-deploy

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -97,8 +97,18 @@ jobs:
           storeFile=upload-keystore.jks
           EOF
 
+      - name: Extract version from tag
+        id: version
+        run: |
+          # v0.3.0 → 0.3.0
+          echo "build_name=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+          echo "build_number=${{ github.run_number }}" >> "$GITHUB_OUTPUT"
+
       - name: Build production AAB
-        run: flutter build appbundle --release -t lib/main_production.dart
+        run: |
+          flutter build appbundle --release -t lib/main_production.dart \
+            --build-name=${{ steps.version.outputs.build_name }} \
+            --build-number=${{ steps.version.outputs.build_number }}
 
       - name: Upload AAB artifact
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary
- Beta builds (`beta/v0.3` branch) get version `0.3.0-beta.N` where N is `github.run_number`
- Production builds (`v0.3.0` tag) get version `0.3.0`
- Uses `flutter build --build-name` and `--build-number` flags
- Firebase App Distribution release notes also show the version

## Test plan
- [ ] Merge to main, update `beta/v0.3` branch, verify Firebase shows version like `0.3.0-beta.N`

🤖 Generated with [Claude Code](https://claude.com/claude-code)