### PR TITLE
fix: add pg_net extension to migration history

### DIFF
--- a/supabase/migrations/20260302130018_add_pg_net_extension.sql
+++ b/supabase/migrations/20260302130018_add_pg_net_extension.sql
@@ -1,0 +1,14 @@
+-- pg_net is defined in schemas/extensions.sql but was never included in a migration.
+--
+-- Why pg_net was missed:
+--   pg_net is a Supabase core extension, pre-installed in both the local dev
+--   environment (supabase start) and the shadow database used by `supabase db diff`.
+--   Because it already exists in the shadow DB, `db diff` never detects it as a
+--   difference — unlike pg_cron, which is NOT pre-installed and was therefore
+--   auto-generated into migration 20251124135306 by `db diff`.
+--
+-- Impact:
+--   `supabase db push` only applies migration files, not schema_paths files.
+--   Remote deployments were missing pg_net, causing "schema net does not exist"
+--   errors in notify_event() and cron jobs that call net.http_post().
+CREATE EXTENSION IF NOT EXISTS pg_net WITH SCHEMA net;


### PR DESCRIPTION
## Summary
- `pg_net` extension was defined in `schemas/extensions.sql` but never included in any migration file
- `supabase db push` only applies migration files, so remote deployments were missing `pg_net`, causing `schema "net" does not exist` errors in `notify_event()` and cron jobs
- `pg_net` is pre-installed in Supabase's local dev and shadow DB, so `db diff` never detected the omission — unlike `pg_cron` which is not pre-installed and was auto-generated into migration `20251124135306`

## Test plan
- [x] `db reset` applies all migrations cleanly (`CREATE EXTENSION IF NOT EXISTS` is idempotent)
- [x] All existing DB tests pass with no regressions
- [ ] After merge, cherry-pick or rebase onto `beta/v0.3` and verify `supabase db push` creates `pg_net` on the beta project

🤖 Generated with [Claude Code](https://claude.com/claude-code)