### PR TITLE
fix: remove WITH SCHEMA from pg_net CREATE EXTENSION

### DIFF
--- a/supabase/migrations/20260302130018_add_pg_net_extension.sql
+++ b/supabase/migrations/20260302130018_add_pg_net_extension.sql
@@ -11,4 +11,4 @@
 --   `supabase db push` only applies migration files, not schema_paths files.
 --   Remote deployments were missing pg_net, causing "schema net does not exist"
 --   errors in notify_event() and cron jobs that call net.http_post().
-CREATE EXTENSION IF NOT EXISTS pg_net WITH SCHEMA net;
+CREATE EXTENSION IF NOT EXISTS pg_net;

--- a/supabase/schemas/extensions.sql
+++ b/supabase/schemas/extensions.sql
@@ -1,7 +1,7 @@
 -- Extensions required by the application
 CREATE EXTENSION IF NOT EXISTS pgcrypto WITH SCHEMA extensions;
 -- HTTP client for server-side callbacks
-CREATE EXTENSION IF NOT EXISTS pg_net WITH SCHEMA net;
+CREATE EXTENSION IF NOT EXISTS pg_net;
 -- Secret management for Postgres-side access to Supabase secrets
 CREATE EXTENSION IF NOT EXISTS supabase_vault WITH SCHEMA vault;
 -- Job scheduling for retries


### PR DESCRIPTION
## Summary
- `WITH SCHEMA net` requires the schema to pre-exist, but pg_net creates its own `net` schema automatically on first install
- This caused `schema "net" does not exist` error when `supabase db push` applied the migration to the beta environment (#289)
- Also fixes `extensions.sql` to match

Ref: https://supabase.github.io/pg_net/installation/

## Test plan
- [x] `db reset` applies all migrations cleanly
- [x] All existing DB tests pass
- [ ] After merge, rebase `beta/v0.3` onto main and verify deploy succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)