### PR TITLE
chore: add env.staging and env.production to supabase .gitignore

### DIFF
--- a/supabase/.gitignore
+++ b/supabase/.gitignore
@@ -7,4 +7,5 @@
 .env.local
 .env.*.local
 .env
-
+.env.staging
+.env.production


### PR DESCRIPTION
## Summary
- Add `.env.staging` and `.env.production` to `supabase/.gitignore` to prevent staging/production environment files from being accidentally committed

🤖 Generated with [Claude Code](https://claude.com/claude-code)