### PR TITLE
chore(stripe): unify API version to 2025-11-17.clover

### DIFF
--- a/stripe/scripts/sync-prices.ts
+++ b/stripe/scripts/sync-prices.ts
@@ -34,7 +34,7 @@ if (!STRIPE_SECRET_KEY) {
 }
 
 const stripe = new Stripe(STRIPE_SECRET_KEY, {
-  apiVersion: '2024-11-20.acacia',
+  apiVersion: '2025-11-17.clover',
 })
 
 async function readCsv(filename: string) {

--- a/supabase/functions/billing-setup/index.ts
+++ b/supabase/functions/billing-setup/index.ts
@@ -11,7 +11,7 @@ const stripeApiKey = Deno.env.get("STRIPE_SECRET_KEY") ?? ""
 const supabaseUrl = Deno.env.get("SUPABASE_URL") ?? ""
 const supabaseAnonKey = Deno.env.get("SUPABASE_ANON_KEY") ?? ""
 const supabaseServiceRoleKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") ?? ""
-const stripeApiVersion = "2024-11-20.acacia"
+const stripeApiVersion = "2025-11-17.clover"
 
 if (!stripeApiKey) {
   console.error("Missing STRIPE_SECRET_KEY")

--- a/supabase/functions/delete-account/index.ts
+++ b/supabase/functions/delete-account/index.ts
@@ -88,7 +88,7 @@ Deno.serve(async (req) => {
     }
 
     const stripe = new Stripe(stripeSecretKey, {
-      apiVersion: "2024-11-20.acacia",
+      apiVersion: "2025-11-17.clover",
     })
 
     // 3. Reward payout (if not force)

--- a/supabase/functions/execute-pending-payouts/index.ts
+++ b/supabase/functions/execute-pending-payouts/index.ts
@@ -8,7 +8,7 @@ const supabaseServiceRoleKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") ?? ""
 const stripeSecretKey = Deno.env.get("STRIPE_SECRET_KEY") ?? ""
 
 const stripe = new Stripe(stripeSecretKey, {
-  apiVersion: "2024-11-20.acacia",
+  apiVersion: "2025-11-17.clover",
 })
 
 const jsonHeaders = { "Content-Type": "application/json" }

--- a/supabase/functions/payout-setup/index.ts
+++ b/supabase/functions/payout-setup/index.ts
@@ -26,7 +26,7 @@ if (!stripeOnboardingReturnUrl || !stripeOnboardingRefreshUrl) {
 }
 
 const stripe = new Stripe(stripeSecretKey, {
-  apiVersion: "2024-11-20.acacia",
+  apiVersion: "2025-11-17.clover",
 })
 
 const jsonHeaders = { "Content-Type": "application/json" }


### PR DESCRIPTION
## Summary
- Standardize Stripe API version across all Edge Functions and scripts
- Updated from `2024-11-20.acacia` to `2025-11-17.clover` (5 files)
- Part of #292 Step 8: API version unification

## Test plan
- [x] Verify Edge Functions deploy successfully with the new API version
- [x] Verify `sync-prices.ts` script runs correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)