### PR TITLE
chore: add pre-commit hook to detect Stripe live keys

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,3 +15,9 @@ repos:
         types_or: [ts, tsx, js, jsx]
         pass_filenames: false
         files: ^supabase/functions/
+      - id: no-stripe-live-keys
+        name: Detect Stripe live keys
+        entry: bash -c 'grep -rn "sk_live_\|rk_live_\|whsec_live_" "$@" && echo "ERROR: Stripe live key detected!" && exit 1 || exit 0'
+        language: system
+        types_or: [ts, tsx, js, jsx, dart, sql, toml, json, yaml]
+        exclude: \.pre-commit-config\.yaml$


### PR DESCRIPTION
## Summary
- Add `no-stripe-live-keys` hook to `.pre-commit-config.yaml`
- Detects `sk_live_`, `rk_live_`, `whsec_live_` patterns in staged files
- Covers TS, JS, Dart, SQL, TOML, JSON, YAML file types
- Part of #292 Step 6: Security

## Test plan
- [ ] Verify hook blocks a commit containing a dummy `sk_live_xxx` string
- [ ] Verify normal commits (without live keys) pass the hook

🤖 Generated with [Claude Code](https://claude.com/claude-code)