### PR TITLE
chore: remove github-language rule in favor of shared dotfiles rule

### DIFF
--- a/.claude/rules/github-language.md
+++ b/.claude/rules/github-language.md
@@ -1,3 +1,0 @@
-# GitHub Language Policy
-
-All GitHub Issues, Pull Requests (title and body), and commit messages MUST be written in English. This applies to all content visible on GitHub, including comments and review feedback.


### PR DESCRIPTION
## Summary
- Remove `.claude/rules/github-language.md` (English-only policy)
- This rule is now covered by the shared `github-conventions.md` in dotfiles

## Test plan
- [x] Verify Claude Code still follows English-only policy via the shared dotfiles rule

🤖 Generated with [Claude Code](https://claude.com/claude-code)