### PR TITLE
chore: add Prettier pre-commit hook and fix hook configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,19 +5,23 @@ repos:
         name: Deno fmt (Edge Functions)
         entry: deno fmt --config supabase/deno.jsonc --check
         language: system
-        types_or: [ts, tsx, js, jsx]
         pass_filenames: false
-        files: ^supabase/functions/
+        files: ^supabase/functions/.*\.(ts|tsx|js|jsx)$
       - id: deno-lint
         name: Deno lint (Edge Functions)
         entry: deno lint --config supabase/deno.jsonc
         language: system
-        types_or: [ts, tsx, js, jsx]
         pass_filenames: false
-        files: ^supabase/functions/
+        files: ^supabase/functions/.*\.(ts|tsx|js|jsx)$
+      - id: prettier-webapp
+        name: Prettier (Webapp)
+        entry: bash -c 'cd peppercheck-webapp && npx prettier --check .'
+        language: system
+        pass_filenames: false
+        files: ^peppercheck-webapp/
       - id: no-stripe-live-keys
         name: Detect Stripe live keys
-        entry: bash -c 'grep -rn "sk_live_\|rk_live_\|whsec_live_" "$@" && echo "ERROR: Stripe live key detected!" && exit 1 || exit 0'
-        language: system
-        types_or: [ts, tsx, js, jsx, dart, sql, toml, json, yaml]
+        entry: 'sk_live_|rk_live_|whsec_live_'
+        language: pygrep
+        files: \.(ts|tsx|js|jsx|dart|sql|toml|json|yaml)$
         exclude: \.pre-commit-config\.yaml$


### PR DESCRIPTION
## Summary
- Add `prettier-webapp` pre-commit hook to catch formatting issues before commit (prevents ci-webapp failures)
- Fix `no-stripe-live-keys` hook: use `pygrep` language instead of `bash -c` (fixes YAML syntax error)
- Fix `types_or` using unrecognized type tags — use `files` regex patterns instead
- Requires local setup: `brew install pre-commit && pre-commit install`

## Context
ci-webapp has failed multiple times due to Prettier formatting issues. This hook catches them locally before push.

## Test plan
- [x] `pre-commit run prettier-webapp --all-files` passes
- [x] `pre-commit run no-stripe-live-keys --all-files` passes
- [x] Commit with hooks enabled succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)