### PR TITLE
chore(flutter): rename app label to PepperCheck

### DIFF
--- a/peppercheck_flutter/android/app/src/main/AndroidManifest.xml
+++ b/peppercheck_flutter/android/app/src/main/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <application
-        android:label="peppercheck_flutter"
+        android:label="PepperCheck"
         android:name="${applicationName}"
         android:icon="@mipmap/ic_launcher">
         <activity


### PR DESCRIPTION
## Summary
- Change `android:label` from `peppercheck_flutter` to `PepperCheck` for Google Play Store listing

Closes partially #288 (Step 2: App Configuration Fixes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)