### PR TITLE
fix(webapp): align Tokushoho page with Stripe commerce disclosure requirements

### DIFF
--- a/peppercheck-webapp/messages/en.json
+++ b/peppercheck-webapp/messages/en.json
@@ -26,7 +26,7 @@
     "privacy": "Privacy Policy",
     "tokushoho": "Specified Commercial Transactions Act",
     "refund": "Refund & Cancellation Policy",
-    "copyright": "© 2024 CloveClove, Inc."
+    "copyright": "© 2024 CloveClove"
   },
   "Dashboard": {
     "title": "Dashboard",
@@ -252,11 +252,7 @@
   },
   "Tokushoho": {
     "title": "Specified Commercial Transactions Act Disclosure",
-    "seller": { "label": "Seller", "value": "CloveClove" },
-    "representative": {
-      "label": "Head of Operations",
-      "value": "Disclosed without delay upon request"
-    },
+    "seller": { "label": "Business Name", "value": "CloveClove" },
     "address": {
       "label": "Address",
       "value": "Disclosed without delay upon request"
@@ -266,33 +262,43 @@
       "value": "Disclosed without delay upon request"
     },
     "contact": { "label": "Email" },
-    "price": {
-      "label": "Service Price",
-      "value": "As listed on the pricing page (tax included)"
+    "representative": {
+      "label": "Head of Operations",
+      "value": "Makoto Kurihara"
     },
     "additionalFees": {
       "label": "Additional Fees",
       "value": "Internet connection fees and other communication charges are borne by the customer"
     },
+    "cancellation": {
+      "label": "Exchange and Return Policy",
+      "normalHeading": "Normal cancellation",
+      "normalBody": "You can cancel your subscription at any time from the app settings or the Stripe customer portal. Cancellation takes effect at the end of the current billing period. No prorated refunds are provided for the unused portion of a billing period.",
+      "defectHeading": "Service issues / defects",
+      "defectBody": "In cases of service outages, duplicate charges, or other exceptional circumstances, refunds will be considered on a case-by-case basis.",
+      "details": "See full policy"
+    },
+    "delivery": {
+      "label": "Delivery Time",
+      "value": "Available immediately after subscription purchase"
+    },
     "payment": {
-      "label": "Payment Method",
+      "label": "Available Payment Methods",
       "value": "Credit card (via Stripe), In-app purchase (Google Play / App Store)"
     },
     "paymentPeriod": {
       "label": "Payment Period",
       "value": "Credit card payments are charged immediately at the time of purchase. In-app purchases follow the respective store's billing terms."
     },
-    "delivery": {
-      "label": "Service Delivery",
-      "value": "Available immediately after subscription purchase"
+    "price": {
+      "label": "Price",
+      "perMonth": "/mo",
+      "taxIncluded": " (tax included)",
+      "details": "View pricing details"
     },
-    "cancellation": {
-      "label": "Returns & Exchanges",
-      "normalHeading": "Normal cancellation",
-      "normalBody": "You can cancel your subscription at any time from the app settings or the Stripe customer portal. Cancellation takes effect at the end of the current billing period. No prorated refunds are provided for the unused portion of a billing period.",
-      "defectHeading": "Service issues / defects",
-      "defectBody": "In cases of service outages, duplicate charges, or other exceptional circumstances, refunds will be considered on a case-by-case basis.",
-      "details": "See full policy"
+    "environment": {
+      "label": "System Requirements",
+      "value": "Android 5.0 or later, iOS 13.0 or later"
     }
   }
 }

--- a/peppercheck-webapp/messages/ja.json
+++ b/peppercheck-webapp/messages/ja.json
@@ -26,7 +26,7 @@
     "privacy": "プライバシーポリシー",
     "tokushoho": "特定商取引法に基づく表記",
     "refund": "返金・キャンセルポリシー",
-    "copyright": "© 2024 CloveClove, Inc."
+    "copyright": "© 2024 CloveClove"
   },
   "Dashboard": {
     "title": "ダッシュボード",
@@ -252,13 +252,9 @@
   },
   "Tokushoho": {
     "title": "特定商取引法に基づく表記",
-    "seller": { "label": "販売業者", "value": "CloveClove" },
-    "representative": {
-      "label": "運営責任者",
-      "value": "請求があった場合に遅滞なく開示いたします"
-    },
+    "seller": { "label": "事業者名", "value": "CloveClove" },
     "address": {
-      "label": "所在地",
+      "label": "住所",
       "value": "請求があった場合に遅滞なく開示いたします"
     },
     "phone": {
@@ -266,33 +262,43 @@
       "value": "請求があった場合に遅滞なく開示いたします"
     },
     "contact": { "label": "メールアドレス" },
-    "price": {
-      "label": "販売価格",
-      "value": "各料金プランページに記載の金額（税込）"
+    "representative": {
+      "label": "運営責任者",
+      "value": "栗原 誠"
     },
     "additionalFees": {
-      "label": "商品代金以外の必要料金",
+      "label": "追加手数料",
       "value": "インターネット接続料金その他通信に要する費用はお客様のご負担となります"
     },
-    "payment": {
-      "label": "支払方法",
-      "value": "クレジットカード（Stripe経由）、アプリ内課金（Google Play / App Store）"
-    },
-    "paymentPeriod": {
-      "label": "支払時期",
-      "value": "クレジットカードの場合はご注文時に即時課金されます。アプリ内課金の場合は各ストアの規定に準じます。"
-    },
-    "delivery": {
-      "label": "提供時期",
-      "value": "サブスクリプション購入後すぐにご利用いただけます"
-    },
     "cancellation": {
-      "label": "返品・交換について",
+      "label": "交換および返品に関するポリシー",
       "normalHeading": "通常のキャンセル",
       "normalBody": "サブスクリプションはアプリの設定画面またはStripeカスタマーポータルからいつでもキャンセルできます。キャンセルは現在の請求期間の終了時に有効となります。請求期間の未使用分に対する日割り返金は行っておりません。",
       "defectHeading": "サービス障害・不具合の場合",
       "defectBody": "サービスの障害、重複課金、その他の例外的な状況については、個別に返金を検討いたします。",
       "details": "詳しくはこちら"
+    },
+    "delivery": {
+      "label": "配達時間",
+      "value": "サブスクリプション購入後すぐにご利用いただけます"
+    },
+    "payment": {
+      "label": "利用可能な決済手段",
+      "value": "クレジットカード（Stripe経由）、アプリ内課金（Google Play / App Store）"
+    },
+    "paymentPeriod": {
+      "label": "決済期間",
+      "value": "クレジットカードの場合はご注文時に即時課金されます。アプリ内課金の場合は各ストアの規定に準じます。"
+    },
+    "price": {
+      "label": "価格",
+      "perMonth": "/月",
+      "taxIncluded": "（税込）",
+      "details": "料金プラン詳細はこちら"
+    },
+    "environment": {
+      "label": "動作環境",
+      "value": "Android 5.0以上、iOS 13.0以上"
     }
   }
 }

--- a/peppercheck-webapp/src/app/[locale]/legal/tokushoho/page.tsx
+++ b/peppercheck-webapp/src/app/[locale]/legal/tokushoho/page.tsx
@@ -4,25 +4,50 @@ import { ObfuscatedEmail } from '@/components/ObfuscatedEmail'
 import { getTranslations } from 'next-intl/server'
 import { createGenerateMetadata } from '@/lib/metadata'
 import { Link } from '@/i18n/routing'
+import { createClient } from '@/lib/supabase/server'
 
 export const generateMetadata = createGenerateMetadata('Tokushoho')
 
 const ROWS = [
   'seller',
-  'representative',
   'address',
   'phone',
   'contact',
-  'price',
+  'representative',
   'additionalFees',
+  'cancellation',
+  'delivery',
   'payment',
   'paymentPeriod',
-  'delivery',
-  'cancellation',
+  'price',
+  'environment',
 ] as const
 
 export default async function TokushohoPage() {
   const t = await getTranslations('Tokushoho')
+  const tPricing = await getTranslations('Pricing')
+
+  const supabase = await createClient()
+  const { data: plans } = await supabase
+    .from('subscription_plans')
+    .select('*, prices:subscription_plan_prices(*)')
+    .eq('is_active', true)
+    .order('monthly_points')
+
+  const priceLines = plans
+    ?.map((plan) => {
+      const price = plan.prices.find(
+        (p: { provider: string; currency_code: string }) =>
+          p.provider === 'stripe' && p.currency_code === 'JPY',
+      )
+      if (!price) return null
+      const planKey = plan.name.toLowerCase().replace(' ', '_')
+      const name = tPricing.has(`plans.${planKey}.name`)
+        ? tPricing(`plans.${planKey}.name`)
+        : plan.name
+      return `${name} ¥${price.amount_minor.toLocaleString()}${t('price.perMonth')}`
+    })
+    .filter(Boolean)
 
   return (
     <div className="flex min-h-screen flex-col font-sans">
@@ -47,12 +72,18 @@ export default async function TokushohoPage() {
                   {key === 'contact' ? (
                     <ObfuscatedEmail />
                   ) : key === 'price' ? (
-                    <Link
-                      href="/pricing"
-                      className="underline decoration-2 hover:opacity-80"
-                    >
-                      {t(`${key}.value`)}
-                    </Link>
+                    <div className="space-y-2">
+                      <p>
+                        {priceLines?.join('、')}
+                        {t('price.taxIncluded')}
+                      </p>
+                      <Link
+                        href="/pricing"
+                        className="block text-sm underline decoration-2 hover:opacity-80"
+                      >
+                        {t('price.details')}
+                      </Link>
+                    </div>
                   ) : key === 'cancellation' ? (
                     <div className="space-y-4">
                       <div>


### PR DESCRIPTION
## Summary
- Align field names, order, and content with [Stripe's commerce disclosure requirements](https://support.stripe.com/questions/how-to-create-and-display-a-commerce-disclosure-page) to resolve repeated review rejections (3rd rejection)
- Add representative name (運営責任者) — required by Stripe even for sole proprietors, unlike address/phone which allow "upon request"
- Fetch prices dynamically from Supabase DB instead of linking to pricing page, so Stripe reviewers see actual amounts
- Add system requirements (動作環境: Android 5.0+, iOS 13.0+) as optional field for app-based service
- Remove "Inc." from footer copyright since CloveClove is a sole proprietorship

### Field changes
| # | Stripe field type | Old label | New label |
|---|---|---|---|
| 1 | 法人名 | 販売業者 | 事業者名 |
| 2 | 住所 | 所在地 | 住所 |
| 3-5 | 電話番号 / メールアドレス / 運営責任者 | (same) | (reordered to match Stripe) |
| 6 | 追加手数料 | 商品代金以外の必要料金 | 追加手数料 |
| 7 | 交換および返品に関するポリシー | 返品・交換について | 交換および返品に関するポリシー |
| 8 | 配達時間 | 提供時期 | 配達時間 |
| 9 | 利用可能な決済手段 | 支払方法 | 利用可能な決済手段 |
| 10 | 決済期間 | 支払時期 | 決済期間 |
| 11 | 価格 | 販売価格 (link only) | 価格 (dynamic from DB) |
| opt | 動作環境 | (missing) | 動作環境 (new) |

### Stripe Dashboard side (manual)
- Set business name to "CloveClove" in Settings > Business > Business details

## Test plan
- [x] Verify Tokushoho page renders correctly with all 12 fields in correct order
- [x] Verify prices are fetched dynamically from DB (match pricing page amounts)
- [x] Verify both EN and JA locales display correctly
- [x] Verify footer copyright no longer shows "Inc."
- [x] Deploy and resubmit website URL to Stripe for review

🤖 Generated with [Claude Code](https://claude.com/claude-code)