### PR TITLE
fix(flutter): improve cancel link tap area in subscription section

### DIFF
--- a/peppercheck_flutter/lib/features/billing/presentation/widgets/subscription_section.dart
+++ b/peppercheck_flutter/lib/features/billing/presentation/widgets/subscription_section.dart
@@ -59,17 +59,23 @@ class _SubscriptionSectionState extends ConsumerState<SubscriptionSection> {
                 Align(
                   alignment: Alignment.centerRight,
                   child: GestureDetector(
+                    behavior: HitTestBehavior.opaque,
                     onTap: () => launchUrl(
                       Uri.parse(
                         'https://play.google.com/store/account/subscriptions',
                       ),
                       mode: LaunchMode.externalApplication,
                     ),
-                    child: Text(
-                      t.billing.cancelViaGooglePlay,
-                      style: const TextStyle(
-                        fontSize: 12,
-                        color: AppColors.textSecondary,
+                    child: Padding(
+                      padding: const EdgeInsets.symmetric(
+                        vertical: AppSizes.spacingTiny,
+                      ),
+                      child: Text(
+                        t.billing.cancelViaGooglePlay,
+                        style: const TextStyle(
+                          fontSize: 12,
+                          color: AppColors.textSecondary,
+                        ),
                       ),
                     ),
                   ),


### PR DESCRIPTION
## Summary
- Add `HitTestBehavior.opaque` to ensure taps on the full text area are detected
- Add vertical padding (`spacingTiny`) around the cancel link text to increase tap target size

## Test Plan
- [ ] Verify cancel link is easy to tap on emulator
- [ ] Verify spacing looks acceptable visually

🤖 Generated with [Claude Code](https://claude.com/claude-code)