### PR TITLE
feat(supabase): handle Stripe account.updated webhook for Connect status sync (#345)

### DIFF
--- a/docs/superpowers/specs/2026-04-12-stripe-account-updated-webhook-design.md
+++ b/docs/superpowers/specs/2026-04-12-stripe-account-updated-webhook-design.md
@@ -1,0 +1,68 @@
+# Stripe account.updated Webhook Design
+
+- **Issue**: #345
+- **Date**: 2026-04-12
+- **Status**: Draft
+
+## Problem
+
+`stripe_accounts.payouts_enabled` / `charges_enabled` / `connect_requirements` are only updated when the user explicitly calls the `payout-setup` Edge Function. After completing Stripe Connect onboarding in the external browser, the user returns to the app but the DB still reflects the pre-onboarding state. The only way to sync is to call `payout-setup` again, which is unnatural UX.
+
+## Solution
+
+Add an `account.updated` event handler to the existing `handle-stripe-webhook` Edge Function. Stripe sends this event whenever a Connect account's status changes (e.g., onboarding completion, bank verification). The handler syncs the relevant fields to `stripe_accounts` automatically.
+
+## Design
+
+### Webhook Handler
+
+Add `account.updated` case to the switch statement in `handle-stripe-webhook/index.ts`.
+
+**Processing flow:**
+
+1. Extract `account.id` from `event.data.object` (the Connect account ID, `acct_xxx`)
+2. Query `stripe_accounts` by `stripe_connect_account_id`
+3. If no matching row exists, log and return (payout-setup has not been called for this account)
+4. Update `charges_enabled`, `payouts_enabled`, `connect_requirements` from the event payload
+
+**Handler function signature:**
+
+```typescript
+async function handleAccountUpdated(
+  event: Stripe.Event,
+  supabaseAdmin: ReturnType<typeof createClient>,
+)
+```
+
+**Key decisions:**
+
+- **User lookup via DB, not Stripe metadata**: Query `stripe_accounts.stripe_connect_account_id` instead of relying on `account.metadata.profile_id`. More robust against metadata changes on Stripe side.
+- **Single UPDATE query**: Use UPDATE with `.eq('stripe_connect_account_id', ...)` and check result rather than SELECT then UPDATE. One round-trip instead of two.
+- **No Stripe API call needed**: The webhook event payload contains all necessary fields (`charges_enabled`, `payouts_enabled`, `requirements`), so no additional `stripe.accounts.retrieve()` is required.
+- **No Flutter changes needed**: `PayoutController` already invalidates its provider on app resume, re-reading status from `stripe_accounts`. Once the webhook updates the DB, the existing Flutter code picks up the new state.
+
+### Testing
+
+No mock-based unit tests for this handler (cost vs. value is low for simple DB update logic). Instead:
+
+- **Local integration test**: Use Stripe CLI (`stripe listen` + `stripe trigger`) against local Supabase
+- **Test data**: SQL snippet in `supabase/snippets/` to insert a `stripe_accounts` row with a known `stripe_connect_account_id`
+- **Test procedure**: Documented in `supabase/functions/handle-stripe-webhook/README.md`
+
+### Stripe Dashboard Configuration
+
+Register `account.updated` (Connected accounts) on the existing webhook endpoint. This is a manual step documented in the README.
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `supabase/functions/handle-stripe-webhook/index.ts` | Add `account.updated` case and `handleAccountUpdated` function |
+| `supabase/functions/handle-stripe-webhook/README.md` | New file. Local test procedure and Stripe Dashboard setup steps |
+| `supabase/snippets/setup_stripe_account_test_data.sql` | New file. Insert test `stripe_accounts` row for webhook testing |
+
+## Out of Scope
+
+- Other webhook events (`payout.paid`, `payout.failed`, etc.)
+- `developer-docs` reorganization
+- Automated E2E test scripting

--- a/supabase/functions/handle-stripe-webhook/README.md
+++ b/supabase/functions/handle-stripe-webhook/README.md
@@ -1,0 +1,57 @@
+# handle-stripe-webhook Edge Function
+
+Handles incoming Stripe webhook events and syncs relevant data to the database.
+
+## Supported Events
+
+| Event | Handler | Purpose |
+|-------|---------|---------|
+| `checkout.session.completed` | `handleSubscriptionChange` | Sync subscription on initial checkout |
+| `customer.subscription.updated` | `handleSubscriptionChange` | Sync subscription status changes |
+| `customer.subscription.deleted` | `handleSubscriptionChange` | Sync subscription cancellation |
+| `invoice.payment_succeeded` | `handleInvoicePaymentSucceeded` | Reset monthly points on renewal |
+| `account.updated` | `handleAccountUpdated` | Sync Connect account onboarding status |
+
+## Local Testing
+
+### Prerequisites
+
+- Supabase local environment running (`supabase start`)
+- [Stripe CLI](https://docs.stripe.com/stripe-cli) installed and authenticated (`stripe login`)
+- Edge Functions served locally (`supabase functions serve`)
+
+### Testing account.updated
+
+1. **Set up test data** — Run `supabase/snippets/setup_stripe_account_webhook_test.sql` in the SQL Editor (http://127.0.0.1:54323), replacing placeholder IDs with real values.
+
+2. **Start webhook listener** (terminal 1):
+   ```bash
+   stripe listen --forward-to http://127.0.0.1:54321/functions/v1/handle-stripe-webhook
+   ```
+   Copy the webhook signing secret (`whsec_...`) and set it in `.env.local` or via `supabase secrets set STRIPE_WEBHOOK_SECRET=whsec_...`.
+
+3. **Trigger event** (terminal 2):
+   ```bash
+   stripe trigger account.updated
+   ```
+
+4. **Verify** — Run the verification query from the snippet. `charges_enabled` / `payouts_enabled` / `connect_requirements` should be updated, and `updated_at` should reflect the current time.
+
+> **Note:** `stripe trigger account.updated` sends a generic test event. The `account.id` in the test event won't match your local test data unless you use a real Connect account from Stripe test mode. For full E2E testing, complete the payout setup flow in the app against Stripe test mode, then the real `account.updated` webhook will fire with the correct account ID.
+
+## Stripe Dashboard Configuration
+
+Register this endpoint in Stripe Dashboard → Developers → Webhooks:
+
+1. **Endpoint URL:** `https://<project>.supabase.co/functions/v1/handle-stripe-webhook`
+2. **Events from your account:** `checkout.session.completed`, `customer.subscription.updated`, `customer.subscription.deleted`, `invoice.payment_succeeded`
+3. **Events from Connected accounts:** `account.updated`
+4. Copy the signing secret → set as `STRIPE_WEBHOOK_SECRET` in Edge Function environment
+
+## Unit Tests
+
+Run existing unit tests:
+
+```bash
+cd supabase/functions/handle-stripe-webhook && deno test --allow-env --allow-net index_test.ts
+```

--- a/supabase/functions/handle-stripe-webhook/index.ts
+++ b/supabase/functions/handle-stripe-webhook/index.ts
@@ -87,6 +87,10 @@ export const handler = async (req: Request, dependencies?: {
         }
         break
       }
+      case 'account.updated': {
+        await handleAccountUpdated(event, supabaseAdmin)
+        break
+      }
       default:
         console.log(`Unhandled event type: ${event.type}`)
     }
@@ -257,6 +261,40 @@ async function handleInvoicePaymentSucceeded(
       `Invoice ${invoice.id} already processed (idempotency check), skipping point reset.`,
     )
   }
+}
+
+async function handleAccountUpdated(
+  event: Stripe.Event,
+  supabaseAdmin: ReturnType<typeof createClient>,
+) {
+  const account = event.data.object as Stripe.Account
+  const connectAccountId = account.id
+
+  // deno-lint-ignore no-explicit-any
+  const supabaseAdminAny = supabaseAdmin as any
+  const { data, error } = await supabaseAdminAny
+    .from('stripe_accounts')
+    .update({
+      charges_enabled: account.charges_enabled,
+      payouts_enabled: account.payouts_enabled,
+      connect_requirements: account.requirements,
+    })
+    .eq('stripe_connect_account_id', connectAccountId)
+    .select('profile_id')
+    .single()
+
+  if (error) {
+    if (error.code === 'PGRST116') {
+      console.log(`No stripe_accounts row for connect account ${connectAccountId}, skipping`)
+    } else {
+      console.error(`Failed to update stripe_accounts for ${connectAccountId}:`, error)
+    }
+    return
+  }
+
+  console.log(
+    `Updated connect status for user ${data.profile_id}: charges=${account.charges_enabled}, payouts=${account.payouts_enabled}`,
+  )
 }
 
 if (import.meta.main) {

--- a/supabase/functions/handle-stripe-webhook/index.ts
+++ b/supabase/functions/handle-stripe-webhook/index.ts
@@ -286,10 +286,10 @@ async function handleAccountUpdated(
   if (error) {
     if (error.code === 'PGRST116') {
       console.log(`No stripe_accounts row for connect account ${connectAccountId}, skipping`)
-    } else {
-      console.error(`Failed to update stripe_accounts for ${connectAccountId}:`, error)
+      return
     }
-    return
+    console.error(`Failed to update stripe_accounts for ${connectAccountId}:`, error)
+    throw error
   }
 
   console.log(

--- a/supabase/snippets/setup_stripe_account_webhook_test.sql
+++ b/supabase/snippets/setup_stripe_account_webhook_test.sql
@@ -1,0 +1,59 @@
+-- Snippet: Set up stripe_accounts row for account.updated webhook testing
+--
+-- Inserts or updates a stripe_accounts row with a known stripe_connect_account_id
+-- so that the account.updated webhook handler can find and update it.
+--
+-- Prerequisites:
+--   - User must exist in profiles table (sign up via app or create manually)
+--   - Supabase local environment must be running (`supabase start`)
+--
+-- Usage:
+--   1. Set v_user_id to an actual user ID from your local auth.users table
+--   2. Set v_connect_account_id to a Stripe Connect account ID (from Stripe Dashboard or test mode)
+--   3. Run this snippet via Supabase SQL Editor (http://127.0.0.1:54323)
+--   4. Start webhook listener: stripe listen --forward-to http://127.0.0.1:54321/functions/v1/handle-stripe-webhook
+--   5. Trigger event: stripe trigger account.updated
+--      OR use Stripe Dashboard test mode to update the Connect account
+--   6. Verify with the queries below
+
+DO $$
+DECLARE
+    -- ========================================
+    -- CONFIGURE THESE VALUES
+    -- ========================================
+    v_user_id uuid := '00000000-0000-0000-0000-000000000000'; -- Replace with actual user ID
+    v_connect_account_id text := 'acct_test123';              -- Replace with actual Connect account ID
+    -- ========================================
+BEGIN
+    INSERT INTO public.stripe_accounts (profile_id, stripe_connect_account_id, charges_enabled, payouts_enabled)
+    VALUES (v_user_id, v_connect_account_id, false, false)
+    ON CONFLICT (profile_id) DO UPDATE SET
+        stripe_connect_account_id = v_connect_account_id,
+        charges_enabled = false,
+        payouts_enabled = false,
+        connect_requirements = NULL;
+
+    RAISE NOTICE 'Inserted/updated stripe_accounts for user % with connect account %', v_user_id, v_connect_account_id;
+    RAISE NOTICE '';
+    RAISE NOTICE '--- Next steps ---';
+    RAISE NOTICE '1. Start listener: stripe listen --forward-to http://127.0.0.1:54321/functions/v1/handle-stripe-webhook';
+    RAISE NOTICE '2. Trigger: stripe trigger account.updated';
+    RAISE NOTICE '3. Check results with the verification query below';
+END;
+$$;
+
+-- =============================================
+-- Verification query
+-- =============================================
+
+SELECT profile_id, stripe_connect_account_id, charges_enabled, payouts_enabled, connect_requirements, updated_at
+FROM public.stripe_accounts
+ORDER BY updated_at DESC
+LIMIT 5;
+
+-- =============================================
+-- Cleanup (run after testing)
+-- =============================================
+-- UPDATE public.stripe_accounts
+-- SET charges_enabled = false, payouts_enabled = false, connect_requirements = NULL
+-- WHERE stripe_connect_account_id = 'acct_test123';


### PR DESCRIPTION
## Summary

- Add `account.updated` event handler to `handle-stripe-webhook` Edge Function to automatically sync Connect account onboarding status (`charges_enabled`, `payouts_enabled`, `connect_requirements`) to `stripe_accounts` table
- Add test data SQL snippet and README with local test procedure and Stripe Dashboard configuration steps

## Context

After completing Stripe Connect onboarding, `stripe_accounts` was only updated when the user explicitly called `payout-setup`. This meant the app showed stale onboarding status until the user triggered a manual refresh. The `account.updated` webhook enables automatic sync.

Closes #345

## Test plan

- [x] Local: Run `stripe listen --forward-to ...` + `stripe trigger account.updated` with test data from snippet
- [ ] Full E2E: Complete payout setup flow in app against Stripe test mode, verify `stripe_accounts` is updated via webhook
- [ ] Stripe Dashboard: Register `account.updated` (Connected accounts) on the production webhook endpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)