### PR TITLE
fix(flutter): auto-refresh stale data across screens after mutations (#344)

### DIFF
--- a/docs/superpowers/specs/2026-04-15-auto-refresh-stale-data-design.md
+++ b/docs/superpowers/specs/2026-04-15-auto-refresh-stale-data-design.md
@@ -1,0 +1,91 @@
+# Auto-Refresh Stale Data Across Screens After Mutations
+
+**Issue**: #344
+**Date**: 2026-04-15
+**Status**: Draft
+
+## Problem
+
+Multiple screens show stale data after mutations because Riverpod provider invalidation is incomplete. Users must manually pull-to-refresh or navigate away and back to see updated information.
+
+## Scope
+
+### In scope
+
+- **Scenarios 1-4 (quick wins)**: Add missing `ref.invalidate()` calls after mutations
+- **Scenario 4 (push notification tap)**: Invalidate task data before navigation
+- **App resume refresh**: Automatically invalidate stale providers when the app returns to foreground
+- **Investigation**: Verify invalidate timing and screen transition order across all mutation flows
+
+### Out of scope
+
+- Supabase Realtime subscriptions (deferred post-MVP due to past reliability issues with race conditions — see #321, #328, #330, #333)
+
+## Design Principles
+
+Based on Riverpod best practices:
+
+1. **Colocate invalidation with mutations** — each controller invalidates the providers it makes stale, directly in the mutation method. No centralized invalidation helper.
+2. **`ref.invalidate()` for cache busting** — marks cached data as stale; the next read triggers a fresh fetch from Supabase.
+3. **`ref.invalidate(familyProvider)` without parameters** — invalidates all instances of a family provider at once. Only currently-watched instances actually refetch.
+
+## Detailed Design
+
+### 1. Controller Invalidation Changes (Scenarios 1-4)
+
+Add missing `ref.invalidate()` calls to each controller's mutation methods:
+
+| Controller | Methods | Add invalidation for |
+|---|---|---|
+| `EvidenceController` | `submit`, `updateEvidence`, `resubmit`, `confirmEvidenceTimeout` | `activeUserTasksProvider`, `activeRefereeTasksProvider` |
+| `JudgementController` | `submit`, `confirmJudgement`, `confirmReviewTimeout` | `activeUserTasksProvider`, `activeRefereeTasksProvider` |
+| `TaskRefereesSection` | cancel assignment action | `activeRefereeTasksProvider` |
+| `TaskCreationController` | `createTask` | `pointWalletProvider`, `trialPointWalletProvider` |
+| `FCMService` | `_navigateFromData` | `taskProvider(taskId)` before navigation |
+
+### 2. Push Notification Tap Refresh (Scenario 4)
+
+In `FCMService._navigateFromData()`:
+
+- Extract `taskId` from notification payload
+- Call `ref.invalidate(taskProvider(taskId))` before `router.push('/task_detail/$taskId')`
+- This ensures the task detail screen fetches fresh data on open
+
+### 3. AppLifecycleObserver (App Resume Refresh)
+
+A new `ConsumerStatefulWidget` with `WidgetsBindingObserver` mixin, placed near the top of the widget tree (inside `ProviderScope`, wrapping or adjacent to `MaterialApp`).
+
+**Trigger**: `AppLifecycleState.resumed`
+
+**Invalidation targets**:
+
+| Provider | Reason |
+|---|---|
+| `activeUserTasksProvider` | Home screen tasker task list |
+| `activeRefereeTasksProvider` | Home screen referee task list |
+| `taskProvider` | All task detail instances (parameter-less invalidation) |
+| `pointWalletProvider` | Point balance |
+| `trialPointWalletProvider` | Trial point balance |
+
+**Guard conditions**:
+
+1. **Authentication check**: Skip invalidation if the user is not authenticated (avoid unnecessary API calls on the login screen)
+2. **Throttle (30 seconds)**: Skip invalidation if less than 30 seconds have elapsed since the last resume-triggered invalidation (prevents excessive refetches from brief app switches, e.g., pulling down the notification shade)
+
+### 4. Investigation Items
+
+Before implementation, verify the following across all mutation flows. If issues are found, include fixes in the implementation scope:
+
+1. **Invalidate timing vs. screen transition order** — Confirm that `ref.invalidate()` executes before navigation (e.g., `router.push`, `router.pop`). If invalidation happens after navigation, the destination screen may read stale cache before the invalidation takes effect.
+2. **autoDispose behavior of home screen providers** — Check whether `activeUserTasksProvider` and `activeRefereeTasksProvider` use `autoDispose`. If they do, navigating away from the home screen disposes them, and returning automatically triggers a fresh fetch — making explicit invalidation unnecessary for some flows.
+3. **Pull-to-refresh coexistence** — Ensure that automatic invalidation (from mutations or app resume) and manual pull-to-refresh do not cause redundant simultaneous fetches.
+
+## Acceptance Criteria
+
+- [ ] After evidence submission/update/resubmit/timeout confirmation, returning to home screen shows updated task status without manual refresh
+- [ ] After judgement submission/confirmation/timeout confirmation, returning to home screen shows updated task status without manual refresh
+- [ ] After referee cancellation, the task disappears from the referee's home screen without manual refresh
+- [ ] After task creation, point balance reflects the deduction immediately
+- [ ] Tapping a push notification shows the latest task data on the detail screen
+- [ ] Returning the app to foreground refreshes data on the current screen (after 30s throttle, when authenticated)
+- [ ] No unnecessary API calls when unauthenticated or within the throttle window

--- a/peppercheck_flutter/lib/app/app.dart
+++ b/peppercheck_flutter/lib/app/app.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:peppercheck_flutter/app/app_lifecycle_observer.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:peppercheck_flutter/app/routing/app_router.dart';
 import 'package:peppercheck_flutter/app/theme/app_theme.dart';
@@ -18,13 +19,15 @@ class MyApp extends ConsumerWidget {
     return TranslationProvider(
       child: Builder(
         builder: (context) {
-          return MaterialApp.router(
-            title: 'PepperCheck',
-            theme: AppTheme.light,
-            routerConfig: router,
-            locale: TranslationProvider.of(context).flutterLocale,
-            supportedLocales: AppLocaleUtils.supportedLocales,
-            localizationsDelegates: GlobalMaterialLocalizations.delegates,
+          return AppLifecycleObserver(
+            child: MaterialApp.router(
+              title: 'PepperCheck',
+              theme: AppTheme.light,
+              routerConfig: router,
+              locale: TranslationProvider.of(context).flutterLocale,
+              supportedLocales: AppLocaleUtils.supportedLocales,
+              localizationsDelegates: GlobalMaterialLocalizations.delegates,
+            ),
           );
         },
       ),

--- a/peppercheck_flutter/lib/app/app_lifecycle_observer.dart
+++ b/peppercheck_flutter/lib/app/app_lifecycle_observer.dart
@@ -1,0 +1,66 @@
+import 'package:flutter/widgets.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:peppercheck_flutter/features/authentication/data/auth_state_provider.dart';
+import 'package:peppercheck_flutter/features/billing/data/billing_providers.dart';
+import 'package:peppercheck_flutter/features/home/presentation/home_controller.dart';
+import 'package:peppercheck_flutter/features/task/presentation/providers/task_provider.dart';
+
+/// Refreshes stale provider data when the app returns to the foreground.
+///
+/// Place this widget near the top of the widget tree (inside ProviderScope).
+/// Guards: skips invalidation when unauthenticated or within the throttle window.
+class AppLifecycleObserver extends ConsumerStatefulWidget {
+  const AppLifecycleObserver({required this.child, super.key});
+
+  final Widget child;
+
+  @override
+  ConsumerState<AppLifecycleObserver> createState() =>
+      _AppLifecycleObserverState();
+}
+
+class _AppLifecycleObserverState extends ConsumerState<AppLifecycleObserver>
+    with WidgetsBindingObserver {
+  static const _throttleDuration = Duration(seconds: 30);
+  DateTime? _lastRefreshedAt;
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addObserver(this);
+  }
+
+  @override
+  void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
+    super.dispose();
+  }
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    if (state != AppLifecycleState.resumed) return;
+
+    // Guard: skip if not authenticated
+    final currentUser = ref.read(currentUserProvider);
+    if (currentUser == null) return;
+
+    // Guard: throttle to avoid excessive refetches
+    final now = DateTime.now();
+    if (_lastRefreshedAt != null &&
+        now.difference(_lastRefreshedAt!) < _throttleDuration) {
+      return;
+    }
+    _lastRefreshedAt = now;
+
+    // Invalidate all key data providers.
+    // Only currently-watched providers will actually refetch.
+    ref.invalidate(activeUserTasksProvider);
+    ref.invalidate(activeRefereeTasksProvider);
+    ref.invalidate(taskProvider);
+    ref.invalidate(pointWalletProvider);
+    ref.invalidate(trialPointWalletProvider);
+  }
+
+  @override
+  Widget build(BuildContext context) => widget.child;
+}

--- a/peppercheck_flutter/lib/features/evidence/presentation/controllers/evidence_controller.dart
+++ b/peppercheck_flutter/lib/features/evidence/presentation/controllers/evidence_controller.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:image_picker/image_picker.dart';
 import 'package:peppercheck_flutter/features/evidence/data/evidence_repository.dart';
+import 'package:peppercheck_flutter/features/home/presentation/home_controller.dart';
 import 'package:peppercheck_flutter/features/task/presentation/providers/task_provider.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
@@ -38,6 +39,8 @@ class EvidenceController extends _$EvidenceController {
           );
       // Invalidate task provider to refresh UI
       ref.invalidate(taskProvider(taskId));
+      ref.invalidate(activeUserTasksProvider);
+      ref.invalidate(activeRefereeTasksProvider);
       onSuccess();
     });
   }
@@ -62,6 +65,8 @@ class EvidenceController extends _$EvidenceController {
             assetIdsToRemove: assetIdsToRemove,
           );
       ref.invalidate(taskProvider(taskId));
+      ref.invalidate(activeUserTasksProvider);
+      ref.invalidate(activeRefereeTasksProvider);
       onSuccess();
     });
   }
@@ -86,6 +91,8 @@ class EvidenceController extends _$EvidenceController {
             assetIdsToRemove: assetIdsToRemove,
           );
       ref.invalidate(taskProvider(taskId));
+      ref.invalidate(activeUserTasksProvider);
+      ref.invalidate(activeRefereeTasksProvider);
       onSuccess();
     });
   }
@@ -102,6 +109,8 @@ class EvidenceController extends _$EvidenceController {
           .read(evidenceRepositoryProvider)
           .confirmEvidenceTimeout(judgementId: judgementId);
       ref.invalidate(taskProvider(taskId));
+      ref.invalidate(activeUserTasksProvider);
+      ref.invalidate(activeRefereeTasksProvider);
       onSuccess();
     });
   }

--- a/peppercheck_flutter/lib/features/judgement/presentation/controllers/judgement_controller.dart
+++ b/peppercheck_flutter/lib/features/judgement/presentation/controllers/judgement_controller.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:peppercheck_flutter/features/home/presentation/home_controller.dart';
 import 'package:peppercheck_flutter/features/judgement/data/judgement_repository.dart';
 import 'package:peppercheck_flutter/features/task/presentation/providers/task_provider.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
@@ -30,6 +31,8 @@ class JudgementController extends _$JudgementController {
             comment: comment,
           );
       ref.invalidate(taskProvider(taskId));
+      ref.invalidate(activeUserTasksProvider);
+      ref.invalidate(activeRefereeTasksProvider);
       onSuccess();
     });
   }
@@ -52,6 +55,8 @@ class JudgementController extends _$JudgementController {
             comment: comment,
           );
       ref.invalidate(taskProvider(taskId));
+      ref.invalidate(activeUserTasksProvider);
+      ref.invalidate(activeRefereeTasksProvider);
       onSuccess();
     });
   }
@@ -68,6 +73,8 @@ class JudgementController extends _$JudgementController {
           .read(judgementRepositoryProvider)
           .confirmReviewTimeout(judgementId: judgementId);
       ref.invalidate(taskProvider(taskId));
+      ref.invalidate(activeUserTasksProvider);
+      ref.invalidate(activeRefereeTasksProvider);
       onSuccess();
     });
   }

--- a/peppercheck_flutter/lib/features/notification/application/fcm_service.dart
+++ b/peppercheck_flutter/lib/features/notification/application/fcm_service.dart
@@ -7,6 +7,7 @@ import 'package:peppercheck_flutter/app/app_logger.dart';
 import 'package:peppercheck_flutter/app/routing/app_router.dart';
 import 'package:peppercheck_flutter/features/notification/application/notification_text_resolver.dart';
 import 'package:peppercheck_flutter/features/notification/data/notification_repository.dart';
+import 'package:peppercheck_flutter/features/task/presentation/providers/task_provider.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
@@ -163,6 +164,7 @@ class FcmService {
       return;
     }
 
+    ref.invalidate(taskProvider(taskId));
     final router = ref.read(routerProvider);
     router.push('/task_detail/$taskId');
   }

--- a/peppercheck_flutter/lib/features/task/presentation/task_creation_controller.dart
+++ b/peppercheck_flutter/lib/features/task/presentation/task_creation_controller.dart
@@ -4,6 +4,7 @@ import 'package:peppercheck_flutter/features/task/domain/task.dart';
 import 'package:peppercheck_flutter/features/task/presentation/task_creation_state.dart';
 import 'package:peppercheck_flutter/features/task/domain/task_creation_request.dart';
 import 'package:peppercheck_flutter/features/task/domain/task_creation_error.dart';
+import 'package:peppercheck_flutter/features/billing/data/billing_providers.dart';
 import 'package:peppercheck_flutter/features/home/presentation/home_controller.dart';
 import 'package:peppercheck_flutter/features/task/presentation/providers/task_provider.dart';
 
@@ -127,6 +128,8 @@ class TaskCreationController extends _$TaskCreationController {
 
       // Refresh the home screen lists
       ref.invalidate(activeUserTasksProvider);
+      ref.invalidate(pointWalletProvider);
+      ref.invalidate(trialPointWalletProvider);
 
       // Success - clear any error and return to data state
       state = AsyncData(currentState.copyWith(creationError: null));

--- a/peppercheck_flutter/lib/features/task/presentation/widgets/task_detail/task_referees_section.dart
+++ b/peppercheck_flutter/lib/features/task/presentation/widgets/task_detail/task_referees_section.dart
@@ -6,6 +6,7 @@ import 'package:peppercheck_flutter/common_widgets/base_section.dart';
 import 'package:peppercheck_flutter/features/matching/data/matching_repository.dart';
 import 'package:peppercheck_flutter/features/matching/domain/referee_request.dart';
 import 'package:peppercheck_flutter/features/task/domain/task.dart';
+import 'package:peppercheck_flutter/features/home/presentation/home_controller.dart';
 import 'package:peppercheck_flutter/features/task/presentation/providers/task_provider.dart';
 import 'package:peppercheck_flutter/gen/slang/strings.g.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
@@ -69,6 +70,7 @@ class _TaskRefereesSectionState extends ConsumerState<TaskRefereesSection> {
       );
 
       ref.invalidate(taskProvider(widget.task.id));
+      ref.invalidate(activeRefereeTasksProvider);
     } catch (e) {
       if (!mounted) return;
 


### PR DESCRIPTION
## Summary
- Add missing `ref.invalidate()` calls to EvidenceController, JudgementController, TaskRefereesSection, TaskCreationController, and FCMService so that home screen task lists, point balances, and task detail data refresh automatically after mutations
- Add `AppLifecycleObserver` widget that auto-refreshes stale providers when the app returns to foreground (with authentication check and 30-second throttle)

## Test plan
- [ ] Submit evidence on task detail → go back to home → task status updated without pull-to-refresh
- [ ] Submit judgement on task detail → go back to home → task status updated without pull-to-refresh
- [ ] Cancel referee assignment → referee's home screen no longer shows the task
- [x] Create a new task → point balance reflects the deduction immediately
- [x] Tap a push notification → task detail shows the latest data
- [x] Put app in background for 30+ seconds → bring to foreground → data refreshes automatically
- [ ] Put app in background briefly (<30s) → bring to foreground → no unnecessary refetch

Closes #344

🤖 Generated with [Claude Code](https://claude.com/claude-code)