### PR TITLE
feat(flutter): show verification pending state during Connect onboarding (#355)

### DIFF
--- a/docs/superpowers/specs/2026-04-19-verification-pending-state-design.md
+++ b/docs/superpowers/specs/2026-04-19-verification-pending-state-design.md
@@ -1,0 +1,95 @@
+# Show Verification Pending State During Connect Onboarding
+
+**Issue**: #355
+**Date**: 2026-04-19
+
+## Problem
+
+After completing Stripe Connect onboarding, if identity verification is still pending, the app shows the "出金設定を再開する" (resume payout setup) button. This is misleading because the user has already completed all required steps and is simply waiting for Stripe's verification.
+
+## Decision Log
+
+- **Logic location**: Flutter-side parsing of `connect_requirements` JSONB (not a DB-side computed column). Rationale: raw Stripe data is already stored; Flutter gains full flexibility without schema changes.
+- **Real-time updates**: Not included in v1.0. The existing `AppLifecycleListener.onResume` → re-fetch pattern is sufficient. Supabase Realtime can be added later.
+- **Pending verification message**: Generic "審査中です。完了までしばらくお待ちください" (not identity-specific), because `pending_verification` can include non-identity items (e.g., bank account verification).
+- **Edge case (`currently_due` empty, `pending_verification` empty, `payouts_enabled=false`)**: Treated as `isInProgress` (show resume button). This is a rare transitional state.
+
+## State Model
+
+`PayoutSetupStatus` gains two new fields parsed from `connect_requirements`:
+
+```dart
+List<String> currentlyDue        // from requirements.currently_due
+List<String> pendingVerification // from requirements.pending_verification
+```
+
+State priority (evaluated top-to-bottom, first match wins):
+
+| Condition | State | UI |
+|---|---|---|
+| `payouts_enabled = true` | `isComplete` | No change |
+| `payouts_enabled = false`, `currentlyDue` empty, `pendingVerification` non-empty | `isPendingVerification` | Message + no action button |
+| `payouts_enabled = false`, otherwise | `isInProgress` / `isNotStarted` | No change (existing behavior) |
+
+`isInProgress` and `isNotStarted` retain their existing `charges_enabled`-based distinction.
+
+## Changes
+
+### 1. `payout_setup_status.dart`
+
+Add `currentlyDue` and `pendingVerification` fields. These are not directly deserialized from the Supabase row JSON (which has a nested `connect_requirements` JSONB column), so they are populated by the repository layer, not `fromJson`.
+
+Add `isPendingVerification` getter:
+
+```dart
+bool get isPendingVerification =>
+    !payoutsEnabled && currentlyDue.isEmpty && pendingVerification.isNotEmpty;
+```
+
+Update `isInProgress` to exclude the pending verification case:
+
+```dart
+bool get isInProgress =>
+    chargesEnabled && !payoutsEnabled && !isPendingVerification;
+```
+
+### 2. `stripe_payout_repository.dart`
+
+Add `connect_requirements` to the select query. Parse `currently_due` and `pending_verification` from the JSONB before constructing `PayoutSetupStatus`:
+
+```dart
+final data = await _supabase
+    .from('stripe_accounts')
+    .select('charges_enabled, payouts_enabled, connect_requirements')
+    .maybeSingle();
+
+// Parse connect_requirements
+final requirements = data?['connect_requirements'] as Map<String, dynamic>?;
+final currentlyDue = (requirements?['currently_due'] as List?)
+    ?.cast<String>() ?? [];
+final pendingVerification = (requirements?['pending_verification'] as List?)
+    ?.cast<String>() ?? [];
+```
+
+### 3. `payout_setup_section.dart`
+
+Add a branch for `isPendingVerification` before the existing `isInProgress` / `isNotStarted` branches. Display:
+
+- Message: `t.payout.verificationPendingDescription` ("審査中です。完了までしばらくお待ちください")
+- No action button (neither resume nor setup)
+- No hints section
+
+### 4. i18n (`ja.i18n.json`)
+
+Add one key:
+
+```json
+"verificationPendingDescription": "審査中です。完了までしばらくお待ちください"
+```
+
+## Not Changed
+
+- **DB schema**: No migration needed. `connect_requirements` JSONB is already stored and updated by the webhook.
+- **Webhook handler**: Already saves full `account.requirements` object (#345).
+- **Realtime subscription**: Deferred; out of v1.0 scope.
+- **`payout_controller.dart`**: No changes needed; it already fetches status and invalidates on resume.

--- a/peppercheck_flutter/assets/i18n/ja.i18n.json
+++ b/peppercheck_flutter/assets/i18n/ja.i18n.json
@@ -66,6 +66,7 @@
     "payoutSetupComplete": "出金設定は完了しています",
     "resumeSetup": "出金設定を再開する",
     "payoutSetupInProgressDescription": "レフェリーをすることはできますが報酬を出金することはできません。出金設定を最後まで終わらせてください。",
+    "verificationPendingDescription": "審査中です。完了までしばらくお待ちください",
     "showHints": "入力のヒントを表示",
     "hideHints": "入力のヒントを隠す",
     "hintIndustry": "業種は「その他の個人向けサービス」を選んでください",

--- a/peppercheck_flutter/lib/features/payout/data/stripe_payout_repository.dart
+++ b/peppercheck_flutter/lib/features/payout/data/stripe_payout_repository.dart
@@ -21,14 +21,27 @@ class StripePayoutRepository {
     try {
       final data = await _supabase
           .from('stripe_accounts')
-          .select('charges_enabled, payouts_enabled')
+          .select('charges_enabled, payouts_enabled, connect_requirements')
           .maybeSingle();
 
       if (data == null) {
         return const PayoutSetupStatus();
       }
 
-      return PayoutSetupStatus.fromJson(data);
+      final requirements =
+          data['connect_requirements'] as Map<String, dynamic>?;
+      final currentlyDue =
+          (requirements?['currently_due'] as List?)?.cast<String>() ?? [];
+      final pendingVerification =
+          (requirements?['pending_verification'] as List?)?.cast<String>() ??
+          [];
+
+      return PayoutSetupStatus(
+        chargesEnabled: data['charges_enabled'] as bool? ?? false,
+        payoutsEnabled: data['payouts_enabled'] as bool? ?? false,
+        currentlyDue: currentlyDue,
+        pendingVerification: pendingVerification,
+      );
     } catch (e, stack) {
       _logger.e(
         'Failed to fetch payout setup status',

--- a/peppercheck_flutter/lib/features/payout/domain/payout_setup_status.dart
+++ b/peppercheck_flutter/lib/features/payout/domain/payout_setup_status.dart
@@ -9,6 +9,8 @@ abstract class PayoutSetupStatus with _$PayoutSetupStatus {
   const factory PayoutSetupStatus({
     @JsonKey(name: 'charges_enabled') @Default(false) bool chargesEnabled,
     @JsonKey(name: 'payouts_enabled') @Default(false) bool payoutsEnabled,
+    @Default([]) List<String> currentlyDue,
+    @Default([]) List<String> pendingVerification,
   }) = _PayoutSetupStatus;
 
   const PayoutSetupStatus._();
@@ -17,6 +19,9 @@ abstract class PayoutSetupStatus with _$PayoutSetupStatus {
       _$PayoutSetupStatusFromJson(json);
 
   bool get isComplete => chargesEnabled && payoutsEnabled;
-  bool get isInProgress => chargesEnabled && !payoutsEnabled;
+  bool get isPendingVerification =>
+      !payoutsEnabled && currentlyDue.isEmpty && pendingVerification.isNotEmpty;
+  bool get isInProgress =>
+      chargesEnabled && !payoutsEnabled && !isPendingVerification;
   bool get isNotStarted => !chargesEnabled && !payoutsEnabled;
 }

--- a/peppercheck_flutter/lib/features/payout/domain/payout_setup_status.freezed.dart
+++ b/peppercheck_flutter/lib/features/payout/domain/payout_setup_status.freezed.dart
@@ -15,7 +15,7 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$PayoutSetupStatus {
 
-@JsonKey(name: 'charges_enabled') bool get chargesEnabled;@JsonKey(name: 'payouts_enabled') bool get payoutsEnabled;
+@JsonKey(name: 'charges_enabled') bool get chargesEnabled;@JsonKey(name: 'payouts_enabled') bool get payoutsEnabled; List<String> get currentlyDue; List<String> get pendingVerification;
 /// Create a copy of PayoutSetupStatus
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -28,16 +28,16 @@ $PayoutSetupStatusCopyWith<PayoutSetupStatus> get copyWith => _$PayoutSetupStatu
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is PayoutSetupStatus&&(identical(other.chargesEnabled, chargesEnabled) || other.chargesEnabled == chargesEnabled)&&(identical(other.payoutsEnabled, payoutsEnabled) || other.payoutsEnabled == payoutsEnabled));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is PayoutSetupStatus&&(identical(other.chargesEnabled, chargesEnabled) || other.chargesEnabled == chargesEnabled)&&(identical(other.payoutsEnabled, payoutsEnabled) || other.payoutsEnabled == payoutsEnabled)&&const DeepCollectionEquality().equals(other.currentlyDue, currentlyDue)&&const DeepCollectionEquality().equals(other.pendingVerification, pendingVerification));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,chargesEnabled,payoutsEnabled);
+int get hashCode => Object.hash(runtimeType,chargesEnabled,payoutsEnabled,const DeepCollectionEquality().hash(currentlyDue),const DeepCollectionEquality().hash(pendingVerification));
 
 @override
 String toString() {
-  return 'PayoutSetupStatus(chargesEnabled: $chargesEnabled, payoutsEnabled: $payoutsEnabled)';
+  return 'PayoutSetupStatus(chargesEnabled: $chargesEnabled, payoutsEnabled: $payoutsEnabled, currentlyDue: $currentlyDue, pendingVerification: $pendingVerification)';
 }
 
 
@@ -48,7 +48,7 @@ abstract mixin class $PayoutSetupStatusCopyWith<$Res>  {
   factory $PayoutSetupStatusCopyWith(PayoutSetupStatus value, $Res Function(PayoutSetupStatus) _then) = _$PayoutSetupStatusCopyWithImpl;
 @useResult
 $Res call({
-@JsonKey(name: 'charges_enabled') bool chargesEnabled,@JsonKey(name: 'payouts_enabled') bool payoutsEnabled
+@JsonKey(name: 'charges_enabled') bool chargesEnabled,@JsonKey(name: 'payouts_enabled') bool payoutsEnabled, List<String> currentlyDue, List<String> pendingVerification
 });
 
 
@@ -65,11 +65,13 @@ class _$PayoutSetupStatusCopyWithImpl<$Res>
 
 /// Create a copy of PayoutSetupStatus
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? chargesEnabled = null,Object? payoutsEnabled = null,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? chargesEnabled = null,Object? payoutsEnabled = null,Object? currentlyDue = null,Object? pendingVerification = null,}) {
   return _then(_self.copyWith(
 chargesEnabled: null == chargesEnabled ? _self.chargesEnabled : chargesEnabled // ignore: cast_nullable_to_non_nullable
 as bool,payoutsEnabled: null == payoutsEnabled ? _self.payoutsEnabled : payoutsEnabled // ignore: cast_nullable_to_non_nullable
-as bool,
+as bool,currentlyDue: null == currentlyDue ? _self.currentlyDue : currentlyDue // ignore: cast_nullable_to_non_nullable
+as List<String>,pendingVerification: null == pendingVerification ? _self.pendingVerification : pendingVerification // ignore: cast_nullable_to_non_nullable
+as List<String>,
   ));
 }
 
@@ -154,10 +156,10 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function(@JsonKey(name: 'charges_enabled')  bool chargesEnabled, @JsonKey(name: 'payouts_enabled')  bool payoutsEnabled)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function(@JsonKey(name: 'charges_enabled')  bool chargesEnabled, @JsonKey(name: 'payouts_enabled')  bool payoutsEnabled,  List<String> currentlyDue,  List<String> pendingVerification)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _PayoutSetupStatus() when $default != null:
-return $default(_that.chargesEnabled,_that.payoutsEnabled);case _:
+return $default(_that.chargesEnabled,_that.payoutsEnabled,_that.currentlyDue,_that.pendingVerification);case _:
   return orElse();
 
 }
@@ -175,10 +177,10 @@ return $default(_that.chargesEnabled,_that.payoutsEnabled);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function(@JsonKey(name: 'charges_enabled')  bool chargesEnabled, @JsonKey(name: 'payouts_enabled')  bool payoutsEnabled)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function(@JsonKey(name: 'charges_enabled')  bool chargesEnabled, @JsonKey(name: 'payouts_enabled')  bool payoutsEnabled,  List<String> currentlyDue,  List<String> pendingVerification)  $default,) {final _that = this;
 switch (_that) {
 case _PayoutSetupStatus():
-return $default(_that.chargesEnabled,_that.payoutsEnabled);case _:
+return $default(_that.chargesEnabled,_that.payoutsEnabled,_that.currentlyDue,_that.pendingVerification);case _:
   throw StateError('Unexpected subclass');
 
 }
@@ -195,10 +197,10 @@ return $default(_that.chargesEnabled,_that.payoutsEnabled);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function(@JsonKey(name: 'charges_enabled')  bool chargesEnabled, @JsonKey(name: 'payouts_enabled')  bool payoutsEnabled)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function(@JsonKey(name: 'charges_enabled')  bool chargesEnabled, @JsonKey(name: 'payouts_enabled')  bool payoutsEnabled,  List<String> currentlyDue,  List<String> pendingVerification)?  $default,) {final _that = this;
 switch (_that) {
 case _PayoutSetupStatus() when $default != null:
-return $default(_that.chargesEnabled,_that.payoutsEnabled);case _:
+return $default(_that.chargesEnabled,_that.payoutsEnabled,_that.currentlyDue,_that.pendingVerification);case _:
   return null;
 
 }
@@ -210,11 +212,25 @@ return $default(_that.chargesEnabled,_that.payoutsEnabled);case _:
 @JsonSerializable()
 
 class _PayoutSetupStatus extends PayoutSetupStatus {
-  const _PayoutSetupStatus({@JsonKey(name: 'charges_enabled') this.chargesEnabled = false, @JsonKey(name: 'payouts_enabled') this.payoutsEnabled = false}): super._();
+  const _PayoutSetupStatus({@JsonKey(name: 'charges_enabled') this.chargesEnabled = false, @JsonKey(name: 'payouts_enabled') this.payoutsEnabled = false, final  List<String> currentlyDue = const [], final  List<String> pendingVerification = const []}): _currentlyDue = currentlyDue,_pendingVerification = pendingVerification,super._();
   factory _PayoutSetupStatus.fromJson(Map<String, dynamic> json) => _$PayoutSetupStatusFromJson(json);
 
 @override@JsonKey(name: 'charges_enabled') final  bool chargesEnabled;
 @override@JsonKey(name: 'payouts_enabled') final  bool payoutsEnabled;
+ final  List<String> _currentlyDue;
+@override@JsonKey() List<String> get currentlyDue {
+  if (_currentlyDue is EqualUnmodifiableListView) return _currentlyDue;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(_currentlyDue);
+}
+
+ final  List<String> _pendingVerification;
+@override@JsonKey() List<String> get pendingVerification {
+  if (_pendingVerification is EqualUnmodifiableListView) return _pendingVerification;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(_pendingVerification);
+}
+
 
 /// Create a copy of PayoutSetupStatus
 /// with the given fields replaced by the non-null parameter values.
@@ -229,16 +245,16 @@ Map<String, dynamic> toJson() {
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _PayoutSetupStatus&&(identical(other.chargesEnabled, chargesEnabled) || other.chargesEnabled == chargesEnabled)&&(identical(other.payoutsEnabled, payoutsEnabled) || other.payoutsEnabled == payoutsEnabled));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _PayoutSetupStatus&&(identical(other.chargesEnabled, chargesEnabled) || other.chargesEnabled == chargesEnabled)&&(identical(other.payoutsEnabled, payoutsEnabled) || other.payoutsEnabled == payoutsEnabled)&&const DeepCollectionEquality().equals(other._currentlyDue, _currentlyDue)&&const DeepCollectionEquality().equals(other._pendingVerification, _pendingVerification));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,chargesEnabled,payoutsEnabled);
+int get hashCode => Object.hash(runtimeType,chargesEnabled,payoutsEnabled,const DeepCollectionEquality().hash(_currentlyDue),const DeepCollectionEquality().hash(_pendingVerification));
 
 @override
 String toString() {
-  return 'PayoutSetupStatus(chargesEnabled: $chargesEnabled, payoutsEnabled: $payoutsEnabled)';
+  return 'PayoutSetupStatus(chargesEnabled: $chargesEnabled, payoutsEnabled: $payoutsEnabled, currentlyDue: $currentlyDue, pendingVerification: $pendingVerification)';
 }
 
 
@@ -249,7 +265,7 @@ abstract mixin class _$PayoutSetupStatusCopyWith<$Res> implements $PayoutSetupSt
   factory _$PayoutSetupStatusCopyWith(_PayoutSetupStatus value, $Res Function(_PayoutSetupStatus) _then) = __$PayoutSetupStatusCopyWithImpl;
 @override @useResult
 $Res call({
-@JsonKey(name: 'charges_enabled') bool chargesEnabled,@JsonKey(name: 'payouts_enabled') bool payoutsEnabled
+@JsonKey(name: 'charges_enabled') bool chargesEnabled,@JsonKey(name: 'payouts_enabled') bool payoutsEnabled, List<String> currentlyDue, List<String> pendingVerification
 });
 
 
@@ -266,11 +282,13 @@ class __$PayoutSetupStatusCopyWithImpl<$Res>
 
 /// Create a copy of PayoutSetupStatus
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? chargesEnabled = null,Object? payoutsEnabled = null,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? chargesEnabled = null,Object? payoutsEnabled = null,Object? currentlyDue = null,Object? pendingVerification = null,}) {
   return _then(_PayoutSetupStatus(
 chargesEnabled: null == chargesEnabled ? _self.chargesEnabled : chargesEnabled // ignore: cast_nullable_to_non_nullable
 as bool,payoutsEnabled: null == payoutsEnabled ? _self.payoutsEnabled : payoutsEnabled // ignore: cast_nullable_to_non_nullable
-as bool,
+as bool,currentlyDue: null == currentlyDue ? _self._currentlyDue : currentlyDue // ignore: cast_nullable_to_non_nullable
+as List<String>,pendingVerification: null == pendingVerification ? _self._pendingVerification : pendingVerification // ignore: cast_nullable_to_non_nullable
+as List<String>,
   ));
 }
 

--- a/peppercheck_flutter/lib/features/payout/domain/payout_setup_status.g.dart
+++ b/peppercheck_flutter/lib/features/payout/domain/payout_setup_status.g.dart
@@ -10,10 +10,22 @@ _PayoutSetupStatus _$PayoutSetupStatusFromJson(Map<String, dynamic> json) =>
     _PayoutSetupStatus(
       chargesEnabled: json['charges_enabled'] as bool? ?? false,
       payoutsEnabled: json['payouts_enabled'] as bool? ?? false,
+      currentlyDue:
+          (json['currentlyDue'] as List<dynamic>?)
+              ?.map((e) => e as String)
+              .toList() ??
+          const [],
+      pendingVerification:
+          (json['pendingVerification'] as List<dynamic>?)
+              ?.map((e) => e as String)
+              .toList() ??
+          const [],
     );
 
 Map<String, dynamic> _$PayoutSetupStatusToJson(_PayoutSetupStatus instance) =>
     <String, dynamic>{
       'charges_enabled': instance.chargesEnabled,
       'payouts_enabled': instance.payoutsEnabled,
+      'currentlyDue': instance.currentlyDue,
+      'pendingVerification': instance.pendingVerification,
     };

--- a/peppercheck_flutter/lib/features/payout/presentation/widgets/payout_setup_section.dart
+++ b/peppercheck_flutter/lib/features/payout/presentation/widgets/payout_setup_section.dart
@@ -43,6 +43,13 @@ class _PayoutSetupSectionState extends ConsumerState<PayoutSetupSection> {
                 ref.read(payoutControllerProvider.notifier).setupPayout();
               },
             ),
+          ] else if (state.value?.isPendingVerification == true) ...[
+            Text(
+              t.payout.verificationPendingDescription,
+              style: TextStyle(
+                color: AppColors.textPrimary.withValues(alpha: 0.6),
+              ),
+            ),
           ] else ...[
             if (state.value?.isInProgress == true)
               Text(

--- a/peppercheck_flutter/lib/gen/slang/strings.g.dart
+++ b/peppercheck_flutter/lib/gen/slang/strings.g.dart
@@ -4,9 +4,9 @@
 /// To regenerate, run: `dart run slang`
 ///
 /// Locales: 1
-/// Strings: 269
+/// Strings: 270
 ///
-/// Built on 2026-04-19 at 14:25 UTC
+/// Built on 2026-04-19 at 17:23 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint, unused_import

--- a/peppercheck_flutter/lib/gen/slang/strings_ja.g.dart
+++ b/peppercheck_flutter/lib/gen/slang/strings_ja.g.dart
@@ -239,6 +239,9 @@ class TranslationsPayoutJa {
 	/// ja: 'レフェリーをすることはできますが報酬を出金することはできません。出金設定を最後まで終わらせてください。'
 	String get payoutSetupInProgressDescription => 'レフェリーをすることはできますが報酬を出金することはできません。出金設定を最後まで終わらせてください。';
 
+	/// ja: '審査中です。完了までしばらくお待ちください'
+	String get verificationPendingDescription => '審査中です。完了までしばらくお待ちください';
+
 	/// ja: '入力のヒントを表示'
 	String get showHints => '入力のヒントを表示';
 
@@ -1237,6 +1240,7 @@ extension on Translations {
 			'payout.payoutSetupComplete' => '出金設定は完了しています',
 			'payout.resumeSetup' => '出金設定を再開する',
 			'payout.payoutSetupInProgressDescription' => 'レフェリーをすることはできますが報酬を出金することはできません。出金設定を最後まで終わらせてください。',
+			'payout.verificationPendingDescription' => '審査中です。完了までしばらくお待ちください',
 			'payout.showHints' => '入力のヒントを表示',
 			'payout.hideHints' => '入力のヒントを隠す',
 			'payout.hintIndustry' => '業種は「その他の個人向けサービス」を選んでください',

--- a/peppercheck_flutter/test/features/payout/domain/payout_setup_status_test.dart
+++ b/peppercheck_flutter/test/features/payout/domain/payout_setup_status_test.dart
@@ -43,6 +43,17 @@ void main() {
         );
         expect(status.isPendingVerification, false);
       });
+
+      test('returns true even when chargesEnabled=false '
+          '(isPendingVerification takes priority over isNotStarted)', () {
+        final status = PayoutSetupStatus(
+          chargesEnabled: false,
+          payoutsEnabled: false,
+          pendingVerification: ['individual.verification.document'],
+        );
+        expect(status.isPendingVerification, true);
+        expect(status.isNotStarted, true);
+      });
     });
 
     group('isInProgress excludes pending verification', () {

--- a/peppercheck_flutter/test/features/payout/domain/payout_setup_status_test.dart
+++ b/peppercheck_flutter/test/features/payout/domain/payout_setup_status_test.dart
@@ -1,0 +1,90 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:peppercheck_flutter/features/payout/domain/payout_setup_status.dart';
+
+void main() {
+  group('PayoutSetupStatus', () {
+    group('isPendingVerification', () {
+      test('returns true when payoutsEnabled=false, currentlyDue empty, '
+          'pendingVerification non-empty', () {
+        final status = PayoutSetupStatus(
+          chargesEnabled: true,
+          payoutsEnabled: false,
+          currentlyDue: [],
+          pendingVerification: ['individual.verification.document'],
+        );
+        expect(status.isPendingVerification, true);
+      });
+
+      test('returns false when currentlyDue is non-empty '
+          '(even if pendingVerification is also non-empty)', () {
+        final status = PayoutSetupStatus(
+          chargesEnabled: true,
+          payoutsEnabled: false,
+          currentlyDue: ['individual.address.city'],
+          pendingVerification: ['individual.verification.document'],
+        );
+        expect(status.isPendingVerification, false);
+      });
+
+      test('returns false when payoutsEnabled=true', () {
+        final status = PayoutSetupStatus(
+          chargesEnabled: true,
+          payoutsEnabled: true,
+          pendingVerification: ['individual.verification.document'],
+        );
+        expect(status.isPendingVerification, false);
+      });
+
+      test('returns false when both currentlyDue and '
+          'pendingVerification are empty', () {
+        final status = PayoutSetupStatus(
+          chargesEnabled: true,
+          payoutsEnabled: false,
+        );
+        expect(status.isPendingVerification, false);
+      });
+    });
+
+    group('isInProgress excludes pending verification', () {
+      test('returns false when isPendingVerification is true', () {
+        final status = PayoutSetupStatus(
+          chargesEnabled: true,
+          payoutsEnabled: false,
+          pendingVerification: ['individual.verification.document'],
+        );
+        expect(status.isInProgress, false);
+      });
+
+      test('returns true when chargesEnabled=true, payoutsEnabled=false, '
+          'not pending verification', () {
+        final status = PayoutSetupStatus(
+          chargesEnabled: true,
+          payoutsEnabled: false,
+          currentlyDue: ['individual.address.city'],
+        );
+        expect(status.isInProgress, true);
+      });
+    });
+
+    group('existing states unchanged', () {
+      test('isComplete when payoutsEnabled=true', () {
+        final status = PayoutSetupStatus(
+          chargesEnabled: true,
+          payoutsEnabled: true,
+        );
+        expect(status.isComplete, true);
+        expect(status.isInProgress, false);
+        expect(status.isNotStarted, false);
+        expect(status.isPendingVerification, false);
+      });
+
+      test('isNotStarted when both disabled', () {
+        final status = PayoutSetupStatus();
+        expect(status.isNotStarted, true);
+        expect(status.isComplete, false);
+        expect(status.isInProgress, false);
+        expect(status.isPendingVerification, false);
+      });
+    });
+  });
+}


### PR DESCRIPTION
## Summary

- Parse `connect_requirements` JSONB from `stripe_accounts` in Flutter to distinguish "waiting for Stripe verification" from "needs to resume setup"
- Show "審査中です。完了までしばらくお待ちください" instead of the misleading "出金設定を再開する" button when `pending_verification` is non-empty and `currently_due` is empty
- No DB schema or webhook changes needed — leverages existing `connect_requirements` data stored by #345

## Changes

- **`payout_setup_status.dart`**: Add `currentlyDue`/`pendingVerification` fields and `isPendingVerification` getter
- **`stripe_payout_repository.dart`**: Parse nested `connect_requirements` JSONB, construct `PayoutSetupStatus` directly
- **`payout_setup_section.dart`**: Add `isPendingVerification` UI branch (message only, no action button)
- **i18n**: Add `verificationPendingDescription` key
- **Tests**: 9 unit tests covering all state transitions including overlap documentation

## Follow-up notes

- `PayoutSetupStatus.fromJson` is now unused by the repository (constructs directly). Could be cleaned up in a future PR.
- Supabase Realtime for instant verification-complete updates deferred to post-v1.0.

## Test plan

- [x] Unit tests pass (9 tests)
- [x] `flutter build apk --debug` succeeds
- [x] Manual: complete Stripe Connect onboarding → verify "審査中です" message appears while verification is pending

Closes #355

🤖 Generated with [Claude Code](https://claude.com/claude-code)