### PR TITLE
fix(flutter): implement proper detailed status logic for home screen task cards (#353)

### DIFF
--- a/docs/superpowers/specs/2026-04-19-task-card-detailed-status-design.md
+++ b/docs/superpowers/specs/2026-04-19-task-card-detailed-status-design.md
@@ -1,0 +1,125 @@
+# Task Card Detailed Status Display
+
+**Issue**: #353
+**Date**: 2026-04-19
+
+## Problem
+
+Home screen task cards display incorrect/stale status labels. `Task.detailedStatus` returns the raw `task.status` (`draft`/`open`/`closed`), but the UI expects granular statuses derived from `referee_request.status` and `judgement.status`.
+
+## Decision Log
+
+- **Logic location**: `Task.getDetailedStatuses(String currentUserId)` method on the Freezed model. Domain logic stays in the model layer; the UI only handles display.
+- **Aggregation strategy**: Per-referee display. When a task has 2 referee requests in the judgement phase, both statuses are shown side by side separated by `|`. Task-level statuses (matching phase, evidence timeout) show as a single label.
+- **Filtering**: `declined` and `cancelled` referee requests are excluded from status computation because re-matching creates a new `pending` request row.
+- **Tasker vs. referee view**: Determined by `currentUserId == task.taskerId`. Tasker sees aggregated state of all active requests. Referee sees only their own request's state.
+- **Removed statuses**: `self_completed` and `done` from the existing UI are removed — they have no corresponding DB enum values.
+
+## State Derivation
+
+### Active request filtering
+
+Exclude requests with status `declined` or `cancelled`. All logic below operates on the remaining "active" requests.
+
+### Tasker view (`currentUserId == taskerId`)
+
+Evaluated top-to-bottom, first match wins:
+
+| Priority | Condition | Return value |
+|---|---|---|
+| 1 | `task.status == 'draft'` | `['draft']` |
+| 2 | All active requests are `expired` | `['matching_failed']` |
+| 3 | Any active request is `pending` or `matched` | `['matching']` |
+| 4 | All active requests are `accepted` AND all judgements are `awaiting_evidence` | `['matching_complete']` |
+| 5 | Any judgement is `evidence_timeout` | `['evidence_timeout']` |
+| 6 | Judgement phase (`in_review` / `approved` / `rejected` / `review_timeout`) | Per-referee status list (e.g. `['in_review', 'approved']`) |
+| 7 | Any request is `payment_processing` | Per-referee status list |
+| 8 | All active requests are `closed` | `['closed']` |
+
+### Referee view (`currentUserId != taskerId`)
+
+Find the request where `matchedRefereeId == currentUserId` and return its status:
+
+| Condition | Return value |
+|---|---|
+| Judgement `awaiting_evidence` | `['awaiting_evidence']` |
+| Judgement `in_review` | `['in_review']` |
+| Judgement `approved` | `['approved']` |
+| Judgement `rejected` | `['rejected']` |
+| Judgement `evidence_timeout` | `['evidence_timeout']` |
+| Judgement `review_timeout` | `['review_timeout']` |
+| Request `payment_processing` | `['payment_processing']` |
+| Request `closed` | `['closed']` |
+
+## Display
+
+### TaskCard changes
+
+- `TaskCard` becomes a `ConsumerWidget` to access `currentUserProvider` for the user ID.
+- `getDetailedStatuses(currentUserId)` returns a `List<String>` of status keys.
+- 1 status: single text label (current layout).
+- 2 statuses: displayed side by side with `|` separator.
+
+### Status labels and colors
+
+| Key | Tasker label | Referee label | Color |
+|---|---|---|---|
+| `draft` | 下書き | — | `textMuted` |
+| `matching` | マッチング中 | — | `accentYellow` |
+| `matching_complete` | マッチング完了 | — | `accentGreenLight` |
+| `matching_failed` | マッチング失敗 | — | `accentRed` |
+| `awaiting_evidence` | — | エビデンス提出前 | `accentYellow` |
+| `evidence_timeout` | エビデンス提出期限切れ | エビデンス提出期限切れ | `textSecondary` |
+| `in_review` | 判定中 | 判定中 | `accentBlueLight` |
+| `approved` | 承認 | 承認 | `accentGreenLight` |
+| `rejected` | 却下 | 却下 | `accentBlue` |
+| `review_timeout` | 判定期限切れ | 判定期限切れ | `textSecondary` |
+| `payment_processing` | 支払い処理中 | 支払い処理中 | `accentYellow` |
+| `closed` | 完了 | 完了 | `accentGreen` |
+
+### i18n (`ja.i18n.json`)
+
+Replace `task.status` keys:
+
+```json
+"status": {
+  "draft": "下書き",
+  "matching": "マッチング中",
+  "matchingComplete": "マッチング完了",
+  "matchingFailed": "マッチング失敗",
+  "awaitingEvidence": "エビデンス提出前",
+  "evidenceTimeout": "エビデンス提出期限切れ",
+  "inReview": "判定中",
+  "approved": "承認",
+  "rejected": "却下",
+  "reviewTimeout": "判定期限切れ",
+  "paymentProcessing": "支払い処理中",
+  "closed": "完了"
+}
+```
+
+## Changes
+
+### 1. `task.dart`
+
+- Remove `detailedStatus` getter.
+- Add `getDetailedStatuses(String currentUserId)` method returning `List<String>`.
+- Implement active request filtering and tasker/referee view logic as specified above.
+
+### 2. `task_card.dart`
+
+- Change from `StatelessWidget` to `ConsumerWidget`.
+- Get `currentUserId` from `currentUserProvider`.
+- Call `task.getDetailedStatuses(currentUserId)` instead of `task.detailedStatus`.
+- Update `_getStatusStyle` to use new status keys and support `isMyTask`-dependent labels.
+- Handle list of statuses: single display or `|`-separated side-by-side display.
+
+### 3. `ja.i18n.json`
+
+- Replace `task.status` section with new keys as specified above.
+
+## Not Changed
+
+- **DB schema**: No migration. All data is already available in `referee_requests` and `judgements`.
+- **Home screen / controllers**: No changes. `activeUserTasksProvider` and `activeRefereeTasks` already fetch tasks with nested `refereeRequests` and `judgements`.
+- **Task detail screen**: Out of scope. This issue focuses on home screen task cards only.

--- a/peppercheck_flutter/assets/i18n/ja.i18n.json
+++ b/peppercheck_flutter/assets/i18n/ja.i18n.json
@@ -109,13 +109,17 @@
     "status": {
       "draft": "下書き",
       "open": "マッチング開始",
-      "judging": "判定中",
+      "matching": "マッチング中",
+      "matchingComplete": "マッチング完了",
+      "matchingFailed": "マッチング失敗",
+      "awaitingEvidence": "エビデンス提出前",
+      "evidenceTimeout": "エビデンス提出期限切れ",
+      "inReview": "判定中",
+      "approved": "承認",
       "rejected": "却下",
-      "completed": "完了",
-      "closed": "終了",
-      "self_completed": "自己完結",
-      "expired": "期限切れ",
-      "done": "完了"
+      "reviewTimeout": "判定期限切れ",
+      "paymentProcessing": "支払い処理中",
+      "closed": "完了"
     },
     "detail": {
       "title": "タスク詳細",

--- a/peppercheck_flutter/lib/features/evidence/presentation/controllers/evidence_controller.dart
+++ b/peppercheck_flutter/lib/features/evidence/presentation/controllers/evidence_controller.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:image_picker/image_picker.dart';
 import 'package:peppercheck_flutter/features/evidence/data/evidence_repository.dart';
+import 'package:peppercheck_flutter/features/home/presentation/home_controller.dart';
 import 'package:peppercheck_flutter/features/task/presentation/providers/task_provider.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
@@ -38,6 +39,8 @@ class EvidenceController extends _$EvidenceController {
           );
       // Invalidate task provider to refresh UI
       ref.invalidate(taskProvider(taskId));
+      ref.invalidate(activeUserTasksProvider);
+      ref.invalidate(activeRefereeTasksProvider);
       onSuccess();
     });
   }
@@ -62,6 +65,8 @@ class EvidenceController extends _$EvidenceController {
             assetIdsToRemove: assetIdsToRemove,
           );
       ref.invalidate(taskProvider(taskId));
+      ref.invalidate(activeUserTasksProvider);
+      ref.invalidate(activeRefereeTasksProvider);
       onSuccess();
     });
   }
@@ -86,6 +91,8 @@ class EvidenceController extends _$EvidenceController {
             assetIdsToRemove: assetIdsToRemove,
           );
       ref.invalidate(taskProvider(taskId));
+      ref.invalidate(activeUserTasksProvider);
+      ref.invalidate(activeRefereeTasksProvider);
       onSuccess();
     });
   }
@@ -102,6 +109,8 @@ class EvidenceController extends _$EvidenceController {
           .read(evidenceRepositoryProvider)
           .confirmEvidenceTimeout(judgementId: judgementId);
       ref.invalidate(taskProvider(taskId));
+      ref.invalidate(activeUserTasksProvider);
+      ref.invalidate(activeRefereeTasksProvider);
       onSuccess();
     });
   }

--- a/peppercheck_flutter/lib/features/home/presentation/home_screen.dart
+++ b/peppercheck_flutter/lib/features/home/presentation/home_screen.dart
@@ -10,17 +10,40 @@ import 'package:peppercheck_flutter/features/home/presentation/widgets/task_card
 import 'package:peppercheck_flutter/features/task/domain/task.dart';
 import 'package:peppercheck_flutter/gen/slang/strings.g.dart';
 
-class HomeScreen extends ConsumerWidget {
+class HomeScreen extends ConsumerStatefulWidget {
   const HomeScreen({super.key});
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  ConsumerState<HomeScreen> createState() => _HomeScreenState();
+}
+
+class _HomeScreenState extends ConsumerState<HomeScreen> {
+  AppLifecycleListener? _listener;
+
+  @override
+  void initState() {
+    super.initState();
+    _listener = AppLifecycleListener(
+      onResume: () {
+        ref.invalidate(activeUserTasksProvider);
+        ref.invalidate(activeRefereeTasksProvider);
+      },
+    );
+  }
+
+  @override
+  void dispose() {
+    _listener?.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
     return AppBackground(
       child: AppScaffold.scrollable(
         title: t.home.title,
         currentIndex: 0,
         onRefresh: () async {
-          // Refresh both providers
           ref.invalidate(activeUserTasksProvider);
           ref.invalidate(activeRefereeTasksProvider);
         },

--- a/peppercheck_flutter/lib/features/home/presentation/home_screen.dart
+++ b/peppercheck_flutter/lib/features/home/presentation/home_screen.dart
@@ -31,7 +31,6 @@ class HomeScreen extends ConsumerWidget {
               _TaskSection(
                 title: t.home.myTasks,
                 tasksValue: ref.watch(activeUserTasksProvider),
-                isMyTask: true,
               ),
               const SizedBox(height: AppSizes.sectionGap),
 
@@ -39,7 +38,6 @@ class HomeScreen extends ConsumerWidget {
               _TaskSection(
                 title: t.home.refereeTasks,
                 tasksValue: ref.watch(activeRefereeTasksProvider),
-                isMyTask: false,
               ),
             ]),
           ),
@@ -52,13 +50,8 @@ class HomeScreen extends ConsumerWidget {
 class _TaskSection extends StatelessWidget {
   final String title;
   final AsyncValue<List<Task>> tasksValue;
-  final bool isMyTask;
 
-  const _TaskSection({
-    required this.title,
-    required this.tasksValue,
-    required this.isMyTask,
-  });
+  const _TaskSection({required this.title, required this.tasksValue});
 
   @override
   Widget build(BuildContext context) {
@@ -78,7 +71,7 @@ class _TaskSection extends StatelessWidget {
             children: [
               for (int i = 0; i < tasks.length; i++) ...[
                 if (i > 0) const SizedBox(height: AppSizes.cardGap),
-                TaskCard(task: tasks[i], isMyTask: isMyTask),
+                TaskCard(task: tasks[i]),
               ],
             ],
           );

--- a/peppercheck_flutter/lib/features/home/presentation/widgets/task_card.dart
+++ b/peppercheck_flutter/lib/features/home/presentation/widgets/task_card.dart
@@ -1,12 +1,14 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:intl/intl.dart';
 import 'package:peppercheck_flutter/app/theme/app_colors.dart';
 import 'package:peppercheck_flutter/app/theme/app_sizes.dart';
+import 'package:peppercheck_flutter/features/authentication/data/auth_state_provider.dart';
 import 'package:peppercheck_flutter/features/task/domain/task.dart';
 import 'package:peppercheck_flutter/gen/slang/strings.g.dart';
 
-class TaskCard extends StatelessWidget {
+class TaskCard extends ConsumerWidget {
   final Task task;
   final bool isMyTask;
   final VoidCallback? onTap;
@@ -19,14 +21,15 @@ class TaskCard extends StatelessWidget {
   });
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final dueDateFormatted = task.dueDate != null
         ? DateFormat(
             'MM/dd H:mm',
           ).format(DateTime.parse(task.dueDate!).toLocal())
         : '';
 
-    final statusStyle = _getStatusStyle(task);
+    final currentUserId = ref.watch(currentUserProvider)?.id ?? '';
+    final statuses = task.getDetailedStatuses(currentUserId);
 
     return Material(
       color: AppColors.backgroundWhite,
@@ -72,13 +75,7 @@ class TaskCard extends StatelessWidget {
                 ),
               ),
               const SizedBox(width: AppSizes.taskCardStatusGap),
-              Text(
-                statusStyle.text,
-                style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                  color: statusStyle.color,
-                  fontWeight: FontWeight.bold,
-                ),
-              ),
+              _buildStatusLabels(context, statuses),
             ],
           ),
         ),
@@ -86,24 +83,95 @@ class TaskCard extends StatelessWidget {
     );
   }
 
-  ({String text, Color color}) _getStatusStyle(Task task) {
-    switch (task.status) {
+  Widget _buildStatusLabels(BuildContext context, List<String> statuses) {
+    if (statuses.length == 1) {
+      final style = _getStatusStyle(statuses[0]);
+      return Text(
+        style.text,
+        style: Theme.of(context).textTheme.bodySmall?.copyWith(
+          color: style.color,
+          fontWeight: FontWeight.bold,
+        ),
+      );
+    }
+
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        for (int i = 0; i < statuses.length; i++) ...[
+          if (i > 0)
+            Padding(
+              padding: const EdgeInsets.symmetric(
+                horizontal: AppSizes.spacingTiny,
+              ),
+              child: Text(
+                '|',
+                style: Theme.of(
+                  context,
+                ).textTheme.bodySmall?.copyWith(color: AppColors.textMuted),
+              ),
+            ),
+          () {
+            final style = _getStatusStyle(statuses[i]);
+            return Text(
+              style.text,
+              style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                color: style.color,
+                fontWeight: FontWeight.bold,
+              ),
+            );
+          }(),
+        ],
+      ],
+    );
+  }
+
+  ({String text, Color color}) _getStatusStyle(String statusKey) {
+    switch (statusKey) {
       case 'draft':
+        return (text: t.task.status.draft, color: AppColors.textMuted);
+      case 'matching':
+        return (text: t.task.status.matching, color: AppColors.accentYellow);
+      case 'matching_complete':
         return (
-          text: t.task.status.draft,
-          color: AppColors.textPrimary.withValues(alpha: 0.6),
+          text: t.task.status.matchingComplete,
+          color: AppColors.accentGreenLight,
         );
-      case 'open':
-        return (text: t.task.status.open, color: AppColors.accentYellow);
+      case 'matching_failed':
+        return (text: t.task.status.matchingFailed, color: AppColors.accentRed);
+      case 'awaiting_evidence':
+        return (
+          text: t.task.status.awaitingEvidence,
+          color: AppColors.accentYellow,
+        );
+      case 'evidence_timeout':
+        return (
+          text: t.task.status.evidenceTimeout,
+          color: AppColors.textSecondary,
+        );
+      case 'in_review':
+        return (text: t.task.status.inReview, color: AppColors.accentBlueLight);
+      case 'approved':
+        return (
+          text: t.task.status.approved,
+          color: AppColors.accentGreenLight,
+        );
       case 'rejected':
-        return (text: t.task.status.rejected, color: AppColors.accentRed);
-      case 'closed':
+        return (text: t.task.status.rejected, color: AppColors.accentBlue);
+      case 'review_timeout':
         return (
-          text: t.task.status.closed,
-          color: AppColors.accentGreen.withValues(alpha: 0.7),
+          text: t.task.status.reviewTimeout,
+          color: AppColors.textSecondary,
         );
+      case 'payment_processing':
+        return (
+          text: t.task.status.paymentProcessing,
+          color: AppColors.accentYellow,
+        );
+      case 'closed':
+        return (text: t.task.status.closed, color: AppColors.accentGreen);
       default:
-        return (text: task.status, color: AppColors.textPrimary);
+        return (text: statusKey, color: AppColors.textPrimary);
     }
   }
 }

--- a/peppercheck_flutter/lib/features/home/presentation/widgets/task_card.dart
+++ b/peppercheck_flutter/lib/features/home/presentation/widgets/task_card.dart
@@ -10,15 +10,9 @@ import 'package:peppercheck_flutter/gen/slang/strings.g.dart';
 
 class TaskCard extends ConsumerWidget {
   final Task task;
-  final bool isMyTask;
   final VoidCallback? onTap;
 
-  const TaskCard({
-    super.key,
-    required this.task,
-    this.isMyTask = false,
-    this.onTap,
-  });
+  const TaskCard({super.key, required this.task, this.onTap});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {

--- a/peppercheck_flutter/lib/features/home/presentation/widgets/task_card.dart
+++ b/peppercheck_flutter/lib/features/home/presentation/widgets/task_card.dart
@@ -87,7 +87,7 @@ class TaskCard extends StatelessWidget {
   }
 
   ({String text, Color color}) _getStatusStyle(Task task) {
-    switch (task.detailedStatus) {
+    switch (task.status) {
       case 'draft':
         return (
           text: t.task.status.draft,

--- a/peppercheck_flutter/lib/features/home/presentation/widgets/task_card.dart
+++ b/peppercheck_flutter/lib/features/home/presentation/widgets/task_card.dart
@@ -95,32 +95,13 @@ class TaskCard extends StatelessWidget {
         );
       case 'open':
         return (text: t.task.status.open, color: AppColors.accentYellow);
-      case 'judging':
-        return (text: t.task.status.judging, color: AppColors.accentBlueLight);
       case 'rejected':
         return (text: t.task.status.rejected, color: AppColors.accentRed);
-      case 'completed':
-        return (
-          text: t.task.status.completed,
-          color: AppColors.accentGreenLight,
-        );
       case 'closed':
         return (
           text: t.task.status.closed,
           color: AppColors.accentGreen.withValues(alpha: 0.7),
         );
-      case 'self_completed':
-        return (
-          text: t.task.status.self_completed,
-          color: AppColors.accentGreen.withValues(alpha: 0.5),
-        );
-      case 'expired':
-        return (
-          text: t.task.status.expired,
-          color: AppColors.textPrimary.withValues(alpha: 0.4),
-        );
-      case 'done':
-        return (text: t.task.status.done, color: AppColors.accentGreenLight);
       default:
         return (text: task.status, color: AppColors.textPrimary);
     }

--- a/peppercheck_flutter/lib/features/judgement/presentation/controllers/judgement_controller.dart
+++ b/peppercheck_flutter/lib/features/judgement/presentation/controllers/judgement_controller.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:peppercheck_flutter/features/judgement/data/judgement_repository.dart';
+import 'package:peppercheck_flutter/features/home/presentation/home_controller.dart';
 import 'package:peppercheck_flutter/features/task/presentation/providers/task_provider.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
@@ -30,6 +31,8 @@ class JudgementController extends _$JudgementController {
             comment: comment,
           );
       ref.invalidate(taskProvider(taskId));
+      ref.invalidate(activeUserTasksProvider);
+      ref.invalidate(activeRefereeTasksProvider);
       onSuccess();
     });
   }
@@ -52,6 +55,8 @@ class JudgementController extends _$JudgementController {
             comment: comment,
           );
       ref.invalidate(taskProvider(taskId));
+      ref.invalidate(activeUserTasksProvider);
+      ref.invalidate(activeRefereeTasksProvider);
       onSuccess();
     });
   }
@@ -68,6 +73,8 @@ class JudgementController extends _$JudgementController {
           .read(judgementRepositoryProvider)
           .confirmReviewTimeout(judgementId: judgementId);
       ref.invalidate(taskProvider(taskId));
+      ref.invalidate(activeUserTasksProvider);
+      ref.invalidate(activeRefereeTasksProvider);
       onSuccess();
     });
   }

--- a/peppercheck_flutter/lib/features/task/domain/task.dart
+++ b/peppercheck_flutter/lib/features/task/domain/task.dart
@@ -37,10 +37,80 @@ abstract class Task with _$Task {
 
   const Task._();
 
-  // TODO: Implement complex status logic using referee_requests and judgement status
-  String get detailedStatus {
-    // For now, it just returns the basic status.
-    // Future implementation will check refereeRequests, etc.
-    return status;
+  static const _terminalStatuses = {'declined', 'cancelled'};
+  static const _matchingStatuses = {'pending', 'matched'};
+
+  List<String> getDetailedStatuses(String currentUserId) {
+    if (status == 'draft') return ['draft'];
+    if (status == 'closed') return ['closed'];
+
+    final activeRequests = refereeRequests
+        .where((r) => !_terminalStatuses.contains(r.status))
+        .toList();
+
+    // Tasker view
+    if (currentUserId == taskerId) {
+      return _taskerStatuses(activeRequests);
+    }
+
+    // Referee view
+    return _refereeStatuses(activeRequests, currentUserId);
+  }
+
+  List<String> _taskerStatuses(List<RefereeRequest> active) {
+    if (active.isEmpty || active.every((r) => r.status == 'expired')) {
+      return active.isEmpty ? ['matching'] : ['matching_failed'];
+    }
+
+    if (active.any((r) => _matchingStatuses.contains(r.status))) {
+      return ['matching'];
+    }
+
+    final accepted = active
+        .where(
+          (r) =>
+              r.status == 'accepted' ||
+              r.status == 'payment_processing' ||
+              r.status == 'closed',
+        )
+        .toList();
+
+    if (accepted.isNotEmpty &&
+        accepted.every((r) => r.judgement?.status == 'awaiting_evidence')) {
+      return ['matching_complete'];
+    }
+
+    if (accepted.any((r) => r.judgement?.status == 'evidence_timeout')) {
+      return ['evidence_timeout'];
+    }
+
+    if (accepted.every((r) => r.status == 'closed')) {
+      return ['closed'];
+    }
+
+    // Per-referee statuses for judgement/payment phase
+    return accepted.map((r) {
+      if (r.status == 'payment_processing') return 'payment_processing';
+      if (r.status == 'closed') return 'closed';
+      return r.judgement?.status ?? 'matching';
+    }).toList();
+  }
+
+  List<String> _refereeStatuses(
+    List<RefereeRequest> active,
+    String currentUserId,
+  ) {
+    final myRequest = active
+        .where((r) => r.matchedRefereeId == currentUserId)
+        .firstOrNull;
+
+    if (myRequest == null) return ['matching'];
+
+    if (myRequest.status == 'payment_processing') {
+      return ['payment_processing'];
+    }
+    if (myRequest.status == 'closed') return ['closed'];
+
+    return [myRequest.judgement?.status ?? 'awaiting_evidence'];
   }
 }

--- a/peppercheck_flutter/lib/features/task/presentation/widgets/task_detail/task_referees_section.dart
+++ b/peppercheck_flutter/lib/features/task/presentation/widgets/task_detail/task_referees_section.dart
@@ -6,6 +6,7 @@ import 'package:peppercheck_flutter/common_widgets/base_section.dart';
 import 'package:peppercheck_flutter/features/matching/data/matching_repository.dart';
 import 'package:peppercheck_flutter/features/matching/domain/referee_request.dart';
 import 'package:peppercheck_flutter/features/task/domain/task.dart';
+import 'package:peppercheck_flutter/features/home/presentation/home_controller.dart';
 import 'package:peppercheck_flutter/features/task/presentation/providers/task_provider.dart';
 import 'package:peppercheck_flutter/gen/slang/strings.g.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
@@ -69,6 +70,8 @@ class _TaskRefereesSectionState extends ConsumerState<TaskRefereesSection> {
       );
 
       ref.invalidate(taskProvider(widget.task.id));
+      ref.invalidate(activeUserTasksProvider);
+      ref.invalidate(activeRefereeTasksProvider);
     } catch (e) {
       if (!mounted) return;
 

--- a/peppercheck_flutter/lib/gen/slang/strings.g.dart
+++ b/peppercheck_flutter/lib/gen/slang/strings.g.dart
@@ -4,9 +4,9 @@
 /// To regenerate, run: `dart run slang`
 ///
 /// Locales: 1
-/// Strings: 270
+/// Strings: 274
 ///
-/// Built on 2026-04-19 at 17:23 UTC
+/// Built on 2026-04-19 at 19:12 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint, unused_import

--- a/peppercheck_flutter/lib/gen/slang/strings_ja.g.dart
+++ b/peppercheck_flutter/lib/gen/slang/strings_ja.g.dart
@@ -674,26 +674,38 @@ class TranslationsTaskStatusJa {
 	/// ja: 'マッチング開始'
 	String get open => 'マッチング開始';
 
+	/// ja: 'マッチング中'
+	String get matching => 'マッチング中';
+
+	/// ja: 'マッチング完了'
+	String get matchingComplete => 'マッチング完了';
+
+	/// ja: 'マッチング失敗'
+	String get matchingFailed => 'マッチング失敗';
+
+	/// ja: 'エビデンス提出前'
+	String get awaitingEvidence => 'エビデンス提出前';
+
+	/// ja: 'エビデンス提出期限切れ'
+	String get evidenceTimeout => 'エビデンス提出期限切れ';
+
 	/// ja: '判定中'
-	String get judging => '判定中';
+	String get inReview => '判定中';
+
+	/// ja: '承認'
+	String get approved => '承認';
 
 	/// ja: '却下'
 	String get rejected => '却下';
 
-	/// ja: '完了'
-	String get completed => '完了';
+	/// ja: '判定期限切れ'
+	String get reviewTimeout => '判定期限切れ';
 
-	/// ja: '終了'
-	String get closed => '終了';
-
-	/// ja: '自己完結'
-	String get self_completed => '自己完結';
-
-	/// ja: '期限切れ'
-	String get expired => '期限切れ';
+	/// ja: '支払い処理中'
+	String get paymentProcessing => '支払い処理中';
 
 	/// ja: '完了'
-	String get done => '完了';
+	String get closed => '完了';
 }
 
 // Path: task.detail
@@ -1278,13 +1290,17 @@ extension on Translations {
 			'dashboard.payoutStatusSkipped' => 'スキップ',
 			'task.status.draft' => '下書き',
 			'task.status.open' => 'マッチング開始',
-			'task.status.judging' => '判定中',
+			'task.status.matching' => 'マッチング中',
+			'task.status.matchingComplete' => 'マッチング完了',
+			'task.status.matchingFailed' => 'マッチング失敗',
+			'task.status.awaitingEvidence' => 'エビデンス提出前',
+			'task.status.evidenceTimeout' => 'エビデンス提出期限切れ',
+			'task.status.inReview' => '判定中',
+			'task.status.approved' => '承認',
 			'task.status.rejected' => '却下',
-			'task.status.completed' => '完了',
-			'task.status.closed' => '終了',
-			'task.status.self_completed' => '自己完結',
-			'task.status.expired' => '期限切れ',
-			'task.status.done' => '完了',
+			'task.status.reviewTimeout' => '判定期限切れ',
+			'task.status.paymentProcessing' => '支払い処理中',
+			'task.status.closed' => '完了',
 			'task.detail.title' => 'タスク詳細',
 			'task.detail.sectionRequests' => 'リクエスト',
 			'task.detail.labelStatus' => 'ステータス',

--- a/peppercheck_flutter/test/features/task/domain/task_detailed_status_test.dart
+++ b/peppercheck_flutter/test/features/task/domain/task_detailed_status_test.dart
@@ -1,0 +1,382 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:peppercheck_flutter/features/judgement/domain/judgement.dart';
+import 'package:peppercheck_flutter/features/matching/domain/referee_request.dart';
+import 'package:peppercheck_flutter/features/task/domain/task.dart';
+
+const _taskerId = 'tasker-001';
+const _refereeId1 = 'referee-001';
+const _refereeId2 = 'referee-002';
+const _now = '2026-04-19T00:00:00Z';
+
+Task _makeTask({
+  String status = 'open',
+  List<RefereeRequest> refereeRequests = const [],
+}) {
+  return Task(
+    id: 'task-001',
+    taskerId: _taskerId,
+    title: 'Test Task',
+    status: status,
+    refereeRequests: refereeRequests,
+  );
+}
+
+RefereeRequest _makeRequest({
+  String id = 'req-001',
+  String status = 'pending',
+  String? matchedRefereeId,
+  Judgement? judgement,
+}) {
+  return RefereeRequest(
+    id: id,
+    taskId: 'task-001',
+    matchingStrategy: 'standard',
+    status: status,
+    matchedRefereeId: matchedRefereeId,
+    createdAt: _now,
+  ).copyWith(judgement: judgement);
+}
+
+Judgement _makeJudgement({
+  String id = 'req-001',
+  String status = 'awaiting_evidence',
+}) {
+  return Judgement(id: id, status: status, createdAt: _now, updatedAt: _now);
+}
+
+void main() {
+  group('Task.getDetailedStatuses - Tasker view', () {
+    test('draft task returns [draft]', () {
+      final task = _makeTask(status: 'draft');
+      expect(task.getDetailedStatuses(_taskerId), ['draft']);
+    });
+
+    test('closed task returns [closed]', () {
+      final task = _makeTask(status: 'closed');
+      expect(task.getDetailedStatuses(_taskerId), ['closed']);
+    });
+
+    test('all requests expired returns [matching_failed]', () {
+      final task = _makeTask(
+        refereeRequests: [
+          _makeRequest(id: 'r1', status: 'expired'),
+          _makeRequest(id: 'r2', status: 'expired'),
+        ],
+      );
+      expect(task.getDetailedStatuses(_taskerId), ['matching_failed']);
+    });
+
+    test('any request pending returns [matching]', () {
+      final task = _makeTask(
+        refereeRequests: [
+          _makeRequest(
+            id: 'r1',
+            status: 'accepted',
+            matchedRefereeId: _refereeId1,
+            judgement: _makeJudgement(id: 'r1'),
+          ),
+          _makeRequest(id: 'r2', status: 'pending'),
+        ],
+      );
+      expect(task.getDetailedStatuses(_taskerId), ['matching']);
+    });
+
+    test('any request matched returns [matching]', () {
+      final task = _makeTask(
+        refereeRequests: [
+          _makeRequest(
+            id: 'r1',
+            status: 'matched',
+            matchedRefereeId: _refereeId1,
+          ),
+        ],
+      );
+      expect(task.getDetailedStatuses(_taskerId), ['matching']);
+    });
+
+    test(
+      'all accepted + all awaiting_evidence returns [matching_complete]',
+      () {
+        final task = _makeTask(
+          refereeRequests: [
+            _makeRequest(
+              id: 'r1',
+              status: 'accepted',
+              matchedRefereeId: _refereeId1,
+              judgement: _makeJudgement(id: 'r1'),
+            ),
+            _makeRequest(
+              id: 'r2',
+              status: 'accepted',
+              matchedRefereeId: _refereeId2,
+              judgement: _makeJudgement(id: 'r2'),
+            ),
+          ],
+        );
+        expect(task.getDetailedStatuses(_taskerId), ['matching_complete']);
+      },
+    );
+
+    test('any judgement evidence_timeout returns [evidence_timeout]', () {
+      final task = _makeTask(
+        refereeRequests: [
+          _makeRequest(
+            id: 'r1',
+            status: 'accepted',
+            matchedRefereeId: _refereeId1,
+            judgement: _makeJudgement(id: 'r1', status: 'evidence_timeout'),
+          ),
+          _makeRequest(
+            id: 'r2',
+            status: 'accepted',
+            matchedRefereeId: _refereeId2,
+            judgement: _makeJudgement(id: 'r2', status: 'evidence_timeout'),
+          ),
+        ],
+      );
+      expect(task.getDetailedStatuses(_taskerId), ['evidence_timeout']);
+    });
+
+    test('judgement phase returns per-referee statuses', () {
+      final task = _makeTask(
+        refereeRequests: [
+          _makeRequest(
+            id: 'r1',
+            status: 'accepted',
+            matchedRefereeId: _refereeId1,
+            judgement: _makeJudgement(id: 'r1', status: 'in_review'),
+          ),
+          _makeRequest(
+            id: 'r2',
+            status: 'accepted',
+            matchedRefereeId: _refereeId2,
+            judgement: _makeJudgement(id: 'r2', status: 'approved'),
+          ),
+        ],
+      );
+      expect(task.getDetailedStatuses(_taskerId), ['in_review', 'approved']);
+    });
+
+    test('single referee in judgement phase returns single status', () {
+      final task = _makeTask(
+        refereeRequests: [
+          _makeRequest(
+            id: 'r1',
+            status: 'accepted',
+            matchedRefereeId: _refereeId1,
+            judgement: _makeJudgement(id: 'r1', status: 'rejected'),
+          ),
+        ],
+      );
+      expect(task.getDetailedStatuses(_taskerId), ['rejected']);
+    });
+
+    test('payment_processing returns per-referee statuses', () {
+      final task = _makeTask(
+        refereeRequests: [
+          _makeRequest(
+            id: 'r1',
+            status: 'payment_processing',
+            matchedRefereeId: _refereeId1,
+            judgement: _makeJudgement(id: 'r1', status: 'approved'),
+          ),
+          _makeRequest(
+            id: 'r2',
+            status: 'closed',
+            matchedRefereeId: _refereeId2,
+            judgement: _makeJudgement(id: 'r2', status: 'approved'),
+          ),
+        ],
+      );
+      expect(task.getDetailedStatuses(_taskerId), [
+        'payment_processing',
+        'closed',
+      ]);
+    });
+
+    test('all requests closed returns [closed]', () {
+      final task = _makeTask(
+        refereeRequests: [
+          _makeRequest(
+            id: 'r1',
+            status: 'closed',
+            matchedRefereeId: _refereeId1,
+            judgement: _makeJudgement(id: 'r1', status: 'approved'),
+          ),
+          _makeRequest(
+            id: 'r2',
+            status: 'closed',
+            matchedRefereeId: _refereeId2,
+            judgement: _makeJudgement(id: 'r2', status: 'approved'),
+          ),
+        ],
+      );
+      expect(task.getDetailedStatuses(_taskerId), ['closed']);
+    });
+
+    test('declined/cancelled requests are filtered out', () {
+      final task = _makeTask(
+        refereeRequests: [
+          _makeRequest(
+            id: 'r1',
+            status: 'accepted',
+            matchedRefereeId: _refereeId1,
+            judgement: _makeJudgement(id: 'r1'),
+          ),
+          _makeRequest(id: 'r2', status: 'declined'),
+          _makeRequest(id: 'r3', status: 'cancelled'),
+          _makeRequest(id: 'r4', status: 'pending'),
+        ],
+      );
+      expect(task.getDetailedStatuses(_taskerId), ['matching']);
+    });
+
+    test('accepted + expired (no pending) returns [matching_complete]', () {
+      final task = _makeTask(
+        refereeRequests: [
+          _makeRequest(
+            id: 'r1',
+            status: 'accepted',
+            matchedRefereeId: _refereeId1,
+            judgement: _makeJudgement(id: 'r1'),
+          ),
+          _makeRequest(id: 'r2', status: 'expired'),
+        ],
+      );
+      expect(task.getDetailedStatuses(_taskerId), ['matching_complete']);
+    });
+
+    test('no referee requests returns [matching]', () {
+      final task = _makeTask(refereeRequests: []);
+      expect(task.getDetailedStatuses(_taskerId), ['matching']);
+    });
+  });
+
+  group('Task.getDetailedStatuses - Referee view', () {
+    test('awaiting_evidence returns [awaiting_evidence]', () {
+      final task = _makeTask(
+        refereeRequests: [
+          _makeRequest(
+            id: 'r1',
+            status: 'accepted',
+            matchedRefereeId: _refereeId1,
+            judgement: _makeJudgement(id: 'r1'),
+          ),
+        ],
+      );
+      expect(task.getDetailedStatuses(_refereeId1), ['awaiting_evidence']);
+    });
+
+    test('in_review returns [in_review]', () {
+      final task = _makeTask(
+        refereeRequests: [
+          _makeRequest(
+            id: 'r1',
+            status: 'accepted',
+            matchedRefereeId: _refereeId1,
+            judgement: _makeJudgement(id: 'r1', status: 'in_review'),
+          ),
+        ],
+      );
+      expect(task.getDetailedStatuses(_refereeId1), ['in_review']);
+    });
+
+    test('approved returns [approved]', () {
+      final task = _makeTask(
+        refereeRequests: [
+          _makeRequest(
+            id: 'r1',
+            status: 'accepted',
+            matchedRefereeId: _refereeId1,
+            judgement: _makeJudgement(id: 'r1', status: 'approved'),
+          ),
+        ],
+      );
+      expect(task.getDetailedStatuses(_refereeId1), ['approved']);
+    });
+
+    test('rejected returns [rejected]', () {
+      final task = _makeTask(
+        refereeRequests: [
+          _makeRequest(
+            id: 'r1',
+            status: 'accepted',
+            matchedRefereeId: _refereeId1,
+            judgement: _makeJudgement(id: 'r1', status: 'rejected'),
+          ),
+        ],
+      );
+      expect(task.getDetailedStatuses(_refereeId1), ['rejected']);
+    });
+
+    test('evidence_timeout returns [evidence_timeout]', () {
+      final task = _makeTask(
+        refereeRequests: [
+          _makeRequest(
+            id: 'r1',
+            status: 'accepted',
+            matchedRefereeId: _refereeId1,
+            judgement: _makeJudgement(id: 'r1', status: 'evidence_timeout'),
+          ),
+        ],
+      );
+      expect(task.getDetailedStatuses(_refereeId1), ['evidence_timeout']);
+    });
+
+    test('review_timeout returns [review_timeout]', () {
+      final task = _makeTask(
+        refereeRequests: [
+          _makeRequest(
+            id: 'r1',
+            status: 'accepted',
+            matchedRefereeId: _refereeId1,
+            judgement: _makeJudgement(id: 'r1', status: 'review_timeout'),
+          ),
+        ],
+      );
+      expect(task.getDetailedStatuses(_refereeId1), ['review_timeout']);
+    });
+
+    test('payment_processing returns [payment_processing]', () {
+      final task = _makeTask(
+        refereeRequests: [
+          _makeRequest(
+            id: 'r1',
+            status: 'payment_processing',
+            matchedRefereeId: _refereeId1,
+            judgement: _makeJudgement(id: 'r1', status: 'approved'),
+          ),
+        ],
+      );
+      expect(task.getDetailedStatuses(_refereeId1), ['payment_processing']);
+    });
+
+    test('closed returns [closed]', () {
+      final task = _makeTask(
+        refereeRequests: [
+          _makeRequest(
+            id: 'r1',
+            status: 'closed',
+            matchedRefereeId: _refereeId1,
+            judgement: _makeJudgement(id: 'r1', status: 'approved'),
+          ),
+        ],
+      );
+      expect(task.getDetailedStatuses(_refereeId1), ['closed']);
+    });
+
+    test('no matching request returns [matching]', () {
+      final task = _makeTask(
+        refereeRequests: [
+          _makeRequest(
+            id: 'r1',
+            status: 'accepted',
+            matchedRefereeId: _refereeId2,
+            judgement: _makeJudgement(id: 'r1'),
+          ),
+        ],
+      );
+      expect(task.getDetailedStatuses(_refereeId1), ['matching']);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

- Add `Task.getDetailedStatuses(String currentUserId)` method that derives granular display statuses from `referee_request.status` and `judgement.status` (replacing the placeholder `detailedStatus` getter)
- Update TaskCard to `ConsumerWidget`, displaying 1-2 status labels with correct labels/colors per tasker/referee perspective
- Replace i18n status keys with 12 new detailed statuses (matching, matching_complete, matching_failed, etc.)
- Remove unused `isMyTask` field from TaskCard (now determined by `currentUserId`)

## Test plan

- [x] 23 unit tests for `getDetailedStatuses` covering all tasker/referee view scenarios
- [x] All 67 existing tests pass (no regressions)
- [x] `flutter build apk --debug` succeeds
- [x] Manual verification on emulator: task cards show correct statuses at each phase

Closes #353

🤖 Generated with [Claude Code](https://claude.com/claude-code)