### PR TITLE
fix(flutter): preserve IME composition and submit button state in evidence form

### DIFF
--- a/peppercheck_flutter/lib/features/evidence/presentation/widgets/evidence_submission_section.dart
+++ b/peppercheck_flutter/lib/features/evidence/presentation/widgets/evidence_submission_section.dart
@@ -37,9 +37,20 @@ class _EvidenceSubmissionSectionState
   List<String> _assetIdsToRemove = [];
 
   @override
+  void initState() {
+    super.initState();
+    _descriptionController.addListener(_onDescriptionChanged);
+  }
+
+  @override
   void dispose() {
+    _descriptionController.removeListener(_onDescriptionChanged);
     _descriptionController.dispose();
     super.dispose();
+  }
+
+  void _onDescriptionChanged() {
+    if (mounted) setState(() {});
   }
 
   bool _canReopen() {
@@ -221,7 +232,7 @@ class _EvidenceSubmissionSectionState
         children: [
           BaseTextField(
             value: _descriptionController.text,
-            onValueChange: (val) => _descriptionController.text = val,
+            onValueChange: (_) {},
             label: t.task.evidence.description,
             maxLines: 1,
             controller: _descriptionController,
@@ -534,7 +545,7 @@ class _EvidenceSubmissionSectionState
         children: [
           BaseTextField(
             value: _descriptionController.text,
-            onValueChange: (val) => _descriptionController.text = val,
+            onValueChange: (_) {},
             label: t.task.evidence.description,
             maxLines: 1,
             controller: _descriptionController,


### PR DESCRIPTION
## Summary
- Fix Japanese IME 変換 being broken on real devices in the evidence description field
- Fix the submit button staying disabled even when both image and description are entered

## Root cause
`EvidenceSubmissionSection` bound a `TextEditingController` to the field but ALSO wrote `_descriptionController.text = val` inside `onValueChange`. Setting `controller.text` clears the `composing` range on every keystroke, which:

1. Destroys the IME composition state so Japanese 変換 cannot continue (English appears unaffected because it does not use composition).
2. Never triggers `setState` on the parent, so the submit button's `onPressed` is computed once at build time and stays `null` even after the user enters text. The button only flipped on the emulator when image picking happened to call `setState` after the text was already typed.

## Fix
- Remove the self-assigning `onValueChange` (the controller is already the source of truth).
- Add a controller listener in `initState` that calls `setState` so the button condition re-evaluates when the user types, with matching `removeListener` in `dispose`.

Applied to both the new-submission form and the edit/resubmit form.

## Test plan
- [ ] Real device (Android, Japanese IME): type `とざんにいく` → 変換 → `登山にいく` works without composition break.
- [ ] Real device: image + description (any language) enables the submit button regardless of input order.
- [ ] Edit mode: same behaviors when editing an existing evidence.
- [ ] Resubmit mode: same behaviors when resubmitting after rejection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)