### PR TITLE
feat: allow taskers to delete draft tasks

### DIFF
--- a/docs/superpowers/specs/2026-04-27-draft-task-deletion-design.md
+++ b/docs/superpowers/specs/2026-04-27-draft-task-deletion-design.md
@@ -1,0 +1,207 @@
+# Draft Task Deletion
+
+**Date**: 2026-04-27
+
+## Problem
+
+Once a task is created as a draft, there is no way for the tasker to delete it. Drafts accumulate as the user experiments with creating tasks, and there is no recovery path for unwanted ones. Users currently can only abandon drafts, which leaves them visible in the home screen.
+
+Deletion must be restricted to drafts only. Tasks that have transitioned to `open` (matching started) or `closed` have related records (referee requests, judgements, evidence, rewards) whose removal has complex implications, so they remain non-deletable.
+
+## Decision Log
+
+- **UI placement**: Below the existing "タスク編集" button inside `TaskDetailInfoSection`, only when `task.status == 'draft'`. Reuses the visual style of the account deletion button (`OutlinedButton`, red-tinted, `Icons.delete_outline`) so destructive actions look consistent across the app.
+- **Confirmation dialog**: Single-step, minimal — title only ("このタスクを削除しますか?"), no body warning text. Drafts are low-stakes; the two-step confirmation used for account deletion would be excessive. Cancel + Delete buttons.
+- **Backend**: New RPC `public.delete_task(p_task_id uuid)` rather than a direct `supabase.from('tasks').delete()`. Rationale: matches the existing `create_task` / `update_task` RPC pattern so all task CRUD lives in one discoverable place. A bare RLS-only approach would scatter the status check into policy logic that is harder to find.
+- **Defense in depth**: Existing RLS DELETE policy (`tasker_id = auth.uid()`) is kept as-is. With `SECURITY INVOKER`, the RPC respects RLS, so ownership is enforced twice (RPC explicit check + RLS).
+- **Post-delete navigation**: `context.go('/')` to home + Snackbar "削除しました". Mirrors account deletion completion UX (`account_actions_section.dart:118-121`).
+- **Race condition**: If matching starts between page render and delete tap, the RPC's `status <> 'draft'` check rejects the call. The UI surfaces a generic "削除できませんでした" Snackbar.
+
+## Database Layer
+
+### New RPC: `delete_task`
+
+File: `supabase/schemas/task/functions/delete_task.sql`
+
+```sql
+CREATE OR REPLACE FUNCTION public.delete_task(p_task_id uuid)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY INVOKER
+AS $$
+DECLARE
+    v_current_status public.task_status;
+    v_tasker_id uuid;
+BEGIN
+    SELECT status, tasker_id INTO v_current_status, v_tasker_id
+    FROM public.tasks
+    WHERE id = p_task_id;
+
+    IF v_current_status IS NULL THEN
+        RAISE EXCEPTION 'Task not found';
+    END IF;
+
+    IF v_tasker_id != auth.uid() THEN
+        RAISE EXCEPTION 'Not authorized to delete this task';
+    END IF;
+
+    IF v_current_status != 'draft' THEN
+        RAISE EXCEPTION 'Only draft tasks can be deleted';
+    END IF;
+
+    DELETE FROM public.tasks WHERE id = p_task_id;
+END;
+$$;
+```
+
+Style mirrors `update_task.sql` (same auth/status check ordering, same exception messages format, `SECURITY INVOKER`).
+
+### config.toml registration
+
+Add the new function to `supabase/config.toml` under `[db.migrations].schema_paths`, alongside the existing task functions:
+
+```toml
+"./schemas/task/functions/create_task.sql",
+"./schemas/task/functions/update_task.sql",
+"./schemas/task/functions/delete_task.sql",   # NEW
+```
+
+### Migration generation
+
+Run `supabase db diff -f add_delete_task_function` after editing `config.toml`. Verify with `./scripts/db-reset-and-clear-android-emulators-cache.sh`.
+
+### RLS
+
+No change. The existing `Tasks: delete if tasker` policy remains.
+
+### FK CASCADE
+
+No change. `task_referee_requests`, `task_evidences`, `reports` already cascade on `tasks` deletion. Drafts should not have any of these rows in practice; the cascades remain a safety net.
+
+### pgTAP tests
+
+File: `supabase/tests/database/delete_task.test.sql` (matches existing `<feature>.test.sql` naming).
+
+Cases:
+
+1. ✅ Tasker deletes their own draft task → row removed.
+2. ✅ Non-owner attempts deletion → exception "Not authorized to delete this task".
+3. ✅ Tasker attempts to delete an `open` task → exception "Only draft tasks can be deleted".
+4. ✅ Tasker attempts to delete a `closed` task → exception "Only draft tasks can be deleted".
+5. ✅ Non-existent task ID → exception "Task not found".
+
+After adding tests, run the full test suite to verify no regressions (per `.claude/rules/db-testing.md`).
+
+## Flutter Layer
+
+### New files
+
+#### 1. `task_repository.dart` — add `deleteTask` method
+
+Add to `peppercheck_flutter/lib/features/task/data/task_repository.dart`:
+
+```dart
+Future<void> deleteTask(String taskId) async {
+  await _supabase.rpc('delete_task', params: {'p_task_id': taskId});
+}
+```
+
+#### 2. `lib/features/task/presentation/task_deletion_controller.dart`
+
+Riverpod `AsyncNotifier` (codegen). Exposes `deleteTask(String taskId, {required VoidCallback onSuccess})`. State: `AsyncValue<void>` (initial = `AsyncData(null)`, transitions to `AsyncLoading` during RPC, then `AsyncData` on success or `AsyncError` on failure).
+
+Naming note: per `.claude/rules/flutter.md`, do NOT name the method `update`. Use `deleteTask`.
+
+#### 3. `lib/features/task/presentation/widgets/task_detail/delete_task_button.dart`
+
+`ConsumerWidget` taking a `Task`. Visually identical to `account_actions_section.dart:60-92`:
+
+- `OutlinedButton`, full width
+- `AppColors.textError` foreground, red-tinted background, red border
+- `Icons.delete_outline` 16px + label
+- Disabled (`onPressed: null`) while `taskDeletionControllerProvider` is loading
+
+On tap → show `DeleteTaskConfirmationDialog`. On confirm → call controller's `deleteTask(task.id, onSuccess: ...)`.
+
+#### 4. `lib/features/task/presentation/widgets/task_detail/delete_task_confirmation_dialog.dart`
+
+Minimal `AlertDialog`:
+
+- Title: `t.task.deletion.confirmTitle` ("このタスクを削除しますか?")
+- No content body
+- Actions: Cancel (textSecondary), Delete (textError)
+
+Style matches `delete_account_confirmation_dialog.dart` (same `backgroundColor`, `shape`, button colors). Reuse `t.common.cancel` for the cancel button to avoid duplicating the existing key.
+
+### Changed files
+
+#### `task_detail_info_section.dart`
+
+Inside the existing `if (task.status == 'draft')` block (line 39), add the delete button below the edit button with `SizedBox(height: AppSizes.spacingSmall)` between them:
+
+```dart
+if (task.status == 'draft') ...[
+  const SizedBox(height: AppSizes.sectionGap),
+  ActionButton(
+    text: t.task.creation.titleEdit,
+    icon: Icons.edit,
+    onPressed: () { context.push('/create_task', extra: task); },
+  ),
+  const SizedBox(height: AppSizes.spacingSmall),
+  DeleteTaskButton(task: task),
+],
+```
+
+No conversion of `TaskDetailInfoSection` itself is needed; `DeleteTaskButton` handles its own Riverpod wiring as a `ConsumerWidget`.
+
+### Success flow
+
+The button widget's `onSuccess` callback runs inside the controller after the RPC succeeds:
+
+1. Show Snackbar `t.task.deletion.deletedSnackbar` ("削除しました")
+2. `context.go('/')` to navigate to home
+
+### Error flow
+
+On `AsyncError` from the controller, show Snackbar `t.task.deletion.failedSnackbar` ("削除できませんでした"). The user stays on the detail screen. They can refresh to see the up-to-date status (e.g., the delete button will disappear if the task moved to `open`).
+
+### i18n
+
+Add to `peppercheck_flutter/assets/i18n/ja.i18n.json` under `task`:
+
+```json
+"deletion": {
+  "button": "タスク削除",
+  "confirmTitle": "このタスクを削除しますか?",
+  "deleteButton": "削除",
+  "deletedSnackbar": "削除しました",
+  "failedSnackbar": "削除できませんでした"
+}
+```
+
+The cancel button reuses the existing `t.common.cancel` ("キャンセル").
+
+Run codegen (`flutter pub run build_runner build --delete-conflicting-outputs` or the project-specific slang command) so `t.task.deletion.*` is available.
+
+## Edge Cases
+
+| Case | Behavior |
+|---|---|
+| Race: status changes from `draft` to `open` between render and tap | RPC raises "Only draft tasks can be deleted" → failure Snackbar |
+| Double-tap | Button disabled during `AsyncLoading` |
+| Network failure | `AsyncError` → failure Snackbar; user can retry |
+| Task already deleted on another device | RPC raises "Task not found" → failure Snackbar |
+
+## Out of Scope
+
+- Bulk deletion of drafts.
+- Soft delete / undo. The single-step dialog is the only safety net.
+- Deletion of `open` or `closed` tasks. Their lifecycle requires separate design.
+- Renaming or reorganizing the existing `billing/` Flutter feature directory.
+
+## Testing
+
+- **DB**: pgTAP cases listed above + full suite regression run.
+- **Flutter**: Manual end-to-end on a real device — create draft → open detail → delete → confirm Snackbar + return to home → confirm draft no longer in home list.
+- **Race-condition**: Manually verify by transitioning a task to `open` server-side, then tapping delete from a stale detail page; expect failure Snackbar.
+- **Build**: `cd peppercheck_flutter && flutter build apk --debug -t lib/main_debug.dart 2>&1 | tail -10` before completion.

--- a/docs/superpowers/specs/2026-04-27-draft-task-deletion-design.md
+++ b/docs/superpowers/specs/2026-04-27-draft-task-deletion-design.md
@@ -147,7 +147,7 @@ Naming note: per `.claude/rules/flutter.md`, do NOT name the method `update`. Us
 Wraps the existing `BaseDialog` (`common_widgets/base_dialog.dart`):
 
 - `title`: `t.task.deletion.confirmTitle` ("このタスクを削除しますか?")
-- `content`: empty `SizedBox.shrink()` (no body text)
+- `content`: `SizedBox.shrink()` — `BaseDialog.content` is required, so this is the workaround for a title-only dialog. The internal `EdgeInsets.fromLTRB(24, 16, 24, 8)` padding still applies, leaving small whitespace below the title; this is acceptable for the minimalist design.
 - `actions`:
   - Cancel: inline `TextButton` with `foregroundColor: AppColors.textSecondary`, label `t.common.cancel`, pops dialog
   - Delete: inline `TextButton` with `foregroundColor: AppColors.textError`, label `t.task.deletion.deleteButton`, pops dialog and triggers the `onConfirm` callback
@@ -186,6 +186,8 @@ DestructiveActionButton(
 ```
 
 The "delete blocked" reason text above the button (`account_actions_section.dart:52-59`) stays as-is.
+
+After the replacement, the now-unused local color variables (`containerColor`, `contentColor`, `borderColor` at lines 39-47) become dead code and should be removed. `_buildDeleteButton` simplifies to: the `Column` with the conditional reason text + the new `DestructiveActionButton`.
 
 ### Success flow
 

--- a/docs/superpowers/specs/2026-04-27-draft-task-deletion-design.md
+++ b/docs/superpowers/specs/2026-04-27-draft-task-deletion-design.md
@@ -11,6 +11,7 @@ Deletion must be restricted to drafts only. Tasks that have transitioned to `ope
 ## Decision Log
 
 - **UI placement**: Below the existing "タスク編集" button inside `TaskDetailInfoSection`, only when `task.status == 'draft'`. Reuses the visual style of the account deletion button (`OutlinedButton`, red-tinted, `Icons.delete_outline`) so destructive actions look consistent across the app.
+- **Common widget extraction**: A new `DestructiveActionButton` is added in `common_widgets/` (red-tinted variant of `ActionButton`). Both the new task delete button and the existing account deletion button (`account_actions_section.dart`) migrate to it in this PR. The dialog uses the existing `BaseDialog`. The cancel `TextButton` inside the dialog is written inline — generalizing it (only ~5 lines per usage) is not worth the extra widget file.
 - **Confirmation dialog**: Single-step, minimal — title only ("このタスクを削除しますか?"), no body warning text. Drafts are low-stakes; the two-step confirmation used for account deletion would be excessive. Cancel + Delete buttons.
 - **Backend**: New RPC `public.delete_task(p_task_id uuid)` rather than a direct `supabase.from('tasks').delete()`. Rationale: matches the existing `create_task` / `update_task` RPC pattern so all task CRUD lives in one discoverable place. A bare RLS-only approach would scatter the status check into policy logic that is harder to find.
 - **Defense in depth**: Existing RLS DELETE policy (`tasker_id = auth.uid()`) is kept as-is. With `SECURITY INVOKER`, the RPC respects RLS, so ownership is enforced twice (RPC explicit check + RLS).
@@ -94,7 +95,27 @@ After adding tests, run the full test suite to verify no regressions (per `.clau
 
 ## Flutter Layer
 
-### New files
+### New common widget
+
+#### `lib/common_widgets/destructive_action_button.dart`
+
+Red-tinted variant of the existing `ActionButton` (`common_widgets/action_button.dart`). Same API (`text`, `icon`, `onPressed`, `isLoading`), but uses `AppColors.textError` for foreground / border / icon, and a red-tinted background:
+
+```dart
+final containerColor = active
+    ? AppColors.textError.withValues(alpha: 0.1)
+    : AppColors.textPrimary.withValues(alpha: 0.05);
+final contentColor = active
+    ? AppColors.textError
+    : AppColors.textPrimary.withValues(alpha: 0.4);
+final borderColor = active
+    ? AppColors.textError.withValues(alpha: 0.5)
+    : AppColors.textPrimary.withValues(alpha: 0.2);
+```
+
+Width, padding, border radius, icon-text layout, and loading-spinner behavior all mirror `ActionButton` for visual consistency.
+
+### New feature files
 
 #### 1. `task_repository.dart` — add `deleteTask` method
 
@@ -114,24 +135,22 @@ Naming note: per `.claude/rules/flutter.md`, do NOT name the method `update`. Us
 
 #### 3. `lib/features/task/presentation/widgets/task_detail/delete_task_button.dart`
 
-`ConsumerWidget` taking a `Task`. Visually identical to `account_actions_section.dart:60-92`:
+`ConsumerWidget` taking a `Task`. Wraps the new `DestructiveActionButton`:
 
-- `OutlinedButton`, full width
-- `AppColors.textError` foreground, red-tinted background, red border
-- `Icons.delete_outline` 16px + label
-- Disabled (`onPressed: null`) while `taskDeletionControllerProvider` is loading
-
-On tap → show `DeleteTaskConfirmationDialog`. On confirm → call controller's `deleteTask(task.id, onSuccess: ...)`.
+- Label: `t.task.deletion.button` ("タスク削除")
+- Icon: `Icons.delete_outline`
+- `isLoading` from `taskDeletionControllerProvider` AsyncValue
+- On tap → show `DeleteTaskConfirmationDialog`. On confirm → call controller's `deleteTask(task.id, onSuccess: ...)`.
 
 #### 4. `lib/features/task/presentation/widgets/task_detail/delete_task_confirmation_dialog.dart`
 
-Minimal `AlertDialog`:
+Wraps the existing `BaseDialog` (`common_widgets/base_dialog.dart`):
 
-- Title: `t.task.deletion.confirmTitle` ("このタスクを削除しますか?")
-- No content body
-- Actions: Cancel (textSecondary), Delete (textError)
-
-Style matches `delete_account_confirmation_dialog.dart` (same `backgroundColor`, `shape`, button colors). Reuse `t.common.cancel` for the cancel button to avoid duplicating the existing key.
+- `title`: `t.task.deletion.confirmTitle` ("このタスクを削除しますか?")
+- `content`: empty `SizedBox.shrink()` (no body text)
+- `actions`:
+  - Cancel: inline `TextButton` with `foregroundColor: AppColors.textSecondary`, label `t.common.cancel`, pops dialog
+  - Delete: inline `TextButton` with `foregroundColor: AppColors.textError`, label `t.task.deletion.deleteButton`, pops dialog and triggers the `onConfirm` callback
 
 ### Changed files
 
@@ -153,6 +172,20 @@ if (task.status == 'draft') ...[
 ```
 
 No conversion of `TaskDetailInfoSection` itself is needed; `DeleteTaskButton` handles its own Riverpod wiring as a `ConsumerWidget`.
+
+#### `account_actions_section.dart` — migrate to `DestructiveActionButton`
+
+Replace the inline red-tinted `OutlinedButton` (`account_actions_section.dart:60-92`) with `DestructiveActionButton`:
+
+```dart
+DestructiveActionButton(
+  text: t.account.actions.deleteAccount,
+  icon: Icons.delete_outline,
+  onPressed: active ? () => _showConfirmation(context, ref) : null,
+)
+```
+
+The "delete blocked" reason text above the button (`account_actions_section.dart:52-59`) stays as-is.
 
 ### Success flow
 

--- a/peppercheck_flutter/assets/i18n/ja.i18n.json
+++ b/peppercheck_flutter/assets/i18n/ja.i18n.json
@@ -194,6 +194,13 @@
         "buttonOk": "OK"
       }
     },
+    "deletion": {
+      "button": "タスク削除",
+      "confirmTitle": "このタスクを削除しますか?",
+      "deleteButton": "削除",
+      "deletedSnackbar": "削除しました",
+      "failedSnackbar": "削除できませんでした"
+    },
     "evidence": {
       "title": "エビデンス",
       "submit": "エビデンスを提出",

--- a/peppercheck_flutter/assets/i18n/ja.i18n.json
+++ b/peppercheck_flutter/assets/i18n/ja.i18n.json
@@ -195,8 +195,8 @@
       }
     },
     "deletion": {
-      "button": "タスク削除",
-      "confirmTitle": "このタスクを削除しますか?",
+      "button": "タスクを削除",
+      "confirmTitle": "このタスクを削除しますか？",
       "deleteButton": "削除",
       "deletedSnackbar": "削除しました",
       "failedSnackbar": "削除できませんでした"

--- a/peppercheck_flutter/lib/common_widgets/destructive_action_button.dart
+++ b/peppercheck_flutter/lib/common_widgets/destructive_action_button.dart
@@ -1,0 +1,74 @@
+import 'package:flutter/material.dart';
+import 'package:peppercheck_flutter/app/theme/app_colors.dart';
+
+class DestructiveActionButton extends StatelessWidget {
+  final String text;
+  final IconData? icon;
+  final VoidCallback? onPressed;
+  final bool isLoading;
+
+  const DestructiveActionButton({
+    super.key,
+    required this.text,
+    this.icon,
+    this.onPressed,
+    this.isLoading = false,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final bool active = onPressed != null && !isLoading;
+
+    final containerColor = active
+        ? AppColors.textError.withValues(alpha: 0.1)
+        : AppColors.textPrimary.withValues(alpha: 0.05);
+    final contentColor = active
+        ? AppColors.textError
+        : AppColors.textPrimary.withValues(alpha: 0.4);
+    final borderColor = active
+        ? AppColors.textError.withValues(alpha: 0.5)
+        : AppColors.textPrimary.withValues(alpha: 0.2);
+
+    Widget button = OutlinedButton(
+      onPressed: active ? onPressed : null,
+      style: OutlinedButton.styleFrom(
+        backgroundColor: containerColor,
+        foregroundColor: contentColor,
+        side: BorderSide(color: borderColor, width: 2),
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
+        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+        minimumSize: Size.zero,
+        tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+        elevation: 0,
+      ),
+      child: isLoading
+          ? SizedBox(
+              width: 16,
+              height: 16,
+              child: CircularProgressIndicator(
+                strokeWidth: 2,
+                valueColor: AlwaysStoppedAnimation<Color>(contentColor),
+              ),
+            )
+          : Row(
+              mainAxisSize: MainAxisSize.min,
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                if (icon != null) ...[
+                  Icon(icon, size: 16, color: contentColor),
+                  const SizedBox(width: 6),
+                ],
+                Text(
+                  text,
+                  style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                    color: contentColor,
+                    fontWeight: FontWeight.w500,
+                  ),
+                ),
+              ],
+            ),
+    );
+
+    return SizedBox(width: double.infinity, child: button);
+  }
+}

--- a/peppercheck_flutter/lib/common_widgets/destructive_action_button.dart
+++ b/peppercheck_flutter/lib/common_widgets/destructive_action_button.dart
@@ -6,6 +6,7 @@ class DestructiveActionButton extends StatelessWidget {
   final IconData? icon;
   final VoidCallback? onPressed;
   final bool isLoading;
+  final double borderRadius;
 
   const DestructiveActionButton({
     super.key,
@@ -13,6 +14,7 @@ class DestructiveActionButton extends StatelessWidget {
     this.icon,
     this.onPressed,
     this.isLoading = false,
+    this.borderRadius = 20,
   });
 
   @override
@@ -35,7 +37,9 @@ class DestructiveActionButton extends StatelessWidget {
         backgroundColor: containerColor,
         foregroundColor: contentColor,
         side: BorderSide(color: borderColor, width: 2),
-        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(borderRadius),
+        ),
         padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
         minimumSize: Size.zero,
         tapTargetSize: MaterialTapTargetSize.shrinkWrap,

--- a/peppercheck_flutter/lib/features/account/presentation/widgets/account_actions_section.dart
+++ b/peppercheck_flutter/lib/features/account/presentation/widgets/account_actions_section.dart
@@ -4,6 +4,7 @@ import 'package:go_router/go_router.dart';
 import 'package:peppercheck_flutter/app/theme/app_colors.dart';
 import 'package:peppercheck_flutter/app/theme/app_sizes.dart';
 import 'package:peppercheck_flutter/common_widgets/base_section.dart';
+import 'package:peppercheck_flutter/common_widgets/destructive_action_button.dart';
 import 'package:peppercheck_flutter/features/account/data/account_repository.dart';
 import 'package:peppercheck_flutter/features/account/presentation/account_deletion_controller.dart';
 import 'package:peppercheck_flutter/features/account/presentation/widgets/delete_account_confirmation_dialog.dart';
@@ -34,18 +35,6 @@ class AccountActionsSection extends ConsumerWidget {
     bool deletable,
     List<String> reasons,
   ) {
-    final bool active = deletable;
-
-    final containerColor = active
-        ? AppColors.textError.withValues(alpha: 0.1)
-        : AppColors.textPrimary.withValues(alpha: 0.05);
-    final contentColor = active
-        ? AppColors.textError
-        : AppColors.textPrimary.withValues(alpha: 0.4);
-    final borderColor = active
-        ? AppColors.textError.withValues(alpha: 0.5)
-        : AppColors.textPrimary.withValues(alpha: 0.2);
-
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
@@ -57,38 +46,10 @@ class AccountActionsSection extends ConsumerWidget {
               style: TextStyle(color: AppColors.textError),
             ),
           ),
-        SizedBox(
-          width: double.infinity,
-          child: OutlinedButton(
-            onPressed: active ? () => _showConfirmation(context, ref) : null,
-            style: OutlinedButton.styleFrom(
-              backgroundColor: containerColor,
-              foregroundColor: contentColor,
-              side: BorderSide(color: borderColor, width: 2),
-              shape: RoundedRectangleBorder(
-                borderRadius: BorderRadius.circular(20),
-              ),
-              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-              minimumSize: Size.zero,
-              tapTargetSize: MaterialTapTargetSize.shrinkWrap,
-              elevation: 0,
-            ),
-            child: Row(
-              mainAxisSize: MainAxisSize.min,
-              mainAxisAlignment: MainAxisAlignment.center,
-              children: [
-                Icon(Icons.delete_outline, size: 16, color: contentColor),
-                const SizedBox(width: 6),
-                Text(
-                  t.account.actions.deleteAccount,
-                  style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                    color: contentColor,
-                    fontWeight: FontWeight.w500,
-                  ),
-                ),
-              ],
-            ),
-          ),
+        DestructiveActionButton(
+          text: t.account.actions.deleteAccount,
+          icon: Icons.delete_outline,
+          onPressed: deletable ? () => _showConfirmation(context, ref) : null,
         ),
       ],
     );

--- a/peppercheck_flutter/lib/features/task/data/task_repository.dart
+++ b/peppercheck_flutter/lib/features/task/data/task_repository.dart
@@ -60,6 +60,15 @@ class TaskRepository {
     }
   }
 
+  Future<void> deleteTask(String taskId) async {
+    try {
+      await _client.rpc('delete_task', params: {'p_task_id': taskId});
+    } catch (e, st) {
+      _logger.e('deleteTask failed', error: e, stackTrace: st);
+      rethrow;
+    }
+  }
+
   Future<List<Task>> fetchActiveUserTasks() async {
     try {
       final userId = _client.auth.currentUser?.id;

--- a/peppercheck_flutter/lib/features/task/presentation/task_deletion_controller.dart
+++ b/peppercheck_flutter/lib/features/task/presentation/task_deletion_controller.dart
@@ -1,0 +1,32 @@
+import 'package:flutter/material.dart';
+import 'package:peppercheck_flutter/app/app_logger.dart';
+import 'package:peppercheck_flutter/features/task/data/task_repository.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'task_deletion_controller.g.dart';
+
+@riverpod
+class TaskDeletionController extends _$TaskDeletionController {
+  @override
+  FutureOr<void> build() async {}
+
+  Future<void> deleteTask(
+    String taskId, {
+    required VoidCallback onSuccess,
+  }) async {
+    state = const AsyncLoading();
+    state = await AsyncValue.guard(() async {
+      await ref.read(taskRepositoryProvider).deleteTask(taskId);
+      onSuccess();
+    });
+    if (state.hasError) {
+      ref
+          .read(loggerProvider)
+          .e(
+            'Task deletion error',
+            error: state.error,
+            stackTrace: state.stackTrace,
+          );
+    }
+  }
+}

--- a/peppercheck_flutter/lib/features/task/presentation/task_deletion_controller.dart
+++ b/peppercheck_flutter/lib/features/task/presentation/task_deletion_controller.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:peppercheck_flutter/app/app_logger.dart';
+import 'package:peppercheck_flutter/features/home/presentation/home_controller.dart';
 import 'package:peppercheck_flutter/features/task/data/task_repository.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
@@ -17,6 +18,9 @@ class TaskDeletionController extends _$TaskDeletionController {
     state = const AsyncLoading();
     state = await AsyncValue.guard(() async {
       await ref.read(taskRepositoryProvider).deleteTask(taskId);
+      // Refresh the home screen lists so the deleted task disappears immediately
+      // when the user lands back on home (no pull-to-refresh needed).
+      ref.invalidate(activeUserTasksProvider);
       onSuccess();
     });
     if (state.hasError) {

--- a/peppercheck_flutter/lib/features/task/presentation/task_deletion_controller.g.dart
+++ b/peppercheck_flutter/lib/features/task/presentation/task_deletion_controller.g.dart
@@ -1,0 +1,56 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'task_deletion_controller.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+
+@ProviderFor(TaskDeletionController)
+const taskDeletionControllerProvider = TaskDeletionControllerProvider._();
+
+final class TaskDeletionControllerProvider
+    extends $AsyncNotifierProvider<TaskDeletionController, void> {
+  const TaskDeletionControllerProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'taskDeletionControllerProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$taskDeletionControllerHash();
+
+  @$internal
+  @override
+  TaskDeletionController create() => TaskDeletionController();
+}
+
+String _$taskDeletionControllerHash() =>
+    r'7a61d4d2e8f55f1b8aa4de628718b45b460c2526';
+
+abstract class _$TaskDeletionController extends $AsyncNotifier<void> {
+  FutureOr<void> build();
+  @$mustCallSuper
+  @override
+  void runBuild() {
+    build();
+    final ref = this.ref as $Ref<AsyncValue<void>, void>;
+    final element =
+        ref.element
+            as $ClassProviderElement<
+              AnyNotifier<AsyncValue<void>, void>,
+              AsyncValue<void>,
+              Object?,
+              Object?
+            >;
+    element.handleValue(ref, null);
+  }
+}

--- a/peppercheck_flutter/lib/features/task/presentation/widgets/task_detail/delete_task_button.dart
+++ b/peppercheck_flutter/lib/features/task/presentation/widgets/task_detail/delete_task_button.dart
@@ -1,0 +1,58 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:peppercheck_flutter/common_widgets/destructive_action_button.dart';
+import 'package:peppercheck_flutter/features/task/domain/task.dart';
+import 'package:peppercheck_flutter/features/task/presentation/task_deletion_controller.dart';
+import 'package:peppercheck_flutter/features/task/presentation/widgets/task_detail/delete_task_confirmation_dialog.dart';
+import 'package:peppercheck_flutter/gen/slang/strings.g.dart';
+
+class DeleteTaskButton extends ConsumerWidget {
+  final Task task;
+
+  const DeleteTaskButton({super.key, required this.task});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final state = ref.watch(taskDeletionControllerProvider);
+    final isLoading = state.isLoading;
+
+    return DestructiveActionButton(
+      text: t.task.deletion.button,
+      icon: Icons.delete_outline,
+      isLoading: isLoading,
+      onPressed: isLoading ? null : () => _showConfirmation(context, ref),
+    );
+  }
+
+  void _showConfirmation(BuildContext context, WidgetRef ref) {
+    showDialog(
+      context: context,
+      builder: (_) => DeleteTaskConfirmationDialog(
+        onConfirm: () => _executeDelete(context, ref),
+      ),
+    );
+  }
+
+  Future<void> _executeDelete(BuildContext context, WidgetRef ref) async {
+    await ref
+        .read(taskDeletionControllerProvider.notifier)
+        .deleteTask(
+          task.id,
+          onSuccess: () {
+            if (!context.mounted) return;
+            ScaffoldMessenger.of(context).showSnackBar(
+              SnackBar(content: Text(t.task.deletion.deletedSnackbar)),
+            );
+            context.go('/');
+          },
+        );
+
+    final newState = ref.read(taskDeletionControllerProvider);
+    if (newState.hasError && context.mounted) {
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(SnackBar(content: Text(t.task.deletion.failedSnackbar)));
+    }
+  }
+}

--- a/peppercheck_flutter/lib/features/task/presentation/widgets/task_detail/delete_task_confirmation_dialog.dart
+++ b/peppercheck_flutter/lib/features/task/presentation/widgets/task_detail/delete_task_confirmation_dialog.dart
@@ -1,0 +1,34 @@
+import 'package:flutter/material.dart';
+import 'package:peppercheck_flutter/app/theme/app_colors.dart';
+import 'package:peppercheck_flutter/common_widgets/base_dialog.dart';
+import 'package:peppercheck_flutter/gen/slang/strings.g.dart';
+
+class DeleteTaskConfirmationDialog extends StatelessWidget {
+  final VoidCallback onConfirm;
+
+  const DeleteTaskConfirmationDialog({super.key, required this.onConfirm});
+
+  @override
+  Widget build(BuildContext context) {
+    return BaseDialog(
+      title: t.task.deletion.confirmTitle,
+      // BaseDialog.content is required; use SizedBox.shrink for a title-only dialog.
+      content: const SizedBox.shrink(),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(),
+          style: TextButton.styleFrom(foregroundColor: AppColors.textSecondary),
+          child: Text(t.common.cancel),
+        ),
+        TextButton(
+          onPressed: () {
+            Navigator.of(context).pop();
+            onConfirm();
+          },
+          style: TextButton.styleFrom(foregroundColor: AppColors.textError),
+          child: Text(t.task.deletion.deleteButton),
+        ),
+      ],
+    );
+  }
+}

--- a/peppercheck_flutter/lib/features/task/presentation/widgets/task_detail/task_detail_info_section.dart
+++ b/peppercheck_flutter/lib/features/task/presentation/widgets/task_detail/task_detail_info_section.dart
@@ -6,6 +6,7 @@ import 'package:peppercheck_flutter/app/theme/app_sizes.dart';
 import 'package:peppercheck_flutter/common_widgets/action_button.dart';
 import 'package:peppercheck_flutter/common_widgets/base_section.dart';
 import 'package:peppercheck_flutter/features/task/domain/task.dart';
+import 'package:peppercheck_flutter/features/task/presentation/widgets/task_detail/delete_task_button.dart';
 import 'package:peppercheck_flutter/gen/slang/strings.g.dart';
 
 class TaskDetailInfoSection extends StatelessWidget {
@@ -47,6 +48,8 @@ class TaskDetailInfoSection extends StatelessWidget {
                 context.push('/create_task', extra: task);
               },
             ),
+            const SizedBox(height: AppSizes.spacingSmall),
+            DeleteTaskButton(task: task),
           ],
         ],
       ),

--- a/peppercheck_flutter/lib/gen/slang/strings.g.dart
+++ b/peppercheck_flutter/lib/gen/slang/strings.g.dart
@@ -6,7 +6,7 @@
 /// Locales: 1
 /// Strings: 315
 ///
-/// Built on 2026-04-27 at 13:57 UTC
+/// Built on 2026-04-27 at 14:42 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint, unused_import

--- a/peppercheck_flutter/lib/gen/slang/strings.g.dart
+++ b/peppercheck_flutter/lib/gen/slang/strings.g.dart
@@ -4,9 +4,9 @@
 /// To regenerate, run: `dart run slang`
 ///
 /// Locales: 1
-/// Strings: 310
+/// Strings: 315
 ///
-/// Built on 2026-04-26 at 12:54 UTC
+/// Built on 2026-04-27 at 13:57 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint, unused_import

--- a/peppercheck_flutter/lib/gen/slang/strings_ja.g.dart
+++ b/peppercheck_flutter/lib/gen/slang/strings_ja.g.dart
@@ -393,6 +393,7 @@ class TranslationsTaskJa {
 	late final TranslationsTaskStatusJa status = TranslationsTaskStatusJa.internal(_root);
 	late final TranslationsTaskDetailJa detail = TranslationsTaskDetailJa.internal(_root);
 	late final TranslationsTaskCreationJa creation = TranslationsTaskCreationJa.internal(_root);
+	late final TranslationsTaskDeletionJa deletion = TranslationsTaskDeletionJa.internal(_root);
 	late final TranslationsTaskEvidenceJa evidence = TranslationsTaskEvidenceJa.internal(_root);
 	late final TranslationsTaskJudgementJa judgement = TranslationsTaskJudgementJa.internal(_root);
 }
@@ -916,6 +917,30 @@ class TranslationsTaskCreationJa {
 
 	late final TranslationsTaskCreationStrategyJa strategy = TranslationsTaskCreationStrategyJa.internal(_root);
 	late final TranslationsTaskCreationErrorJa error = TranslationsTaskCreationErrorJa.internal(_root);
+}
+
+// Path: task.deletion
+class TranslationsTaskDeletionJa {
+	TranslationsTaskDeletionJa.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// ja: 'タスク削除'
+	String get button => 'タスク削除';
+
+	/// ja: 'このタスクを削除しますか?'
+	String get confirmTitle => 'このタスクを削除しますか?';
+
+	/// ja: '削除'
+	String get deleteButton => '削除';
+
+	/// ja: '削除しました'
+	String get deletedSnackbar => '削除しました';
+
+	/// ja: '削除できませんでした'
+	String get failedSnackbar => '削除できませんでした';
 }
 
 // Path: task.evidence
@@ -1604,6 +1629,11 @@ extension on Translations {
 			'task.creation.error.unknown' => 'エラーが発生しました',
 			'task.creation.error.unknownDetail' => ({required Object message}) => '${message}',
 			'task.creation.error.buttonOk' => 'OK',
+			'task.deletion.button' => 'タスク削除',
+			'task.deletion.confirmTitle' => 'このタスクを削除しますか?',
+			'task.deletion.deleteButton' => '削除',
+			'task.deletion.deletedSnackbar' => '削除しました',
+			'task.deletion.failedSnackbar' => '削除できませんでした',
 			'task.evidence.title' => 'エビデンス',
 			'task.evidence.submit' => 'エビデンスを提出',
 			'task.evidence.submitted' => '提出済みエビデンス',

--- a/peppercheck_flutter/lib/gen/slang/strings_ja.g.dart
+++ b/peppercheck_flutter/lib/gen/slang/strings_ja.g.dart
@@ -927,11 +927,11 @@ class TranslationsTaskDeletionJa {
 
 	// Translations
 
-	/// ja: 'タスク削除'
-	String get button => 'タスク削除';
+	/// ja: 'タスクを削除'
+	String get button => 'タスクを削除';
 
-	/// ja: 'このタスクを削除しますか?'
-	String get confirmTitle => 'このタスクを削除しますか?';
+	/// ja: 'このタスクを削除しますか？'
+	String get confirmTitle => 'このタスクを削除しますか？';
 
 	/// ja: '削除'
 	String get deleteButton => '削除';
@@ -1629,8 +1629,8 @@ extension on Translations {
 			'task.creation.error.unknown' => 'エラーが発生しました',
 			'task.creation.error.unknownDetail' => ({required Object message}) => '${message}',
 			'task.creation.error.buttonOk' => 'OK',
-			'task.deletion.button' => 'タスク削除',
-			'task.deletion.confirmTitle' => 'このタスクを削除しますか?',
+			'task.deletion.button' => 'タスクを削除',
+			'task.deletion.confirmTitle' => 'このタスクを削除しますか？',
 			'task.deletion.deleteButton' => '削除',
 			'task.deletion.deletedSnackbar' => '削除しました',
 			'task.deletion.failedSnackbar' => '削除できませんでした',

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -166,7 +166,8 @@ schema_paths = [
   # Task extra functions
   "./schemas/task/functions/create_task.sql",
   "./schemas/task/functions/update_task.sql",
-  
+  "./schemas/task/functions/delete_task.sql",
+
   # Task Utils
   "./schemas/task/functions/utils/validate_task_inputs.sql",
   "./schemas/task/functions/utils/validate_task_open_requirements.sql",

--- a/supabase/migrations/20260427133309_add_delete_task_function.sql
+++ b/supabase/migrations/20260427133309_add_delete_task_function.sql
@@ -1,0 +1,36 @@
+set check_function_bodies = off;
+
+CREATE OR REPLACE FUNCTION public.delete_task(p_task_id uuid)
+ RETURNS void
+ LANGUAGE plpgsql
+AS $function$
+DECLARE
+    v_current_status public.task_status;
+    v_tasker_id uuid;
+BEGIN
+    -- 1. Check Existence and capture state
+    SELECT status, tasker_id INTO v_current_status, v_tasker_id
+    FROM public.tasks
+    WHERE id = p_task_id;
+
+    IF v_current_status IS NULL THEN
+        RAISE EXCEPTION 'Task not found';
+    END IF;
+
+    -- 2. Check Ownership
+    IF v_tasker_id != auth.uid() THEN
+        RAISE EXCEPTION 'Not authorized to delete this task';
+    END IF;
+
+    -- 3. Check Status (only drafts can be deleted)
+    IF v_current_status != 'draft' THEN
+        RAISE EXCEPTION 'Only draft tasks can be deleted';
+    END IF;
+
+    -- 4. Delete (FK CASCADE handles task_referee_requests / task_evidences / reports if any)
+    DELETE FROM public.tasks WHERE id = p_task_id;
+END;
+$function$
+;
+
+

--- a/supabase/schemas/task/functions/delete_task.sql
+++ b/supabase/schemas/task/functions/delete_task.sql
@@ -1,0 +1,32 @@
+CREATE OR REPLACE FUNCTION public.delete_task(p_task_id uuid)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY INVOKER
+AS $$
+DECLARE
+    v_current_status public.task_status;
+    v_tasker_id uuid;
+BEGIN
+    -- 1. Check Existence and capture state
+    SELECT status, tasker_id INTO v_current_status, v_tasker_id
+    FROM public.tasks
+    WHERE id = p_task_id;
+
+    IF v_current_status IS NULL THEN
+        RAISE EXCEPTION 'Task not found';
+    END IF;
+
+    -- 2. Check Ownership
+    IF v_tasker_id != auth.uid() THEN
+        RAISE EXCEPTION 'Not authorized to delete this task';
+    END IF;
+
+    -- 3. Check Status (only drafts can be deleted)
+    IF v_current_status != 'draft' THEN
+        RAISE EXCEPTION 'Only draft tasks can be deleted';
+    END IF;
+
+    -- 4. Delete (FK CASCADE handles task_referee_requests / task_evidences / reports if any)
+    DELETE FROM public.tasks WHERE id = p_task_id;
+END;
+$$;

--- a/supabase/tests/database/delete_task.test.sql
+++ b/supabase/tests/database/delete_task.test.sql
@@ -1,0 +1,118 @@
+begin;
+create extension if not exists pgtap with schema extensions;
+select plan(8);
+
+-- ============================================================
+-- Setup: two test users + tasks in various states
+-- ============================================================
+delete from auth.users where id in (
+  'aa000001-0000-0000-0000-000000000000',
+  'aa000002-0000-0000-0000-000000000000'
+);
+
+insert into auth.users (id, email, instance_id, aud, role, encrypted_password, email_confirmed_at, created_at, updated_at)
+values
+  ('aa000001-0000-0000-0000-000000000000', 'tasker@test.com', '00000000-0000-0000-0000-000000000000', 'authenticated', 'authenticated', crypt('password123', gen_salt('bf')), now(), now(), now()),
+  ('aa000002-0000-0000-0000-000000000000', 'other@test.com',  '00000000-0000-0000-0000-000000000000', 'authenticated', 'authenticated', crypt('password123', gen_salt('bf')), now(), now(), now());
+
+insert into public.tasks (id, tasker_id, title, status, due_date)
+values
+  ('aa100001-0000-0000-0000-000000000000', 'aa000001-0000-0000-0000-000000000000', 'Draft Task',  'draft', null),
+  ('aa100002-0000-0000-0000-000000000000', 'aa000001-0000-0000-0000-000000000000', 'Open Task',   'open',  now() + interval '1 day'),
+  ('aa100003-0000-0000-0000-000000000000', 'aa000001-0000-0000-0000-000000000000', 'Closed Task', 'closed', now() + interval '1 day'),
+  ('aa100004-0000-0000-0000-000000000000', 'aa000002-0000-0000-0000-000000000000', 'Other Draft', 'draft', null);
+
+-- ============================================================
+-- Test 1: tasker deletes own draft task → succeeds
+-- ============================================================
+select set_config('request.jwt.claims', '{"sub": "aa000001-0000-0000-0000-000000000000"}', true);
+
+select lives_ok(
+    $$ select public.delete_task('aa100001-0000-0000-0000-000000000000') $$,
+    'Test 1: tasker can delete own draft task'
+);
+
+-- Test 2: row was actually removed
+select is(
+    (select count(*) from public.tasks where id = 'aa100001-0000-0000-0000-000000000000'),
+    0::bigint,
+    'Test 2: deleted task row is removed'
+);
+
+-- ============================================================
+-- Test 3: tasker cannot delete own open task
+-- ============================================================
+select set_config('request.jwt.claims', '{"sub": "aa000001-0000-0000-0000-000000000000"}', true);
+
+select throws_ok(
+    $$ select public.delete_task('aa100002-0000-0000-0000-000000000000') $$,
+    'P0001',
+    'Only draft tasks can be deleted',
+    'Test 3: open task deletion raises exception'
+);
+
+-- ============================================================
+-- Test 4: tasker cannot delete own closed task
+-- ============================================================
+select set_config('request.jwt.claims', '{"sub": "aa000001-0000-0000-0000-000000000000"}', true);
+
+select throws_ok(
+    $$ select public.delete_task('aa100003-0000-0000-0000-000000000000') $$,
+    'P0001',
+    'Only draft tasks can be deleted',
+    'Test 4: closed task deletion raises exception'
+);
+
+-- ============================================================
+-- Test 5: non-owner cannot delete another user's draft
+-- ============================================================
+select set_config('request.jwt.claims', '{"sub": "aa000001-0000-0000-0000-000000000000"}', true);
+
+select throws_ok(
+    $$ select public.delete_task('aa100004-0000-0000-0000-000000000000') $$,
+    'P0001',
+    'Not authorized to delete this task',
+    'Test 5: non-owner deletion raises authorization error'
+);
+
+-- Test 6: row was NOT removed (sanity check on Test 5)
+select is(
+    (select count(*) from public.tasks where id = 'aa100004-0000-0000-0000-000000000000'),
+    1::bigint,
+    'Test 6: non-owner attempt did not delete the row'
+);
+
+-- ============================================================
+-- Test 7: non-existent task ID raises "Task not found"
+-- ============================================================
+select set_config('request.jwt.claims', '{"sub": "aa000001-0000-0000-0000-000000000000"}', true);
+
+select throws_ok(
+    $$ select public.delete_task('aa999999-9999-9999-9999-999999999999') $$,
+    'P0001',
+    'Task not found',
+    'Test 7: non-existent task ID raises Task not found'
+);
+
+-- ============================================================
+-- Test 8: FK CASCADE — deleting draft cascades to any task_referee_requests
+-- (drafts normally have no requests, but the cascade is a safety net)
+-- ============================================================
+insert into public.tasks (id, tasker_id, title, status, due_date)
+values ('aa100005-0000-0000-0000-000000000000', 'aa000001-0000-0000-0000-000000000000', 'Draft With Request', 'draft', null);
+
+insert into public.task_referee_requests (id, task_id, matching_strategy, status)
+values ('aa200001-0000-0000-0000-000000000000', 'aa100005-0000-0000-0000-000000000000', 'standard', 'pending');
+
+select set_config('request.jwt.claims', '{"sub": "aa000001-0000-0000-0000-000000000000"}', true);
+
+select public.delete_task('aa100005-0000-0000-0000-000000000000');
+
+select is(
+    (select count(*) from public.task_referee_requests where id = 'aa200001-0000-0000-0000-000000000000'),
+    0::bigint,
+    'Test 8: deleting task cascades to task_referee_requests'
+);
+
+select * from finish();
+rollback;


### PR DESCRIPTION
## Summary
- Adds `public.delete_task(p_task_id)` RPC (`SECURITY INVOKER`) that lets a tasker delete only their own `draft` tasks; `open` / `closed` tasks remain non-deletable. Defense in depth: RPC explicit checks + existing RLS DELETE policy.
- Adds a destructive delete button below the existing edit button on the task detail screen (drafts only), gated by a single-step confirmation dialog. On success: Snackbar + navigate home + invalidate `activeUserTasksProvider` so the list updates without pull-to-refresh.
- Introduces a shared `DestructiveActionButton` common widget (red-tinted variant of `ActionButton`, with a configurable `borderRadius` defaulting to 20). The existing account deletion button migrates to it.

## Design
`docs/superpowers/specs/2026-04-27-draft-task-deletion-design.md`

## Test plan
- [x] pgTAP: 8 cases in `supabase/tests/database/delete_task.test.sql` (success + row-removed sanity, open/closed/non-owner/non-existent rejection paths, non-owner row-not-removed sanity, FK CASCADE to `task_referee_requests`).
- [x] All existing pgTAP files in `supabase/tests/database/` still pass.
- [x] `flutter analyze` shows no new issues.
- [x] `flutter build apk --debug -t lib/main_debug.dart` succeeds.
- [x] Manual end-to-end on Android emulator:
  - Create draft → tap delete → confirm → Snackbar appears → navigate home → list updated immediately.
  - Cancel dialog → no change.
  - Open task → delete button is not shown.
  - Account delete button visual is unchanged after migrating to `DestructiveActionButton`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)