### PR TITLE
chore(flutter): polish home task card and section title

### DIFF
--- a/peppercheck_flutter/assets/i18n/ja.i18n.json
+++ b/peppercheck_flutter/assets/i18n/ja.i18n.json
@@ -5,7 +5,7 @@
   },
   "home": {
     "title": "Home",
-    "myTasks": "自分のタスク",
+    "myTasks": "タスク",
     "refereeTasks": "判定依頼",
     "noTasks": "タスクはありません"
   },

--- a/peppercheck_flutter/lib/features/home/presentation/widgets/task_card.dart
+++ b/peppercheck_flutter/lib/features/home/presentation/widgets/task_card.dart
@@ -17,9 +17,7 @@ class TaskCard extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final dueDateFormatted = task.dueDate != null
-        ? DateFormat(
-            'MM/dd H:mm',
-          ).format(DateTime.parse(task.dueDate!).toLocal())
+        ? DateFormat('M/d H:mm').format(DateTime.parse(task.dueDate!).toLocal())
         : '';
 
     final currentUserId = ref.watch(currentUserProvider)?.id ?? '';
@@ -60,7 +58,7 @@ class TaskCard extends ConsumerWidget {
                     ),
                     const SizedBox(height: AppSizes.taskCardTitleInfoGap),
                     Text(
-                      '$dueDateFormatted   ¥${task.feeAmount?.toInt() ?? 0}', // TODO: Multi currency
+                      dueDateFormatted,
                       style: Theme.of(context).textTheme.bodySmall?.copyWith(
                         color: AppColors.textSecondary,
                       ),

--- a/peppercheck_flutter/lib/gen/slang/strings.g.dart
+++ b/peppercheck_flutter/lib/gen/slang/strings.g.dart
@@ -6,7 +6,7 @@
 /// Locales: 1
 /// Strings: 315
 ///
-/// Built on 2026-04-27 at 14:42 UTC
+/// Built on 2026-04-28 at 08:31 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint, unused_import

--- a/peppercheck_flutter/lib/gen/slang/strings_ja.g.dart
+++ b/peppercheck_flutter/lib/gen/slang/strings_ja.g.dart
@@ -83,8 +83,8 @@ class TranslationsHomeJa {
 	/// ja: 'Home'
 	String get title => 'Home';
 
-	/// ja: '自分のタスク'
-	String get myTasks => '自分のタスク';
+	/// ja: 'タスク'
+	String get myTasks => 'タスク';
 
 	/// ja: '判定依頼'
 	String get refereeTasks => '判定依頼';
@@ -1480,7 +1480,7 @@ extension on Translations {
 			'login.title' => 'PEPPERCHECK',
 			'login.aboutLink' => 'PepperCheckとは？',
 			'home.title' => 'Home',
-			'home.myTasks' => '自分のタスク',
+			'home.myTasks' => 'タスク',
 			'home.refereeTasks' => '判定依頼',
 			'home.noTasks' => 'タスクはありません',
 			'nav.home' => 'Home',


### PR DESCRIPTION
## Summary

- Removes legacy ¥-amount display from home task cards (pre-subscription artifact)
- Date format `MM/dd H:mm` → `M/d H:mm` (e.g., "4/30 14:45")
- Section title `"自分のタスク"` → `"タスク"` — contrast with "判定依頼" carries ownership

Spec: docs/superpowers/specs/2026-04-28-pre-release-ui-polish-design.md §3, §4
Related: #367 (consumed-points placeholder follow-up)

## Test plan

- [x] App builds: \`flutter build apk --debug -t lib/main_debug.dart\`
- [ ] Emulator confirmation happens in the consolidated verification pass after all 4 PRs land

🤖 Generated with [Claude Code](https://claude.com/claude-code)