### PR TITLE
feat(flutter): show contextual avatars on home task card and judgement card

### DIFF
--- a/peppercheck_flutter/lib/app/theme/app_sizes.dart
+++ b/peppercheck_flutter/lib/app/theme/app_sizes.dart
@@ -41,6 +41,9 @@ class AppSizes {
   // Mid-size avatar used in task detail referee/requester cards.
   static const double avatarSizeMedium = 24.0;
 
+  // Width of the white ring around overlapping avatars in a stack.
+  static const double avatarStackRingWidth = 1.0;
+
   // Task Card specific
   static const double taskCardTitleInfoGap = 2.0;
   static const double taskCardStatusGap = 8.0;

--- a/peppercheck_flutter/lib/features/home/presentation/widgets/task_card.dart
+++ b/peppercheck_flutter/lib/features/home/presentation/widgets/task_card.dart
@@ -5,6 +5,7 @@ import 'package:intl/intl.dart';
 import 'package:peppercheck_flutter/app/theme/app_colors.dart';
 import 'package:peppercheck_flutter/app/theme/app_sizes.dart';
 import 'package:peppercheck_flutter/features/authentication/data/auth_state_provider.dart';
+import 'package:peppercheck_flutter/features/profile/domain/profile.dart';
 import 'package:peppercheck_flutter/features/task/domain/task.dart';
 import 'package:peppercheck_flutter/gen/slang/strings.g.dart';
 
@@ -37,11 +38,7 @@ class TaskCard extends ConsumerWidget {
           ),
           child: Row(
             children: [
-              const Icon(
-                Icons.person,
-                color: AppColors.textSecondary,
-                size: AppSizes.baseCardIconSize,
-              ),
+              _buildLeading(currentUserId),
               const SizedBox(width: AppSizes.baseCardIconGap),
               Expanded(
                 child: Column(
@@ -72,6 +69,28 @@ class TaskCard extends ConsumerWidget {
           ),
         ),
       ),
+    );
+  }
+
+  Widget _buildLeading(String currentUserId) {
+    final isOwnTask = task.taskerId == currentUserId;
+
+    if (isOwnTask) {
+      final matchedReferees = task.refereeRequests
+          .where((r) => r.referee != null)
+          .map((r) => r.referee!)
+          .take(2)
+          .toList();
+      if (matchedReferees.isEmpty) return const _AvatarPlaceholder();
+      return _RefereeAvatarStack(referees: matchedReferees);
+    }
+
+    final taskerAvatarUrl = task.tasker?.avatarUrl;
+    if (taskerAvatarUrl == null) return const _AvatarPlaceholder();
+    return CircleAvatar(
+      radius: AppSizes.avatarSizeMedium / 2,
+      backgroundImage: NetworkImage(taskerAvatarUrl),
+      backgroundColor: Colors.transparent,
     );
   }
 
@@ -165,5 +184,92 @@ class TaskCard extends ConsumerWidget {
       default:
         return (text: statusKey, color: AppColors.textPrimary);
     }
+  }
+}
+
+class _AvatarPlaceholder extends StatelessWidget {
+  const _AvatarPlaceholder();
+
+  @override
+  Widget build(BuildContext context) {
+    return const Icon(
+      Icons.person,
+      color: AppColors.textSecondary,
+      size: AppSizes.avatarSizeMedium,
+    );
+  }
+}
+
+class _RefereeAvatarStack extends StatelessWidget {
+  final List<Profile> referees;
+
+  const _RefereeAvatarStack({required this.referees});
+
+  @override
+  Widget build(BuildContext context) {
+    if (referees.length == 1) {
+      return _RefereeAvatarBubble(profile: referees.first);
+    }
+
+    const offset = AppSizes.avatarSizeMedium * 0.6;
+    const bubbleSize =
+        AppSizes.avatarSizeMedium + 2 * AppSizes.avatarStackRingWidth;
+    final width = bubbleSize + (referees.length - 1) * offset;
+
+    return SizedBox(
+      width: width,
+      height: bubbleSize,
+      child: Stack(
+        clipBehavior: Clip.none,
+        children: [
+          for (int i = 0; i < referees.length; i++)
+            Positioned(
+              left: i * offset,
+              child: _RefereeAvatarBubble(profile: referees[i], showRing: true),
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+class _RefereeAvatarBubble extends StatelessWidget {
+  final Profile profile;
+  final bool showRing;
+
+  const _RefereeAvatarBubble({required this.profile, this.showRing = false});
+
+  @override
+  Widget build(BuildContext context) {
+    final avatar = _buildAvatar();
+    if (!showRing) return avatar;
+
+    const total = AppSizes.avatarSizeMedium + 2 * AppSizes.avatarStackRingWidth;
+    return Container(
+      width: total,
+      height: total,
+      alignment: Alignment.center,
+      decoration: const BoxDecoration(
+        shape: BoxShape.circle,
+        color: AppColors.backgroundWhite,
+      ),
+      child: avatar,
+    );
+  }
+
+  Widget _buildAvatar() {
+    final avatarUrl = profile.avatarUrl;
+    if (avatarUrl != null) {
+      return CircleAvatar(
+        radius: AppSizes.avatarSizeMedium / 2,
+        backgroundImage: NetworkImage(avatarUrl),
+        backgroundColor: Colors.transparent,
+      );
+    }
+    return const Icon(
+      Icons.person,
+      color: AppColors.textSecondary,
+      size: AppSizes.avatarSizeMedium,
+    );
   }
 }

--- a/peppercheck_flutter/lib/features/judgement/presentation/widgets/judgement_section.dart
+++ b/peppercheck_flutter/lib/features/judgement/presentation/widgets/judgement_section.dart
@@ -281,7 +281,7 @@ class _JudgementSectionState extends ConsumerState<JudgementSection> {
             children: [
               if (request.referee?.avatarUrl != null)
                 CircleAvatar(
-                  radius: AppSizes.baseCardIconSize / 2,
+                  radius: AppSizes.avatarSizeMedium / 2,
                   backgroundImage: NetworkImage(request.referee!.avatarUrl!),
                   backgroundColor: Colors.transparent,
                 )
@@ -289,7 +289,7 @@ class _JudgementSectionState extends ConsumerState<JudgementSection> {
                 const Icon(
                   Icons.person,
                   color: AppColors.textSecondary,
-                  size: AppSizes.baseCardIconSize,
+                  size: AppSizes.avatarSizeMedium,
                 ),
               const SizedBox(width: AppSizes.baseCardIconGap),
               Expanded(


### PR DESCRIPTION
## Summary
- Home task card now shows contextual avatars instead of a generic person icon: own tasks display matched referees stacked (max 2, with a thin white ring around each bubble for separation), referee tasks display the requester's avatar; placeholder is shown until referees are matched or when the requester has no avatar.
- Judgement result card avatar is bumped from 20pt (`baseCardIconSize`) to 24pt (`avatarSizeMedium`) so every avatar surface in the app shares one size.
- New `AppSizes.avatarStackRingWidth = 1.0` controls the white ring around stacked avatars.

## Test plan
- [x] Home tab "自分のタスク" with 0 matched referees → person placeholder
- [x] Home tab "自分のタスク" with 1 matched referee (with avatar) → single 24pt avatar, no ring
- [x] Home tab "自分のタスク" with 1 matched referee (no avatar) → person placeholder inside the leading slot
- [ ] Home tab "自分のタスク" with 2 matched referees → two avatars overlapping with a white ring around each
- [x] Home tab "判定依頼" with requester avatar → tasker avatar shown
- [x] Home tab "判定依頼" without requester avatar → person placeholder
- [ ] Judgement section result card avatar appears at the same 24pt size as the rest of the app

🤖 Generated with [Claude Code](https://claude.com/claude-code)