### PR TITLE
feat(flutter): auto-resize evidence images before upload

### DIFF
--- a/docs/superpowers/specs/2026-04-29-evidence-image-resize-design.md
+++ b/docs/superpowers/specs/2026-04-29-evidence-image-resize-design.md
@@ -1,0 +1,197 @@
+# Evidence Image: Auto-Resize Before Upload
+
+**Date:** 2026-04-29
+**Status:** Approved
+
+## Context
+
+Evidence image upload currently fails with a hard error dialog when the file exceeds 5MB. The 5MB limit is enforced server-side in the `generate-upload-url` Edge Function (`supabase/functions/generate-upload-url/index.ts:31`), and the client (`evidence_repository.dart`) sends the original picked file as-is.
+
+Modern smartphone photos routinely exceed 5MB:
+
+- iPhone HEIC: 1–3 MB, but iOS may produce JPEG variants that are 3–6 MB
+- Android JPEG: typically 3–8 MB on flagship cameras
+
+The avatar upload flow already handles this via `image_cropper` (`avatar_edit_controller.dart:32-37`), which crops to 512×512 / JPEG 85% before upload. Evidence has no equivalent normalization step.
+
+## Decision
+
+Normalize evidence images on the client side before upload. Always re-encode to JPEG quality 85% with longest side ≤ 2048px. If the result still exceeds 5MB, retry with smaller dimensions. Keep the server-side 5MB limit as a safety net.
+
+This guarantees that uploads fit within 5MB in the vast majority of cases, removes the HEIC compatibility concern (HEIC → JPEG is automatic), and improves perceived UX with progress feedback.
+
+## Design
+
+### 1. Normalization pipeline
+
+A new class `ImageNormalizer` encapsulates the pipeline.
+
+**Location:** `peppercheck_flutter/lib/features/evidence/data/image_normalizer.dart`
+
+**Responsibility:** take an `XFile`, return a `NormalizedImage(bytes, filename, mimeType)` ready for R2 upload.
+
+**Algorithm:**
+
+```
+for (longestSide, quality) in [(2048, 85), (1536, 85), (1024, 85)]:
+    encoded = compress(originalBytes, longestSide, quality)
+    if encoded.length <= 5 MB:
+        return NormalizedImage(encoded, "<basename>.jpg", "image/jpeg")
+throw ImageTooLargeException
+```
+
+Smaller source images are not upscaled — `flutter_image_compress` honors original dimensions when they are below the target. They are still re-encoded to JPEG for output uniformity (and to convert HEIC).
+
+The encode function is injected via the constructor (`EncodeFn`) so that fallback branches can be unit-tested without large fixture images:
+
+```dart
+typedef EncodeFn = Future<Uint8List> Function(Uint8List bytes, int longestSide, int quality);
+
+class ImageNormalizer {
+  ImageNormalizer({EncodeFn? encode}) : _encode = encode ?? _defaultEncode;
+  final EncodeFn _encode;
+  // ...
+}
+```
+
+### 2. Library: `flutter_image_compress`
+
+New dependency added to `pubspec.yaml`. Chosen over the alternatives because:
+
+- Native iOS / Android implementation, fast
+- Supports HEIC → JPEG conversion (critical for iPhone users)
+- Allows fine-grained control of dimensions and quality per call (required for the 3-step fallback)
+
+Alternatives considered and rejected:
+- `image_picker`'s built-in `imageQuality` / `maxWidth`: only one pass, cannot retry with smaller dimensions
+- `image` package (pure Dart): no HEIC support
+
+### 3. Filename and MIME rewrite
+
+The Edge Function validates that the file extension matches `content_type` (`generate-upload-url/index.ts:35-48`). After normalization, the basename is preserved but the extension is forced to `.jpg`, and `content_type` is sent as `image/jpeg`. Edge Function code is unchanged.
+
+### 4. EvidenceRepository
+
+`_uploadImages` (`evidence_repository.dart:17-69`) is updated to:
+
+1. Call `ImageNormalizer.normalize(image)` instead of reading bytes directly
+2. Use the normalized `bytes`, `filename`, and `mimeType` for the Edge Function request and the R2 PUT
+3. Accept progress callbacks (`onPreparing(current, total)`, `onUploading(current, total)`) and invoke them at the appropriate points
+
+### 5. EvidenceController state
+
+State type changes from `AsyncValue<void>` to `AsyncValue<EvidenceSubmissionState>`:
+
+```dart
+@freezed
+class EvidenceSubmissionState with _$EvidenceSubmissionState {
+  const EvidenceSubmissionState._();
+  const factory EvidenceSubmissionState.idle() = _Idle;
+  const factory EvidenceSubmissionState.preparing({
+    required int current,
+    required int total,
+  }) = _Preparing;
+  const factory EvidenceSubmissionState.uploading({
+    required int current,
+    required int total,
+  }) = _Uploading;
+
+  bool get isLoading => switch (this) {
+    _Idle() => false,
+    _Preparing() || _Uploading() => true,
+  };
+}
+```
+
+State transitions during a 3-image submit:
+
+```
+.idle()
+→ .preparing(1, 3) → .uploading(1, 3)
+→ .preparing(2, 3) → .uploading(2, 3)
+→ .preparing(3, 3) → .uploading(3, 3)
+→ .idle()      // on success
+// or AsyncError(...) on failure
+```
+
+Applies to all three flows: `submit`, `updateEvidence`, `resubmit`.
+
+### 6. UI changes
+
+In `evidence_submission_section.dart`, render a muted progress text directly below the Submit/Update/Resubmit button (parallel to the existing error display at `evidence_submission_section.dart:659-664`):
+
+```
+[Submit button (spinner when isLoading)]
+画像を準備中... (2/5)            ← AppColors.textSecondary, smaller font
+```
+
+Hidden when state is `.idle()` or `AsyncError`.
+
+For single-image submissions, the count suffix is omitted.
+
+### 7. i18n strings (slang)
+
+New keys under `task.evidence`:
+
+| Key | Japanese (example) |
+|---|---|
+| `preparing` | 画像を準備中... |
+| `preparingMulti` | 画像を準備中... ({current}/{total}) |
+| `uploading` | アップロード中... |
+| `uploadingMulti` | アップロード中... ({current}/{total}) |
+| `error.imageTooLarge` | 画像のサイズが大きすぎます。別の画像を選んでください。 |
+| `error.imageProcessingFailed` | 画像の処理に失敗しました。別の画像を選んでください。 |
+
+Final copy will be confirmed during implementation.
+
+### 8. Errors
+
+| Exception | Where it is thrown | UI message |
+|---|---|---|
+| `ImageTooLargeException` | After 3-step fallback all > 5MB | `error.imageTooLarge` |
+| `ImageProcessingException` | `flutter_image_compress` failure (codec, OOM) | `error.imageProcessingFailed` |
+| Existing exceptions | Edge Function / R2 / RPC failures | existing `state.error.toString()` (unchanged) |
+
+Mid-batch failures: behavior unchanged. Already-uploaded R2 objects from earlier images in the same batch may be left orphaned on failure. This is an existing issue and is out of scope for this change.
+
+## Testing
+
+### Unit tests
+
+`peppercheck_flutter/test/features/evidence/data/image_normalizer_test.dart` (new):
+
+- **Normal path:** input fixture image → output ≤ 5MB, longest side ≤ 2048px, MIME `image/jpeg`, filename `*.jpg`
+- **Filename extension rewrite:** `photo.heic` → `photo.jpg`
+- **Fallback (via `EncodeFn` injection):**
+  - step 1 returns 6MB-sized buffer, step 2 returns 4MB → expects step 2's bytes
+  - step 1 returns 6MB, step 2 returns 6MB, step 3 returns 4MB → expects step 3's bytes
+  - all three steps return > 5MB → expects `ImageTooLargeException`
+
+The injection-based fallback test avoids the difficulty of selecting a real-world fixture image that is still > 5MB after JPEG 85% compression.
+
+### Manual / device verification
+
+- iPhone (HEIC source): submit evidence with a typical photo → succeeds, server receives a JPEG ≤ 5MB
+- Android (JPEG source): submit evidence with a typical photo → succeeds
+- Large photo (~10MB): triggers fallback to step 2 (verify via logging or R2 file size)
+- Multi-image (3–5 photos): progress text shows correct `(current/total)` and transitions correctly between "preparing" and "uploading"
+
+## Out of Scope
+
+- Avatar upload (already handled by `image_cropper`)
+- Modifying the server-side 5MB limit
+- Cleaning up orphaned R2 images from partial multi-image uploads (existing issue)
+- Network error special-casing (existing error display is sufficient)
+
+## Affected files
+
+**New:**
+- `peppercheck_flutter/lib/features/evidence/data/image_normalizer.dart`
+- `peppercheck_flutter/test/features/evidence/data/image_normalizer_test.dart`
+
+**Modified:**
+- `peppercheck_flutter/lib/features/evidence/data/evidence_repository.dart`
+- `peppercheck_flutter/lib/features/evidence/presentation/controllers/evidence_controller.dart`
+- `peppercheck_flutter/lib/features/evidence/presentation/widgets/evidence_submission_section.dart`
+- `peppercheck_flutter/pubspec.yaml` (add `flutter_image_compress`)
+- i18n string files under `peppercheck_flutter/lib/i18n/`

--- a/peppercheck_flutter/assets/i18n/ja.i18n.json
+++ b/peppercheck_flutter/assets/i18n/ja.i18n.json
@@ -219,6 +219,12 @@
       "resubmit_success": "エビデンスを再提出しました",
       "update": "更新",
       "update_success": "エビデンスを更新しました",
+      "preparing": "画像を準備中...",
+      "preparing_multi": "画像を準備中... ($current/$total)",
+      "uploading": "アップロード中...",
+      "uploading_multi": "アップロード中... ($current/$total)",
+      "image_too_large": "画像のサイズが大きすぎます。\n別の画像を選んでください。",
+      "image_processing_failed": "画像の処理に失敗しました。\n別の画像を選んでください。",
       "timeout": {
         "title": "タイムアウト通知",
         "description": "期限を過ぎました。ポイントが支払われました。",

--- a/peppercheck_flutter/lib/features/evidence/data/evidence_repository.dart
+++ b/peppercheck_flutter/lib/features/evidence/data/evidence_repository.dart
@@ -1,37 +1,47 @@
 import 'package:dio/dio.dart';
 import 'package:image_picker/image_picker.dart';
 import 'package:logger/logger.dart';
-import 'package:mime/mime.dart';
 import 'package:peppercheck_flutter/app/app_logger.dart';
+import 'package:peppercheck_flutter/features/evidence/data/image_normalizer.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
 part 'evidence_repository.g.dart';
 
+typedef ProgressCallback = void Function(int current, int total);
+
 class EvidenceRepository {
   final SupabaseClient _client;
   final Logger _logger;
+  final ImageNormalizer _normalizer;
 
-  EvidenceRepository(this._client, this._logger);
+  EvidenceRepository(this._client, this._logger, {ImageNormalizer? normalizer})
+    : _normalizer = normalizer ?? ImageNormalizer();
 
   Future<List<Map<String, dynamic>>> _uploadImages(
     String taskId,
-    List<XFile> images,
-  ) async {
+    List<XFile> images, {
+    ProgressCallback? onPreparing,
+    ProgressCallback? onUploading,
+  }) async {
     final assets = <Map<String, dynamic>>[];
     final dio = Dio();
 
-    for (final image in images) {
-      final length = await image.length();
-      final mimeType = lookupMimeType(image.path) ?? 'application/octet-stream';
+    for (var i = 0; i < images.length; i++) {
+      final image = images[i];
+      onPreparing?.call(i + 1, images.length);
 
-      // 1. Get presigned URL
+      final normalized = await _normalizer.normalize(image);
+      final length = normalized.bytes.length;
+
+      onUploading?.call(i + 1, images.length);
+
       final response = await _client.functions.invoke(
         'generate-upload-url',
         body: {
           'task_id': taskId,
-          'filename': image.name,
-          'content_type': mimeType,
+          'filename': normalized.filename,
+          'content_type': normalized.mimeType,
           'file_size_bytes': length,
           'kind': 'evidence',
         },
@@ -45,22 +55,21 @@ class EvidenceRepository {
       final r2Key = response.data['r2_key'] as String;
       final publicUrl = response.data['public_url'] as String?;
 
-      // 2. Upload file to R2
-      final fileBytes = await image.readAsBytes();
-
-      // Using Dio for PUT (Presigned URL)
       await dio.put(
         uploadUrl,
-        data: Stream.fromIterable([fileBytes]), // Allow streaming
+        data: Stream.fromIterable([normalized.bytes]),
         options: Options(
-          headers: {'Content-Type': mimeType, 'Content-Length': length},
+          headers: {
+            'Content-Type': normalized.mimeType,
+            'Content-Length': length,
+          },
         ),
       );
 
       assets.add({
-        'file_url': r2Key, // We store the key/path
+        'file_url': r2Key,
         'file_size_bytes': length,
-        'content_type': mimeType,
+        'content_type': normalized.mimeType,
         'public_url': publicUrl,
       });
     }
@@ -72,11 +81,16 @@ class EvidenceRepository {
     required String taskId,
     required String description,
     required List<XFile> images,
+    ProgressCallback? onPreparing,
+    ProgressCallback? onUploading,
   }) async {
     try {
-      final assets = await _uploadImages(taskId, images);
-
-      // Submit Evidence RPC
+      final assets = await _uploadImages(
+        taskId,
+        images,
+        onPreparing: onPreparing,
+        onUploading: onUploading,
+      );
       await _client.rpc(
         'submit_evidence',
         params: {
@@ -97,11 +111,18 @@ class EvidenceRepository {
     required String description,
     required List<XFile> newImages,
     required List<String> assetIdsToRemove,
+    ProgressCallback? onPreparing,
+    ProgressCallback? onUploading,
   }) async {
     try {
       List<Map<String, dynamic>>? assetsToAdd;
       if (newImages.isNotEmpty) {
-        assetsToAdd = await _uploadImages(taskId, newImages);
+        assetsToAdd = await _uploadImages(
+          taskId,
+          newImages,
+          onPreparing: onPreparing,
+          onUploading: onUploading,
+        );
       }
 
       await _client.rpc(
@@ -126,11 +147,18 @@ class EvidenceRepository {
     required String description,
     required List<XFile> newImages,
     required List<String> assetIdsToRemove,
+    ProgressCallback? onPreparing,
+    ProgressCallback? onUploading,
   }) async {
     try {
       List<Map<String, dynamic>>? assetsToAdd;
       if (newImages.isNotEmpty) {
-        assetsToAdd = await _uploadImages(taskId, newImages);
+        assetsToAdd = await _uploadImages(
+          taskId,
+          newImages,
+          onPreparing: onPreparing,
+          onUploading: onUploading,
+        );
       }
 
       await _client.rpc(

--- a/peppercheck_flutter/lib/features/evidence/data/image_normalizer.dart
+++ b/peppercheck_flutter/lib/features/evidence/data/image_normalizer.dart
@@ -39,13 +39,16 @@ class ImageNormalizer {
 
   Future<NormalizedImage> normalize(XFile image) async {
     final original = await image.readAsBytes();
-    final encoded = await _encode(original, 2048, 85);
-    if (encoded.lengthInBytes <= _maxBytes) {
-      return NormalizedImage(
-        bytes: encoded,
-        filename: image.name,
-        mimeType: 'image/jpeg',
-      );
+    const steps = [(2048, 85), (1536, 85)];
+    for (final (side, quality) in steps) {
+      final encoded = await _encode(original, side, quality);
+      if (encoded.lengthInBytes <= _maxBytes) {
+        return NormalizedImage(
+          bytes: encoded,
+          filename: image.name,
+          mimeType: 'image/jpeg',
+        );
+      }
     }
     throw ImageTooLargeException();
   }

--- a/peppercheck_flutter/lib/features/evidence/data/image_normalizer.dart
+++ b/peppercheck_flutter/lib/features/evidence/data/image_normalizer.dart
@@ -39,7 +39,7 @@ class ImageNormalizer {
 
   Future<NormalizedImage> normalize(XFile image) async {
     final original = await image.readAsBytes();
-    const steps = [(2048, 85), (1536, 85)];
+    const steps = [(2048, 85), (1536, 85), (1024, 85)];
     for (final (side, quality) in steps) {
       final encoded = await _encode(original, side, quality);
       if (encoded.lengthInBytes <= _maxBytes) {

--- a/peppercheck_flutter/lib/features/evidence/data/image_normalizer.dart
+++ b/peppercheck_flutter/lib/features/evidence/data/image_normalizer.dart
@@ -31,9 +31,30 @@ class ImageProcessingException implements Exception {
 }
 
 class ImageNormalizer {
-  ImageNormalizer({EncodeFn? encode});
+  ImageNormalizer({EncodeFn? encode}) : _encode = encode ?? _defaultEncode;
 
-  Future<NormalizedImage> normalize(XFile image) {
-    throw UnimplementedError();
+  final EncodeFn _encode;
+
+  static const int _maxBytes = 5 * 1024 * 1024;
+
+  Future<NormalizedImage> normalize(XFile image) async {
+    final original = await image.readAsBytes();
+    final encoded = await _encode(original, 2048, 85);
+    if (encoded.lengthInBytes <= _maxBytes) {
+      return NormalizedImage(
+        bytes: encoded,
+        filename: image.name,
+        mimeType: 'image/jpeg',
+      );
+    }
+    throw ImageTooLargeException();
+  }
+
+  static Future<Uint8List> _defaultEncode(
+    Uint8List bytes,
+    int longestSide,
+    int quality,
+  ) async {
+    throw UnimplementedError(); // wired in Task 8
   }
 }

--- a/peppercheck_flutter/lib/features/evidence/data/image_normalizer.dart
+++ b/peppercheck_flutter/lib/features/evidence/data/image_normalizer.dart
@@ -1,0 +1,39 @@
+import 'dart:typed_data';
+
+import 'package:image_picker/image_picker.dart';
+
+typedef EncodeFn =
+    Future<Uint8List> Function(Uint8List bytes, int longestSide, int quality);
+
+class NormalizedImage {
+  NormalizedImage({
+    required this.bytes,
+    required this.filename,
+    required this.mimeType,
+  });
+
+  final Uint8List bytes;
+  final String filename;
+  final String mimeType;
+}
+
+class ImageTooLargeException implements Exception {
+  @override
+  String toString() =>
+      'ImageTooLargeException: image still exceeds 5MB after fallback';
+}
+
+class ImageProcessingException implements Exception {
+  ImageProcessingException(this.reason);
+  final String reason;
+  @override
+  String toString() => 'ImageProcessingException: $reason';
+}
+
+class ImageNormalizer {
+  ImageNormalizer({EncodeFn? encode});
+
+  Future<NormalizedImage> normalize(XFile image) {
+    throw UnimplementedError();
+  }
+}

--- a/peppercheck_flutter/lib/features/evidence/data/image_normalizer.dart
+++ b/peppercheck_flutter/lib/features/evidence/data/image_normalizer.dart
@@ -25,8 +25,9 @@ class ImageTooLargeException implements Exception {
 }
 
 class ImageProcessingException implements Exception {
-  ImageProcessingException(this.reason);
+  ImageProcessingException(this.reason, {this.cause});
   final String reason;
+  final Object? cause;
   @override
   String toString() => 'ImageProcessingException: $reason';
 }
@@ -45,8 +46,14 @@ class ImageNormalizer {
       Uint8List encoded;
       try {
         encoded = await _encode(original, side, quality);
-      } catch (e) {
-        throw ImageProcessingException(e.toString());
+      } catch (e, st) {
+        Error.throwWithStackTrace(
+          ImageProcessingException(e.toString(), cause: e),
+          st,
+        );
+      }
+      if (encoded.isEmpty) {
+        throw ImageProcessingException('encoder returned empty bytes');
       }
       if (encoded.lengthInBytes <= _maxBytes) {
         return NormalizedImage(
@@ -70,6 +77,8 @@ class ImageNormalizer {
     int longestSide,
     int quality,
   ) async {
+    // Both axes set to longestSide so the plugin fits the longer dimension
+    // to that bound while preserving aspect ratio.
     return FlutterImageCompress.compressWithList(
       bytes,
       minWidth: longestSide,

--- a/peppercheck_flutter/lib/features/evidence/data/image_normalizer.dart
+++ b/peppercheck_flutter/lib/features/evidence/data/image_normalizer.dart
@@ -1,5 +1,6 @@
 import 'dart:typed_data';
 
+import 'package:flutter_image_compress/flutter_image_compress.dart';
 import 'package:image_picker/image_picker.dart';
 
 typedef EncodeFn =
@@ -41,7 +42,12 @@ class ImageNormalizer {
     final original = await image.readAsBytes();
     const steps = [(2048, 85), (1536, 85), (1024, 85)];
     for (final (side, quality) in steps) {
-      final encoded = await _encode(original, side, quality);
+      Uint8List encoded;
+      try {
+        encoded = await _encode(original, side, quality);
+      } catch (e) {
+        throw ImageProcessingException(e.toString());
+      }
       if (encoded.lengthInBytes <= _maxBytes) {
         return NormalizedImage(
           bytes: encoded,
@@ -64,6 +70,12 @@ class ImageNormalizer {
     int longestSide,
     int quality,
   ) async {
-    throw UnimplementedError(); // wired in Task 8
+    return FlutterImageCompress.compressWithList(
+      bytes,
+      minWidth: longestSide,
+      minHeight: longestSide,
+      quality: quality,
+      format: CompressFormat.jpeg,
+    );
   }
 }

--- a/peppercheck_flutter/lib/features/evidence/data/image_normalizer.dart
+++ b/peppercheck_flutter/lib/features/evidence/data/image_normalizer.dart
@@ -45,12 +45,18 @@ class ImageNormalizer {
       if (encoded.lengthInBytes <= _maxBytes) {
         return NormalizedImage(
           bytes: encoded,
-          filename: image.name,
+          filename: _toJpgFilename(image.name),
           mimeType: 'image/jpeg',
         );
       }
     }
     throw ImageTooLargeException();
+  }
+
+  static String _toJpgFilename(String name) {
+    final dotIndex = name.lastIndexOf('.');
+    if (dotIndex <= 0) return '$name.jpg';
+    return '${name.substring(0, dotIndex)}.jpg';
   }
 
   static Future<Uint8List> _defaultEncode(

--- a/peppercheck_flutter/lib/features/evidence/presentation/controllers/evidence_controller.dart
+++ b/peppercheck_flutter/lib/features/evidence/presentation/controllers/evidence_controller.dart
@@ -91,6 +91,7 @@ class EvidenceController extends _$EvidenceController {
     required String judgementId,
     required VoidCallback onSuccess,
   }) async {
+    state = const AsyncLoading();
     state = await AsyncValue.guard(() async {
       await ref
           .read(evidenceRepositoryProvider)

--- a/peppercheck_flutter/lib/features/evidence/presentation/controllers/evidence_controller.dart
+++ b/peppercheck_flutter/lib/features/evidence/presentation/controllers/evidence_controller.dart
@@ -114,7 +114,7 @@ class EvidenceController extends _$EvidenceController {
     )
     action,
   }) async {
-    state = const AsyncData(EvidenceSubmissionState.idle());
+    state = const AsyncLoading();
     state = await AsyncValue.guard(() async {
       final repo = ref.read(evidenceRepositoryProvider);
       void onPreparing(int current, int total) {

--- a/peppercheck_flutter/lib/features/evidence/presentation/controllers/evidence_controller.dart
+++ b/peppercheck_flutter/lib/features/evidence/presentation/controllers/evidence_controller.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:image_picker/image_picker.dart';
 import 'package:peppercheck_flutter/features/evidence/data/evidence_repository.dart';
+import 'package:peppercheck_flutter/features/evidence/presentation/controllers/evidence_submission_state.dart';
 import 'package:peppercheck_flutter/features/home/presentation/home_controller.dart';
 import 'package:peppercheck_flutter/features/task/presentation/providers/task_provider.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
@@ -10,8 +11,8 @@ part 'evidence_controller.g.dart';
 @riverpod
 class EvidenceController extends _$EvidenceController {
   @override
-  FutureOr<void> build() {
-    // nothing to initialize
+  FutureOr<EvidenceSubmissionState> build() {
+    return const EvidenceSubmissionState.idle();
   }
 
   Future<void> submit({
@@ -26,23 +27,17 @@ class EvidenceController extends _$EvidenceController {
     if (images.isEmpty) {
       throw Exception('At least one image is required');
     }
-
-    state = const AsyncLoading();
-
-    state = await AsyncValue.guard(() async {
-      await ref
-          .read(evidenceRepositoryProvider)
-          .uploadEvidence(
-            taskId: taskId,
-            description: description,
-            images: images,
-          );
-      // Invalidate task provider to refresh UI
-      ref.invalidate(taskProvider(taskId));
-      ref.invalidate(activeUserTasksProvider);
-      ref.invalidate(activeRefereeTasksProvider);
-      onSuccess();
-    });
+    await _runUpload(
+      taskId: taskId,
+      onSuccess: onSuccess,
+      action: (repo, onPreparing, onUploading) => repo.uploadEvidence(
+        taskId: taskId,
+        description: description,
+        images: images,
+        onPreparing: onPreparing,
+        onUploading: onUploading,
+      ),
+    );
   }
 
   Future<void> updateEvidence({
@@ -53,22 +48,19 @@ class EvidenceController extends _$EvidenceController {
     required List<String> assetIdsToRemove,
     required VoidCallback onSuccess,
   }) async {
-    state = const AsyncLoading();
-    state = await AsyncValue.guard(() async {
-      await ref
-          .read(evidenceRepositoryProvider)
-          .updateEvidence(
-            evidenceId: evidenceId,
-            taskId: taskId,
-            description: description,
-            newImages: newImages,
-            assetIdsToRemove: assetIdsToRemove,
-          );
-      ref.invalidate(taskProvider(taskId));
-      ref.invalidate(activeUserTasksProvider);
-      ref.invalidate(activeRefereeTasksProvider);
-      onSuccess();
-    });
+    await _runUpload(
+      taskId: taskId,
+      onSuccess: onSuccess,
+      action: (repo, onPreparing, onUploading) => repo.updateEvidence(
+        evidenceId: evidenceId,
+        taskId: taskId,
+        description: description,
+        newImages: newImages,
+        assetIdsToRemove: assetIdsToRemove,
+        onPreparing: onPreparing,
+        onUploading: onUploading,
+      ),
+    );
   }
 
   Future<void> resubmit({
@@ -79,22 +71,19 @@ class EvidenceController extends _$EvidenceController {
     required List<String> assetIdsToRemove,
     required VoidCallback onSuccess,
   }) async {
-    state = const AsyncLoading();
-    state = await AsyncValue.guard(() async {
-      await ref
-          .read(evidenceRepositoryProvider)
-          .resubmitEvidence(
-            evidenceId: evidenceId,
-            taskId: taskId,
-            description: description,
-            newImages: newImages,
-            assetIdsToRemove: assetIdsToRemove,
-          );
-      ref.invalidate(taskProvider(taskId));
-      ref.invalidate(activeUserTasksProvider);
-      ref.invalidate(activeRefereeTasksProvider);
-      onSuccess();
-    });
+    await _runUpload(
+      taskId: taskId,
+      onSuccess: onSuccess,
+      action: (repo, onPreparing, onUploading) => repo.resubmitEvidence(
+        evidenceId: evidenceId,
+        taskId: taskId,
+        description: description,
+        newImages: newImages,
+        assetIdsToRemove: assetIdsToRemove,
+        onPreparing: onPreparing,
+        onUploading: onUploading,
+      ),
+    );
   }
 
   Future<void> confirmEvidenceTimeout({
@@ -102,8 +91,6 @@ class EvidenceController extends _$EvidenceController {
     required String judgementId,
     required VoidCallback onSuccess,
   }) async {
-    state = const AsyncLoading();
-
     state = await AsyncValue.guard(() async {
       await ref
           .read(evidenceRepositoryProvider)
@@ -112,6 +99,41 @@ class EvidenceController extends _$EvidenceController {
       ref.invalidate(activeUserTasksProvider);
       ref.invalidate(activeRefereeTasksProvider);
       onSuccess();
+      return const EvidenceSubmissionState.idle();
+    });
+  }
+
+  Future<void> _runUpload({
+    required String taskId,
+    required VoidCallback onSuccess,
+    required Future<void> Function(
+      EvidenceRepository repo,
+      ProgressCallback onPreparing,
+      ProgressCallback onUploading,
+    )
+    action,
+  }) async {
+    state = const AsyncData(EvidenceSubmissionState.idle());
+    state = await AsyncValue.guard(() async {
+      final repo = ref.read(evidenceRepositoryProvider);
+      void onPreparing(int current, int total) {
+        state = AsyncData(
+          EvidenceSubmissionState.preparing(current: current, total: total),
+        );
+      }
+
+      void onUploading(int current, int total) {
+        state = AsyncData(
+          EvidenceSubmissionState.uploading(current: current, total: total),
+        );
+      }
+
+      await action(repo, onPreparing, onUploading);
+      ref.invalidate(taskProvider(taskId));
+      ref.invalidate(activeUserTasksProvider);
+      ref.invalidate(activeRefereeTasksProvider);
+      onSuccess();
+      return const EvidenceSubmissionState.idle();
     });
   }
 }

--- a/peppercheck_flutter/lib/features/evidence/presentation/controllers/evidence_controller.g.dart
+++ b/peppercheck_flutter/lib/features/evidence/presentation/controllers/evidence_controller.g.dart
@@ -13,7 +13,8 @@ part of 'evidence_controller.dart';
 const evidenceControllerProvider = EvidenceControllerProvider._();
 
 final class EvidenceControllerProvider
-    extends $AsyncNotifierProvider<EvidenceController, void> {
+    extends
+        $AsyncNotifierProvider<EvidenceController, EvidenceSubmissionState> {
   const EvidenceControllerProvider._()
     : super(
         from: null,
@@ -34,23 +35,32 @@ final class EvidenceControllerProvider
 }
 
 String _$evidenceControllerHash() =>
-    r'410454fde3c0d2fb636a88c716171aaf277ea7c3';
+    r'7327a354279e88133524d454fb71a6220a3e8b41';
 
-abstract class _$EvidenceController extends $AsyncNotifier<void> {
-  FutureOr<void> build();
+abstract class _$EvidenceController
+    extends $AsyncNotifier<EvidenceSubmissionState> {
+  FutureOr<EvidenceSubmissionState> build();
   @$mustCallSuper
   @override
   void runBuild() {
-    build();
-    final ref = this.ref as $Ref<AsyncValue<void>, void>;
+    final created = build();
+    final ref =
+        this.ref
+            as $Ref<
+              AsyncValue<EvidenceSubmissionState>,
+              EvidenceSubmissionState
+            >;
     final element =
         ref.element
             as $ClassProviderElement<
-              AnyNotifier<AsyncValue<void>, void>,
-              AsyncValue<void>,
+              AnyNotifier<
+                AsyncValue<EvidenceSubmissionState>,
+                EvidenceSubmissionState
+              >,
+              AsyncValue<EvidenceSubmissionState>,
               Object?,
               Object?
             >;
-    element.handleValue(ref, null);
+    element.handleValue(ref, created);
   }
 }

--- a/peppercheck_flutter/lib/features/evidence/presentation/controllers/evidence_submission_state.dart
+++ b/peppercheck_flutter/lib/features/evidence/presentation/controllers/evidence_submission_state.dart
@@ -3,7 +3,7 @@ import 'package:freezed_annotation/freezed_annotation.dart';
 part 'evidence_submission_state.freezed.dart';
 
 @freezed
-abstract class EvidenceSubmissionState with _$EvidenceSubmissionState {
+sealed class EvidenceSubmissionState with _$EvidenceSubmissionState {
   const EvidenceSubmissionState._();
 
   const factory EvidenceSubmissionState.idle() = _Idle;
@@ -19,7 +19,6 @@ abstract class EvidenceSubmissionState with _$EvidenceSubmissionState {
   bool get isLoading => switch (this) {
     _Idle() => false,
     _Preparing() || _Uploading() => true,
-    _ => false,
   };
 
   bool get isPreparing => this is _Preparing;
@@ -31,6 +30,6 @@ abstract class EvidenceSubmissionState with _$EvidenceSubmissionState {
       :final current,
       :final total,
     ) => (current: current, total: total),
-    _ => null,
+    _Idle() => null,
   };
 }

--- a/peppercheck_flutter/lib/features/evidence/presentation/controllers/evidence_submission_state.dart
+++ b/peppercheck_flutter/lib/features/evidence/presentation/controllers/evidence_submission_state.dart
@@ -1,0 +1,36 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'evidence_submission_state.freezed.dart';
+
+@freezed
+abstract class EvidenceSubmissionState with _$EvidenceSubmissionState {
+  const EvidenceSubmissionState._();
+
+  const factory EvidenceSubmissionState.idle() = _Idle;
+  const factory EvidenceSubmissionState.preparing({
+    required int current,
+    required int total,
+  }) = _Preparing;
+  const factory EvidenceSubmissionState.uploading({
+    required int current,
+    required int total,
+  }) = _Uploading;
+
+  bool get isLoading => switch (this) {
+    _Idle() => false,
+    _Preparing() || _Uploading() => true,
+    _ => false,
+  };
+
+  bool get isPreparing => this is _Preparing;
+  bool get isUploading => this is _Uploading;
+
+  ({int current, int total})? get progress => switch (this) {
+    _Preparing(:final current, :final total) ||
+    _Uploading(
+      :final current,
+      :final total,
+    ) => (current: current, total: total),
+    _ => null,
+  };
+}

--- a/peppercheck_flutter/lib/features/evidence/presentation/controllers/evidence_submission_state.freezed.dart
+++ b/peppercheck_flutter/lib/features/evidence/presentation/controllers/evidence_submission_state.freezed.dart
@@ -1,0 +1,354 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'evidence_submission_state.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+/// @nodoc
+mixin _$EvidenceSubmissionState {
+
+
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is EvidenceSubmissionState);
+}
+
+
+@override
+int get hashCode => runtimeType.hashCode;
+
+@override
+String toString() {
+  return 'EvidenceSubmissionState()';
+}
+
+
+}
+
+/// @nodoc
+class $EvidenceSubmissionStateCopyWith<$Res>  {
+$EvidenceSubmissionStateCopyWith(EvidenceSubmissionState _, $Res Function(EvidenceSubmissionState) __);
+}
+
+
+/// Adds pattern-matching-related methods to [EvidenceSubmissionState].
+extension EvidenceSubmissionStatePatterns on EvidenceSubmissionState {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>({TResult Function( _Idle value)?  idle,TResult Function( _Preparing value)?  preparing,TResult Function( _Uploading value)?  uploading,required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _Idle() when idle != null:
+return idle(_that);case _Preparing() when preparing != null:
+return preparing(_that);case _Uploading() when uploading != null:
+return uploading(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>({required TResult Function( _Idle value)  idle,required TResult Function( _Preparing value)  preparing,required TResult Function( _Uploading value)  uploading,}){
+final _that = this;
+switch (_that) {
+case _Idle():
+return idle(_that);case _Preparing():
+return preparing(_that);case _Uploading():
+return uploading(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>({TResult? Function( _Idle value)?  idle,TResult? Function( _Preparing value)?  preparing,TResult? Function( _Uploading value)?  uploading,}){
+final _that = this;
+switch (_that) {
+case _Idle() when idle != null:
+return idle(_that);case _Preparing() when preparing != null:
+return preparing(_that);case _Uploading() when uploading != null:
+return uploading(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>({TResult Function()?  idle,TResult Function( int current,  int total)?  preparing,TResult Function( int current,  int total)?  uploading,required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _Idle() when idle != null:
+return idle();case _Preparing() when preparing != null:
+return preparing(_that.current,_that.total);case _Uploading() when uploading != null:
+return uploading(_that.current,_that.total);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>({required TResult Function()  idle,required TResult Function( int current,  int total)  preparing,required TResult Function( int current,  int total)  uploading,}) {final _that = this;
+switch (_that) {
+case _Idle():
+return idle();case _Preparing():
+return preparing(_that.current,_that.total);case _Uploading():
+return uploading(_that.current,_that.total);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>({TResult? Function()?  idle,TResult? Function( int current,  int total)?  preparing,TResult? Function( int current,  int total)?  uploading,}) {final _that = this;
+switch (_that) {
+case _Idle() when idle != null:
+return idle();case _Preparing() when preparing != null:
+return preparing(_that.current,_that.total);case _Uploading() when uploading != null:
+return uploading(_that.current,_that.total);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+
+
+class _Idle extends EvidenceSubmissionState {
+  const _Idle(): super._();
+  
+
+
+
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _Idle);
+}
+
+
+@override
+int get hashCode => runtimeType.hashCode;
+
+@override
+String toString() {
+  return 'EvidenceSubmissionState.idle()';
+}
+
+
+}
+
+
+
+
+/// @nodoc
+
+
+class _Preparing extends EvidenceSubmissionState {
+  const _Preparing({required this.current, required this.total}): super._();
+  
+
+ final  int current;
+ final  int total;
+
+/// Create a copy of EvidenceSubmissionState
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$PreparingCopyWith<_Preparing> get copyWith => __$PreparingCopyWithImpl<_Preparing>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _Preparing&&(identical(other.current, current) || other.current == current)&&(identical(other.total, total) || other.total == total));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,current,total);
+
+@override
+String toString() {
+  return 'EvidenceSubmissionState.preparing(current: $current, total: $total)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$PreparingCopyWith<$Res> implements $EvidenceSubmissionStateCopyWith<$Res> {
+  factory _$PreparingCopyWith(_Preparing value, $Res Function(_Preparing) _then) = __$PreparingCopyWithImpl;
+@useResult
+$Res call({
+ int current, int total
+});
+
+
+
+
+}
+/// @nodoc
+class __$PreparingCopyWithImpl<$Res>
+    implements _$PreparingCopyWith<$Res> {
+  __$PreparingCopyWithImpl(this._self, this._then);
+
+  final _Preparing _self;
+  final $Res Function(_Preparing) _then;
+
+/// Create a copy of EvidenceSubmissionState
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') $Res call({Object? current = null,Object? total = null,}) {
+  return _then(_Preparing(
+current: null == current ? _self.current : current // ignore: cast_nullable_to_non_nullable
+as int,total: null == total ? _self.total : total // ignore: cast_nullable_to_non_nullable
+as int,
+  ));
+}
+
+
+}
+
+/// @nodoc
+
+
+class _Uploading extends EvidenceSubmissionState {
+  const _Uploading({required this.current, required this.total}): super._();
+  
+
+ final  int current;
+ final  int total;
+
+/// Create a copy of EvidenceSubmissionState
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$UploadingCopyWith<_Uploading> get copyWith => __$UploadingCopyWithImpl<_Uploading>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _Uploading&&(identical(other.current, current) || other.current == current)&&(identical(other.total, total) || other.total == total));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,current,total);
+
+@override
+String toString() {
+  return 'EvidenceSubmissionState.uploading(current: $current, total: $total)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$UploadingCopyWith<$Res> implements $EvidenceSubmissionStateCopyWith<$Res> {
+  factory _$UploadingCopyWith(_Uploading value, $Res Function(_Uploading) _then) = __$UploadingCopyWithImpl;
+@useResult
+$Res call({
+ int current, int total
+});
+
+
+
+
+}
+/// @nodoc
+class __$UploadingCopyWithImpl<$Res>
+    implements _$UploadingCopyWith<$Res> {
+  __$UploadingCopyWithImpl(this._self, this._then);
+
+  final _Uploading _self;
+  final $Res Function(_Uploading) _then;
+
+/// Create a copy of EvidenceSubmissionState
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') $Res call({Object? current = null,Object? total = null,}) {
+  return _then(_Uploading(
+current: null == current ? _self.current : current // ignore: cast_nullable_to_non_nullable
+as int,total: null == total ? _self.total : total // ignore: cast_nullable_to_non_nullable
+as int,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/peppercheck_flutter/lib/features/evidence/presentation/controllers/evidence_submission_state.freezed.dart
+++ b/peppercheck_flutter/lib/features/evidence/presentation/controllers/evidence_submission_state.freezed.dart
@@ -85,10 +85,7 @@ switch (_that) {
 case _Idle():
 return idle(_that);case _Preparing():
 return preparing(_that);case _Uploading():
-return uploading(_that);case _:
-  throw StateError('Unexpected subclass');
-
-}
+return uploading(_that);}
 }
 /// A variant of `map` that fallback to returning `null`.
 ///
@@ -153,10 +150,7 @@ switch (_that) {
 case _Idle():
 return idle();case _Preparing():
 return preparing(_that.current,_that.total);case _Uploading():
-return uploading(_that.current,_that.total);case _:
-  throw StateError('Unexpected subclass');
-
-}
+return uploading(_that.current,_that.total);}
 }
 /// A variant of `when` that fallback to returning `null`
 ///

--- a/peppercheck_flutter/lib/features/evidence/presentation/widgets/evidence_submission_section.dart
+++ b/peppercheck_flutter/lib/features/evidence/presentation/widgets/evidence_submission_section.dart
@@ -397,7 +397,7 @@ class _EvidenceSubmissionSectionState
   @override
   Widget build(BuildContext context) {
     final state = ref.watch(evidenceControllerProvider);
-    final isLoading = state.isLoading;
+    final isLoading = state.isLoading || (state.value?.isLoading ?? false);
 
     // Check if evidence is already submitted
     // If Evidence exists, show submitted view (Read Only) or edit form

--- a/peppercheck_flutter/lib/features/evidence/presentation/widgets/evidence_submission_section.dart
+++ b/peppercheck_flutter/lib/features/evidence/presentation/widgets/evidence_submission_section.dart
@@ -9,6 +9,7 @@ import 'package:peppercheck_flutter/common_widgets/action_button.dart';
 import 'package:peppercheck_flutter/common_widgets/primary_action_button.dart';
 import 'package:peppercheck_flutter/common_widgets/base_text_field.dart';
 
+import 'package:peppercheck_flutter/features/evidence/data/image_normalizer.dart';
 import 'package:peppercheck_flutter/features/evidence/presentation/controllers/evidence_controller.dart';
 import 'package:peppercheck_flutter/common_widgets/base_section.dart';
 import 'package:peppercheck_flutter/features/matching/domain/referee_request.dart';
@@ -79,6 +80,53 @@ class _EvidenceSubmissionSectionState
   bool _isCurrentUserTasker() {
     return Supabase.instance.client.auth.currentUser?.id ==
         widget.task.taskerId;
+  }
+
+  String _mapErrorMessage(Object error) {
+    if (error is ImageTooLargeException) {
+      return t.task.evidence.image_too_large;
+    }
+    if (error is ImageProcessingException) {
+      return t.task.evidence.image_processing_failed;
+    }
+    return error.toString();
+  }
+
+  Widget? _buildProgressText() {
+    final state = ref.watch(evidenceControllerProvider);
+    final value = state.value;
+    if (value == null) return null;
+
+    String? text;
+    if (value.isPreparing) {
+      final p = value.progress!;
+      text = p.total > 1
+          ? t.task.evidence.preparing_multi(current: p.current, total: p.total)
+          : t.task.evidence.preparing;
+    } else if (value.isUploading) {
+      final p = value.progress!;
+      text = p.total > 1
+          ? t.task.evidence.uploading_multi(current: p.current, total: p.total)
+          : t.task.evidence.uploading;
+    }
+
+    if (text == null) return null;
+    return Padding(
+      padding: const EdgeInsets.only(top: AppSizes.spacingTiny),
+      child: Text(
+        text,
+        style: const TextStyle(color: AppColors.textSecondary, fontSize: 12),
+      ),
+    );
+  }
+
+  Widget? _buildErrorText() {
+    final state = ref.watch(evidenceControllerProvider);
+    if (!state.hasError) return null;
+    return Text(
+      _mapErrorMessage(state.error!),
+      style: const TextStyle(color: AppColors.textError),
+    );
   }
 
   void _enterEditMode({required bool isResubmit}) {
@@ -359,11 +407,8 @@ class _EvidenceSubmissionSectionState
             ),
           ),
           const SizedBox(height: AppSizes.spacingSmall),
-          if (ref.watch(evidenceControllerProvider).hasError) ...[
-            Text(
-              ref.watch(evidenceControllerProvider).error.toString(),
-              style: TextStyle(color: AppColors.textError),
-            ),
+          if (_buildErrorText() != null) ...[
+            _buildErrorText()!,
             const SizedBox(height: 8),
           ],
           Row(
@@ -389,6 +434,7 @@ class _EvidenceSubmissionSectionState
               TextButton(onPressed: _cancelEdit, child: Text(t.common.cancel)),
             ],
           ),
+          if (_buildProgressText() != null) _buildProgressText()!,
         ],
       ),
     );
@@ -535,11 +581,8 @@ class _EvidenceSubmissionSectionState
             ),
             if (!allConfirmed) ...[
               const SizedBox(height: AppSizes.spacingSmall),
-              if (state.hasError) ...[
-                Text(
-                  state.error.toString(),
-                  style: TextStyle(color: AppColors.textError),
-                ),
+              if (_buildErrorText() != null) ...[
+                _buildErrorText()!,
                 const SizedBox(height: AppSizes.spacingSmall),
               ],
               PrimaryActionButton(
@@ -656,11 +699,8 @@ class _EvidenceSubmissionSectionState
             ),
           ),
           const SizedBox(height: AppSizes.spacingSmall),
-          if (state.hasError) ...[
-            Text(
-              state.error.toString(),
-              style: TextStyle(color: AppColors.textError),
-            ),
+          if (_buildErrorText() != null) ...[
+            _buildErrorText()!,
             const SizedBox(height: 8),
           ],
           PrimaryActionButton(
@@ -672,6 +712,7 @@ class _EvidenceSubmissionSectionState
                 : null,
             isLoading: isLoading,
           ),
+          if (_buildProgressText() != null) _buildProgressText()!,
         ],
       ),
     );

--- a/peppercheck_flutter/lib/gen/slang/strings.g.dart
+++ b/peppercheck_flutter/lib/gen/slang/strings.g.dart
@@ -4,9 +4,9 @@
 /// To regenerate, run: `dart run slang`
 ///
 /// Locales: 1
-/// Strings: 333
+/// Strings: 339
 ///
-/// Built on 2026-04-28 at 21:38 UTC
+/// Built on 2026-04-29 at 09:10 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint, unused_import

--- a/peppercheck_flutter/lib/gen/slang/strings_ja.g.dart
+++ b/peppercheck_flutter/lib/gen/slang/strings_ja.g.dart
@@ -1002,6 +1002,24 @@ class TranslationsTaskEvidenceJa {
 	/// ja: 'エビデンスを更新しました'
 	String get update_success => 'エビデンスを更新しました';
 
+	/// ja: '画像を準備中...'
+	String get preparing => '画像を準備中...';
+
+	/// ja: '画像を準備中... ($current/$total)'
+	String preparing_multi({required Object current, required Object total}) => '画像を準備中... (${current}/${total})';
+
+	/// ja: 'アップロード中...'
+	String get uploading => 'アップロード中...';
+
+	/// ja: 'アップロード中... ($current/$total)'
+	String uploading_multi({required Object current, required Object total}) => 'アップロード中... (${current}/${total})';
+
+	/// ja: '画像のサイズが大きすぎます。 別の画像を選んでください。'
+	String get image_too_large => '画像のサイズが大きすぎます。\n別の画像を選んでください。';
+
+	/// ja: '画像の処理に失敗しました。 別の画像を選んでください。'
+	String get image_processing_failed => '画像の処理に失敗しました。\n別の画像を選んでください。';
+
 	late final TranslationsTaskEvidenceTimeoutJa timeout = TranslationsTaskEvidenceTimeoutJa.internal(_root);
 }
 
@@ -1737,6 +1755,12 @@ extension on Translations {
 			'task.evidence.resubmit_success' => 'エビデンスを再提出しました',
 			'task.evidence.update' => '更新',
 			'task.evidence.update_success' => 'エビデンスを更新しました',
+			'task.evidence.preparing' => '画像を準備中...',
+			'task.evidence.preparing_multi' => ({required Object current, required Object total}) => '画像を準備中... (${current}/${total})',
+			'task.evidence.uploading' => 'アップロード中...',
+			'task.evidence.uploading_multi' => ({required Object current, required Object total}) => 'アップロード中... (${current}/${total})',
+			'task.evidence.image_too_large' => '画像のサイズが大きすぎます。\n別の画像を選んでください。',
+			'task.evidence.image_processing_failed' => '画像の処理に失敗しました。\n別の画像を選んでください。',
 			'task.evidence.timeout.title' => 'タイムアウト通知',
 			'task.evidence.timeout.description' => '期限を過ぎました。ポイントが支払われました。',
 			'task.evidence.timeout.referee_description' => 'エビデンスの提出期限が過ぎたため、報酬が付与されました。',

--- a/peppercheck_flutter/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/peppercheck_flutter/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -9,6 +9,7 @@ import app_links
 import file_selector_macos
 import firebase_core
 import firebase_messaging
+import flutter_image_compress_macos
 import flutter_local_notifications
 import flutter_timezone
 import google_sign_in_ios
@@ -22,6 +23,7 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   FileSelectorPlugin.register(with: registry.registrar(forPlugin: "FileSelectorPlugin"))
   FLTFirebaseCorePlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseCorePlugin"))
   FLTFirebaseMessagingPlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseMessagingPlugin"))
+  FlutterImageCompressMacosPlugin.register(with: registry.registrar(forPlugin: "FlutterImageCompressMacosPlugin"))
   FlutterLocalNotificationsPlugin.register(with: registry.registrar(forPlugin: "FlutterLocalNotificationsPlugin"))
   FlutterTimezonePlugin.register(with: registry.registrar(forPlugin: "FlutterTimezonePlugin"))
   FLTGoogleSignInPlugin.register(with: registry.registrar(forPlugin: "FLTGoogleSignInPlugin"))

--- a/peppercheck_flutter/pubspec.lock
+++ b/peppercheck_flutter/pubspec.lock
@@ -494,6 +494,54 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.12.0"
+  flutter_image_compress:
+    dependency: "direct main"
+    description:
+      name: flutter_image_compress
+      sha256: "51d23be39efc2185e72e290042a0da41aed70b14ef97db362a6b5368d0523b27"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.0"
+  flutter_image_compress_common:
+    dependency: transitive
+    description:
+      name: flutter_image_compress_common
+      sha256: c5c5d50c15e97dd7dc72ff96bd7077b9f791932f2076c5c5b6c43f2c88607bfb
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.6"
+  flutter_image_compress_macos:
+    dependency: transitive
+    description:
+      name: flutter_image_compress_macos
+      sha256: "20019719b71b743aba0ef874ed29c50747461e5e8438980dfa5c2031898f7337"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.3"
+  flutter_image_compress_ohos:
+    dependency: transitive
+    description:
+      name: flutter_image_compress_ohos
+      sha256: e76b92bbc830ee08f5b05962fc78a532011fcd2041f620b5400a593e96da3f51
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.0.3"
+  flutter_image_compress_platform_interface:
+    dependency: transitive
+    description:
+      name: flutter_image_compress_platform_interface
+      sha256: "579cb3947fd4309103afe6442a01ca01e1e6f93dc53bb4cbd090e8ce34a41889"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.5"
+  flutter_image_compress_web:
+    dependency: transitive
+    description:
+      name: flutter_image_compress_web
+      sha256: b9b141ac7c686a2ce7bb9a98176321e1182c9074650e47bb140741a44b6f5a96
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.5"
   flutter_lints:
     dependency: "direct dev"
     description:

--- a/peppercheck_flutter/pubspec.yaml
+++ b/peppercheck_flutter/pubspec.yaml
@@ -62,6 +62,7 @@ dependencies:
   dio: ^5.9.0
   image_picker: ^1.2.1
   image_cropper: ^9.1.0
+  flutter_image_compress: ^2.4.0
   confetti: ^0.8.0
   mime: ^2.0.0
   in_app_purchase_android: ^0.4.0+10

--- a/peppercheck_flutter/test/features/evidence/data/image_normalizer_test.dart
+++ b/peppercheck_flutter/test/features/evidence/data/image_normalizer_test.dart
@@ -216,5 +216,51 @@ void main() {
         throwsA(isA<ImageProcessingException>()),
       );
     });
+
+    test(
+      'throws ImageProcessingException when encoder returns empty bytes',
+      () async {
+        final fakeXFile = XFile.fromData(
+          Uint8List.fromList([0x01]),
+          path: 'photo.jpg',
+        );
+
+        Future<Uint8List> emptyEncode(
+          Uint8List bytes,
+          int longestSide,
+          int quality,
+        ) async {
+          return Uint8List(0);
+        }
+
+        expect(
+          () => ImageNormalizer(encode: emptyEncode).normalize(fakeXFile),
+          throwsA(isA<ImageProcessingException>()),
+        );
+      },
+    );
+
+    test('preserves original exception as cause', () async {
+      final fakeXFile = XFile.fromData(
+        Uint8List.fromList([0x01]),
+        path: 'photo.jpg',
+      );
+      final originalError = StateError('codec gone');
+
+      Future<Uint8List> failingEncode(
+        Uint8List bytes,
+        int longestSide,
+        int quality,
+      ) async {
+        throw originalError;
+      }
+
+      try {
+        await ImageNormalizer(encode: failingEncode).normalize(fakeXFile);
+        fail('expected ImageProcessingException');
+      } on ImageProcessingException catch (e) {
+        expect(e.cause, same(originalError));
+      }
+    });
   });
 }

--- a/peppercheck_flutter/test/features/evidence/data/image_normalizer_test.dart
+++ b/peppercheck_flutter/test/features/evidence/data/image_normalizer_test.dart
@@ -85,5 +85,54 @@ void main() {
 
       expect(result.bytes, equals(step2Bytes));
     });
+
+    test(
+      'falls back to step 3 (1024px) when steps 1 and 2 exceed 5MB',
+      () async {
+        final fakeXFile = XFile.fromData(
+          Uint8List.fromList([0x01]),
+          path: 'photo.jpg',
+        );
+        final step3Bytes = Uint8List(3 * 1024 * 1024); // 3MB
+
+        Future<Uint8List> fakeEncode(
+          Uint8List bytes,
+          int longestSide,
+          int quality,
+        ) async {
+          if (longestSide == 2048) return Uint8List(6 * 1024 * 1024);
+          if (longestSide == 1536) return Uint8List(6 * 1024 * 1024);
+          if (longestSide == 1024) return step3Bytes;
+          fail('unexpected longestSide: $longestSide');
+        }
+
+        final normalizer = ImageNormalizer(encode: fakeEncode);
+        final result = await normalizer.normalize(fakeXFile);
+
+        expect(result.bytes, equals(step3Bytes));
+      },
+    );
+
+    test('throws ImageTooLargeException when all 3 steps exceed 5MB', () async {
+      final fakeXFile = XFile.fromData(
+        Uint8List.fromList([0x01]),
+        path: 'photo.jpg',
+      );
+
+      Future<Uint8List> fakeEncode(
+        Uint8List bytes,
+        int longestSide,
+        int quality,
+      ) async {
+        return Uint8List(6 * 1024 * 1024);
+      }
+
+      final normalizer = ImageNormalizer(encode: fakeEncode);
+
+      expect(
+        () => normalizer.normalize(fakeXFile),
+        throwsA(isA<ImageTooLargeException>()),
+      );
+    });
   });
 }

--- a/peppercheck_flutter/test/features/evidence/data/image_normalizer_test.dart
+++ b/peppercheck_flutter/test/features/evidence/data/image_normalizer_test.dart
@@ -1,0 +1,35 @@
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:peppercheck_flutter/features/evidence/data/image_normalizer.dart';
+
+void main() {
+  group('NormalizedImage', () {
+    test('holds bytes, filename, and mimeType', () {
+      final bytes = Uint8List.fromList([0xFF, 0xD8, 0xFF]);
+      final image = NormalizedImage(
+        bytes: bytes,
+        filename: 'photo.jpg',
+        mimeType: 'image/jpeg',
+      );
+
+      expect(image.bytes, equals(bytes));
+      expect(image.filename, equals('photo.jpg'));
+      expect(image.mimeType, equals('image/jpeg'));
+    });
+  });
+
+  group('ImageTooLargeException', () {
+    test('is an Exception', () {
+      expect(ImageTooLargeException(), isA<Exception>());
+    });
+  });
+
+  group('ImageProcessingException', () {
+    test('is an Exception with reason', () {
+      final exception = ImageProcessingException('codec failed');
+      expect(exception, isA<Exception>());
+      expect(exception.toString(), contains('codec failed'));
+    });
+  });
+}

--- a/peppercheck_flutter/test/features/evidence/data/image_normalizer_test.dart
+++ b/peppercheck_flutter/test/features/evidence/data/image_normalizer_test.dart
@@ -135,4 +135,64 @@ void main() {
       );
     });
   });
+
+  group('ImageNormalizer.normalize - filename rewrite', () {
+    Future<Uint8List> tinyEncode(Uint8List bytes, int side, int q) async =>
+        Uint8List(1024); // 1KB, always under 5MB
+
+    test('rewrites .heic extension to .jpg', () async {
+      final fakeXFile = XFile.fromData(
+        Uint8List.fromList([0x01]),
+        path: 'photo.heic',
+      );
+      final result = await ImageNormalizer(
+        encode: tinyEncode,
+      ).normalize(fakeXFile);
+      expect(result.filename, equals('photo.jpg'));
+    });
+
+    test('rewrites .png extension to .jpg', () async {
+      final fakeXFile = XFile.fromData(
+        Uint8List.fromList([0x01]),
+        path: 'screenshot.png',
+      );
+      final result = await ImageNormalizer(
+        encode: tinyEncode,
+      ).normalize(fakeXFile);
+      expect(result.filename, equals('screenshot.jpg'));
+    });
+
+    test('keeps .jpg as-is', () async {
+      final fakeXFile = XFile.fromData(
+        Uint8List.fromList([0x01]),
+        path: 'photo.jpg',
+      );
+      final result = await ImageNormalizer(
+        encode: tinyEncode,
+      ).normalize(fakeXFile);
+      expect(result.filename, equals('photo.jpg'));
+    });
+
+    test('rewrites .HEIC (uppercase) to .jpg', () async {
+      final fakeXFile = XFile.fromData(
+        Uint8List.fromList([0x01]),
+        path: 'PHOTO.HEIC',
+      );
+      final result = await ImageNormalizer(
+        encode: tinyEncode,
+      ).normalize(fakeXFile);
+      expect(result.filename, equals('PHOTO.jpg'));
+    });
+
+    test('handles filename without extension', () async {
+      final fakeXFile = XFile.fromData(
+        Uint8List.fromList([0x01]),
+        path: 'photo',
+      );
+      final result = await ImageNormalizer(
+        encode: tinyEncode,
+      ).normalize(fakeXFile);
+      expect(result.filename, equals('photo.jpg'));
+    });
+  });
 }

--- a/peppercheck_flutter/test/features/evidence/data/image_normalizer_test.dart
+++ b/peppercheck_flutter/test/features/evidence/data/image_normalizer_test.dart
@@ -1,6 +1,7 @@
 import 'dart:typed_data';
 
 import 'package:flutter_test/flutter_test.dart';
+import 'package:image_picker/image_picker.dart';
 import 'package:peppercheck_flutter/features/evidence/data/image_normalizer.dart';
 
 void main() {
@@ -31,5 +32,35 @@ void main() {
       expect(exception, isA<Exception>());
       expect(exception.toString(), contains('codec failed'));
     });
+  });
+
+  group('ImageNormalizer.normalize - happy path', () {
+    test(
+      'returns step 1 bytes when first encoded result is under 5MB',
+      () async {
+        final fakeXFile = XFile.fromData(
+          Uint8List.fromList([0x01, 0x02, 0x03]),
+          path: 'photo.jpg',
+        );
+        final encodedBytes = Uint8List(1024 * 1024); // 1MB
+
+        Future<Uint8List> fakeEncode(
+          Uint8List bytes,
+          int longestSide,
+          int quality,
+        ) async {
+          expect(longestSide, equals(2048));
+          expect(quality, equals(85));
+          return encodedBytes;
+        }
+
+        final normalizer = ImageNormalizer(encode: fakeEncode);
+        final result = await normalizer.normalize(fakeXFile);
+
+        expect(result.bytes, equals(encodedBytes));
+        expect(result.filename, equals('photo.jpg'));
+        expect(result.mimeType, equals('image/jpeg'));
+      },
+    );
   });
 }

--- a/peppercheck_flutter/test/features/evidence/data/image_normalizer_test.dart
+++ b/peppercheck_flutter/test/features/evidence/data/image_normalizer_test.dart
@@ -195,4 +195,26 @@ void main() {
       expect(result.filename, equals('photo.jpg'));
     });
   });
+
+  group('ImageNormalizer.normalize - error wrapping', () {
+    test('wraps encoder errors in ImageProcessingException', () async {
+      final fakeXFile = XFile.fromData(
+        Uint8List.fromList([0x01]),
+        path: 'photo.jpg',
+      );
+
+      Future<Uint8List> failingEncode(
+        Uint8List bytes,
+        int longestSide,
+        int quality,
+      ) async {
+        throw Exception('codec failed');
+      }
+
+      expect(
+        () => ImageNormalizer(encode: failingEncode).normalize(fakeXFile),
+        throwsA(isA<ImageProcessingException>()),
+      );
+    });
+  });
 }

--- a/peppercheck_flutter/test/features/evidence/data/image_normalizer_test.dart
+++ b/peppercheck_flutter/test/features/evidence/data/image_normalizer_test.dart
@@ -62,5 +62,28 @@ void main() {
         expect(result.mimeType, equals('image/jpeg'));
       },
     );
+
+    test('falls back to step 2 (1536px) when step 1 exceeds 5MB', () async {
+      final fakeXFile = XFile.fromData(
+        Uint8List.fromList([0x01]),
+        path: 'photo.jpg',
+      );
+      final step2Bytes = Uint8List(2 * 1024 * 1024); // 2MB
+
+      Future<Uint8List> fakeEncode(
+        Uint8List bytes,
+        int longestSide,
+        int quality,
+      ) async {
+        if (longestSide == 2048) return Uint8List(6 * 1024 * 1024); // 6MB
+        if (longestSide == 1536) return step2Bytes;
+        fail('unexpected longestSide: $longestSide');
+      }
+
+      final normalizer = ImageNormalizer(encode: fakeEncode);
+      final result = await normalizer.normalize(fakeXFile);
+
+      expect(result.bytes, equals(step2Bytes));
+    });
   });
 }

--- a/peppercheck_flutter/test/features/evidence/presentation/controllers/evidence_submission_state_test.dart
+++ b/peppercheck_flutter/test/features/evidence/presentation/controllers/evidence_submission_state_test.dart
@@ -1,0 +1,82 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:peppercheck_flutter/features/evidence/presentation/controllers/evidence_submission_state.dart';
+
+void main() {
+  group('EvidenceSubmissionState.isLoading', () {
+    test('idle is not loading', () {
+      expect(const EvidenceSubmissionState.idle().isLoading, isFalse);
+    });
+    test('preparing is loading', () {
+      expect(
+        const EvidenceSubmissionState.preparing(current: 1, total: 3).isLoading,
+        isTrue,
+      );
+    });
+    test('uploading is loading', () {
+      expect(
+        const EvidenceSubmissionState.uploading(current: 2, total: 3).isLoading,
+        isTrue,
+      );
+    });
+  });
+
+  group('EvidenceSubmissionState discriminators', () {
+    test('isPreparing flags only the preparing variant', () {
+      expect(const EvidenceSubmissionState.idle().isPreparing, isFalse);
+      expect(
+        const EvidenceSubmissionState.preparing(
+          current: 1,
+          total: 1,
+        ).isPreparing,
+        isTrue,
+      );
+      expect(
+        const EvidenceSubmissionState.uploading(
+          current: 1,
+          total: 1,
+        ).isPreparing,
+        isFalse,
+      );
+    });
+
+    test('isUploading flags only the uploading variant', () {
+      expect(const EvidenceSubmissionState.idle().isUploading, isFalse);
+      expect(
+        const EvidenceSubmissionState.preparing(
+          current: 1,
+          total: 1,
+        ).isUploading,
+        isFalse,
+      );
+      expect(
+        const EvidenceSubmissionState.uploading(
+          current: 1,
+          total: 1,
+        ).isUploading,
+        isTrue,
+      );
+    });
+  });
+
+  group('EvidenceSubmissionState.progress', () {
+    test('idle returns null', () {
+      expect(const EvidenceSubmissionState.idle().progress, isNull);
+    });
+    test('preparing returns current/total record', () {
+      final p = const EvidenceSubmissionState.preparing(
+        current: 2,
+        total: 5,
+      ).progress;
+      expect(p?.current, equals(2));
+      expect(p?.total, equals(5));
+    });
+    test('uploading returns current/total record', () {
+      final p = const EvidenceSubmissionState.uploading(
+        current: 3,
+        total: 5,
+      ).progress;
+      expect(p?.current, equals(3));
+      expect(p?.total, equals(5));
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Replaces the hard-error dialog when an evidence image exceeds the 5MB Edge Function limit with a graceful client-side normalization pipeline.

- Always re-encodes to JPEG (quality 85%, longest side 2048px). HEIC → JPEG conversion is automatic.
- 3-step fallback (2048 → 1536 → 1024px) for the rare case the first encode still exceeds 5MB.
- Muted progress text below the submit button: 「画像を準備中... (n/m)」 → 「アップロード中... (n/m)」
- Friendly error messages mapped from \`ImageTooLargeException\` / \`ImageProcessingException\`.
- 16 new unit tests; all 104 project tests pass.

Spec: [\`docs/superpowers/specs/2026-04-29-evidence-image-resize-design.md\`](docs/superpowers/specs/2026-04-29-evidence-image-resize-design.md)

## Test plan

- [x] Android — typical JPEG photo (~3MB) → submit succeeds, progress text visible
- [x] Android — large photo (~10MB) → fallback works, submit succeeds
- [ ] iPhone (if available) — HEIC source → uploads as JPEG
- [x] Multi-image (3–5) → progress shows \`(n/m)\`
- [ ] Edit and Resubmit flows — progress visible
- [ ] Description-only edit / asset-removal-only edit — spinner visible (regression-tested)
- [ ] Evidence timeout confirm — spinner visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)