### PR TITLE
feat(flutter): hide payout info card until Connect setup is complete

### DIFF
--- a/docs/superpowers/specs/2026-05-03-payout-card-gating-design.md
+++ b/docs/superpowers/specs/2026-05-03-payout-card-gating-design.md
@@ -1,0 +1,100 @@
+# Payout Info Card: Gate on Stripe Connect Setup Completion
+
+**Date:** 2026-05-03
+
+## Problem
+
+On the Wallet screen, the **ポイント・報酬** (`PaymentSummarySection`) currently shows a payout info card with two rows:
+
+- **直近** — most recent `reward_payouts` row (any status)
+- **次回振り込み予定** — last day of the current month, computed unconditionally
+
+This card is visible even when the user has not finished Stripe Connect onboarding (i.e. `payouts_enabled = false`). Two concrete problems result:
+
+1. **A future payout date is shown to a user whose payouts will not happen.** The same screen has a separate **出金設定** section that says "報酬を受け取るには決済サービスStripeでの出金設定が必要です。" The mismatch — "you need to set this up" *and* "your next payout is on 5/31" — is contradictory and confusing.
+2. **A skipped past payout is rendered as "直近 ¥X (スキップ)".** For a first-time user who hasn't onboarded, this looks like a failure rather than the expected outcome of an unfinished setup.
+
+The skip behavior itself is correct: `prepare_monthly_payouts()` (`supabase/schemas/reward/functions/prepare_monthly_payouts.sql`) checks `stripe_accounts.payouts_enabled` per user and inserts a `status='skipped'` row without calling `stripe.transfers.create`. No Stripe instruction is sent. So the issue is purely a UI confusion: we show information that implies an active payout pipeline when there is none.
+
+## Design
+
+### Change
+
+**`peppercheck_flutter/lib/features/payment_dashboard/presentation/widgets/payment_summary_section.dart`** — gate the payout info card on Stripe Connect setup completion.
+
+1. Convert `_SummaryContent` from `StatelessWidget` to `ConsumerWidget` so it can read `payoutControllerProvider`.
+2. Read the existing payout setup status:
+   ```dart
+   final isPayoutSetupComplete =
+       ref.watch(payoutControllerProvider).value?.isComplete ?? false;
+   ```
+3. AND this into the existing visibility condition for the payout info `BaseCard`:
+   ```dart
+   if (isPayoutSetupComplete &&
+       (summary.recentPayout != null ||
+           (summary.rewards != null && summary.rewards!.balance > 0))) ...
+   ```
+
+The reward-balance + total-earned row, the trial/regular points card, and the obligations card are **not** changed — they remain visible regardless of payout setup state.
+
+### Why frontend-only
+
+`payoutControllerProvider` is already watched on the same Wallet screen by `PayoutSetupSection`, so reading it from `PaymentSummarySection` adds no extra fetch. Keeping the gate in the UI avoids a `get_payment_summary()` migration and keeps the SQL function single-purpose (point/reward data only, not display policy).
+
+### Visibility matrix
+
+| `PayoutSetupStatus` | Payout info card | Reward balance / total earned | Points card | Obligations |
+|---|---|---|---|---|
+| `isNotStarted` | hidden | shown | shown | shown |
+| `isInProgress` | hidden | shown | shown | shown |
+| `isPendingVerification` | hidden | shown | shown | shown |
+| `isComplete` (and existing condition) | shown | shown | shown | shown |
+| AsyncLoading / AsyncError | hidden | shown | shown | shown |
+
+`isComplete` is defined as `chargesEnabled && payoutsEnabled` (see `peppercheck_flutter/lib/features/payout/domain/payout_setup_status.dart`). Only this state shows the payout card — the three intermediate states (`isInProgress`, `isPendingVerification`, `isNotStarted`) all hide it, since `prepare_monthly_payouts` skips them all.
+
+### Loading and error handling
+
+`value?.isComplete ?? false` collapses AsyncLoading and AsyncError into "hidden". This is intentional:
+
+- **Loading**: a brief flicker on revisit ("missing → appears") for already-set-up users is acceptable; showing a stale or guessed state is worse.
+- **Error**: errors in fetching Connect status are already surfaced by `PayoutSetupSection` directly above. Duplicating an error state in `PaymentSummarySection` would clutter the screen.
+
+### Edge cases
+
+- **Setup complete with `recentPayout.status='skipped'` in history.** The card shows "直近 ¥X (スキップ)". Intentional — we do not retroactively hide history once the user has earned the right to see their wallet activity.
+- **Setup transitions from complete → not complete** (Stripe re-verification, account flagged). The card disappears while in that state. This matches reality: the next month's payout *will* be skipped if the state persists.
+- **Setup just completed, reward balance is 0, no past payouts.** The existing inner condition (`recentPayout != null || balance > 0`) already keeps the card hidden. Behavior unchanged.
+
+### Files changed
+
+```
+peppercheck_flutter/
+  lib/features/payment_dashboard/presentation/widgets/
+    payment_summary_section.dart   # MODIFY: gate payout info card
+```
+
+No backend changes. No migrations. No new providers. No data model changes.
+
+### Tests
+
+There are no existing widget tests under `test/features/payment_dashboard/` — only a domain test for `PayoutSetupStatus` at `test/features/payout/domain/payout_setup_status_test.dart`, which is unaffected. The new gate is a pure conditional on an external provider; no new unit tests are added. Manual verification on the Android emulator covers the four `PayoutSetupStatus` states.
+
+### Manual verification
+
+On the Android emulator, with a test user, walk through each state:
+
+1. **`isNotStarted`** (no `stripe_accounts` row): payout info card is absent; reward balance + total earned are still shown.
+2. **`isInProgress`** (`charges_enabled=true`, `payouts_enabled=false`): card absent.
+3. **`isPendingVerification`** (`pending_verification` non-empty): card absent.
+4. **`isComplete`** (`charges_enabled=true`, `payouts_enabled=true`) with a non-zero reward balance: card present with "次回振り込み予定" row.
+5. **`isComplete`** with a `status='skipped'` historical row: "直近 ¥X (スキップ)" is shown alongside the next-payout row. (Intentional.)
+
+Build verification: `cd peppercheck_flutter && flutter build apk --debug -t lib/main_debug.dart`.
+
+### Out of scope
+
+- Changing `next_payout_date` computation in `get_payment_summary()`.
+- Changing `prepare_monthly_payouts()` skip behavior or the `notification_payout_connect_required_referee` flow.
+- Renaming `peppercheck_flutter/lib/features/billing/` to `point/` (tracked separately).
+- Web app parity: web does not currently render this section; no change needed.

--- a/docs/superpowers/specs/2026-05-03-payout-card-gating-design.md
+++ b/docs/superpowers/specs/2026-05-03-payout-card-gating-design.md
@@ -4,15 +4,15 @@
 
 ## Problem
 
-On the Wallet screen, the **ポイント・報酬** (`PaymentSummarySection`) currently shows a payout info card with two rows:
+On the Wallet screen, the Points & Rewards section (`PaymentSummarySection`) currently shows a payout info card with two rows:
 
-- **直近** — most recent `reward_payouts` row (any status)
-- **次回振り込み予定** — last day of the current month, computed unconditionally
+- **Recent payout** — most recent `reward_payouts` row (any status)
+- **Next payout date** — last day of the current month, computed unconditionally
 
 This card is visible even when the user has not finished Stripe Connect onboarding (i.e. `payouts_enabled = false`). Two concrete problems result:
 
-1. **A future payout date is shown to a user whose payouts will not happen.** The same screen has a separate **出金設定** section that says "報酬を受け取るには決済サービスStripeでの出金設定が必要です。" The mismatch — "you need to set this up" *and* "your next payout is on 5/31" — is contradictory and confusing.
-2. **A skipped past payout is rendered as "直近 ¥X (スキップ)".** For a first-time user who hasn't onboarded, this looks like a failure rather than the expected outcome of an unfinished setup.
+1. **A future payout date is shown to a user whose payouts will not happen.** The same screen has a separate Payout Setup section that already tells the user "rewards require Stripe Connect payout setup". The mismatch — "you need to set this up" *and* "your next payout is on 5/31" — is contradictory and confusing.
+2. **A skipped past payout is rendered as "Recent: ¥X (skipped)".** For a first-time user who hasn't onboarded, this looks like a failure rather than the expected outcome of an unfinished setup.
 
 The skip behavior itself is correct: `prepare_monthly_payouts()` (`supabase/schemas/reward/functions/prepare_monthly_payouts.sql`) checks `stripe_accounts.payouts_enabled` per user and inserts a `status='skipped'` row without calling `stripe.transfers.create`. No Stripe instruction is sent. So the issue is purely a UI confusion: we show information that implies an active payout pipeline when there is none.
 
@@ -32,7 +32,7 @@ The skip behavior itself is correct: `prepare_monthly_payouts()` (`supabase/sche
    ```
 3. AND this into the visibility condition for the payout info `BaseCard`.
 
-**(b) Always hide the "直近" row when the most recent payout has `status='skipped'`.**
+**(b) Always hide the recent-payout row when the most recent payout has `status='skipped'`.**
 
 A skipped payout is bookkeeping for "we did nothing because the account wasn't ready". The skip event is already communicated to the user via the `notification_payout_connect_required_referee` push notification at skip time; re-surfacing it on the wallet — especially right after Connect setup completes — produces a "did my setup not work?" moment of confusion. `success` / `pending` / `failed` continue to show.
 
@@ -45,7 +45,7 @@ final hasRewardBalance =
     summary.rewards != null && summary.rewards!.balance > 0;
 ```
 
-The outer guard, the inter-row spacer, and the inner "直近" `if` all key off these locals.
+The outer guard, the inter-row spacer, and the inner recent-payout `if` all key off these locals.
 
 The reward-balance + total-earned row, the trial/regular points card, and the obligations card are **not** changed — they remain visible regardless of payout setup state.
 
@@ -71,8 +71,8 @@ Row-level (within the card, when `isComplete`):
 
 | Row | Visible when |
 |---|---|
-| 直近 (recent payout) | `recentPayout != null` AND `recentPayout.status != 'skipped'` |
-| 次回振り込み予定 (next payout date) | `rewards != null` AND `rewards.balance > 0` |
+| Recent payout | `recentPayout != null` AND `recentPayout.status != 'skipped'` |
+| Next payout date | `rewards != null` AND `rewards.balance > 0` |
 
 ### Loading and error handling
 
@@ -83,8 +83,8 @@ Row-level (within the card, when `isComplete`):
 
 ### Edge cases
 
-- **Setup just completed, most recent payout in history is `status='skipped'`.** The "直近" row stays hidden (per (b) above). The "次回振り込み予定" row shows. Without (b) the user would see "直近 ¥X (スキップ)" right after celebrating completion — the most acute confusion case observed in emulator testing.
-- **Setup complete, latest payout is `skipped` but an older payout was `success`.** Backend `get_payment_summary()` returns the latest row only, so the older success is not reachable through this view. The 直近 row is hidden; the user still sees 累計受取額 and 次回振り込み予定. Acceptable: this state is rare (success → re-verification → another skip cycle) and 累計受取額 still confirms past activity.
+- **Setup just completed, most recent payout in history is `status='skipped'`.** The recent-payout row stays hidden (per (b) above). The next-payout-date row shows. Without (b) the user would see "Recent: ¥X (skipped)" right after celebrating completion — the most acute confusion case observed in emulator testing.
+- **Setup complete, latest payout is `skipped` but an older payout was `success`.** Backend `get_payment_summary()` returns the latest row only, so the older success is not reachable through this view. The recent-payout row is hidden; the user still sees the total-earned card and the next-payout-date row. Acceptable: this state is rare (success → re-verification → another skip cycle) and the total-earned card still confirms past activity.
 - **Setup transitions from complete → not complete** (Stripe re-verification, account flagged). The card disappears while in that state. This matches reality: the next month's payout *will* be skipped if the state persists.
 - **Setup just completed, reward balance is 0, no past payouts.** Outer guard `hasRecentPayoutToShow || hasRewardBalance` is false → card hidden. Behavior unchanged from before.
 - **`status='failed'` or `status='pending'` recent payout.** Shown unchanged. Failure requires user attention; pending is informational ("transfer in transit").
@@ -110,9 +110,9 @@ On the Android emulator, with a test user, walk through each state:
 1. **`isNotStarted`** (no `stripe_accounts` row): payout info card is absent; reward balance + total earned are still shown.
 2. **`isInProgress`** (`charges_enabled=true`, `payouts_enabled=false`): card absent.
 3. **`isPendingVerification`** (`pending_verification` non-empty): card absent.
-4. **`isComplete`** (`charges_enabled=true`, `payouts_enabled=true`) with a non-zero reward balance and no past payouts: card present with **only** "次回振り込み予定" row.
-5. **`isComplete`** with a `status='skipped'` recent row: 直近 row is **hidden**, next-payout row is shown. (Skipped suppression behavior — case (b).)
-6. **`isComplete`** with a `status='success'` recent row: 直近 row is shown ("直近 ¥X (成功) — YYYY/M/D"), next-payout row is shown.
+4. **`isComplete`** (`charges_enabled=true`, `payouts_enabled=true`) with a non-zero reward balance and no past payouts: card present with **only** the next-payout-date row.
+5. **`isComplete`** with a `status='skipped'` recent row: recent-payout row is **hidden**, next-payout row is shown. (Skipped suppression behavior — case (b).)
+6. **`isComplete`** with a `status='success'` recent row: recent-payout row is shown (e.g. "Recent: ¥X (success) — YYYY/M/D"), next-payout row is shown.
 
 Build verification: `cd peppercheck_flutter && flutter build apk --debug -t lib/main_debug.dart`.
 

--- a/docs/superpowers/specs/2026-05-03-payout-card-gating-design.md
+++ b/docs/superpowers/specs/2026-05-03-payout-card-gating-design.md
@@ -20,7 +20,9 @@ The skip behavior itself is correct: `prepare_monthly_payouts()` (`supabase/sche
 
 ### Change
 
-**`peppercheck_flutter/lib/features/payment_dashboard/presentation/widgets/payment_summary_section.dart`** — gate the payout info card on Stripe Connect setup completion.
+**`peppercheck_flutter/lib/features/payment_dashboard/presentation/widgets/payment_summary_section.dart`** — two coordinated changes:
+
+**(a) Gate the whole payout info card on Connect setup completion.**
 
 1. Convert `_SummaryContent` from `StatelessWidget` to `ConsumerWidget` so it can read `payoutControllerProvider`.
 2. Read the existing payout setup status:
@@ -28,12 +30,22 @@ The skip behavior itself is correct: `prepare_monthly_payouts()` (`supabase/sche
    final isPayoutSetupComplete =
        ref.watch(payoutControllerProvider).value?.isComplete ?? false;
    ```
-3. AND this into the existing visibility condition for the payout info `BaseCard`:
-   ```dart
-   if (isPayoutSetupComplete &&
-       (summary.recentPayout != null ||
-           (summary.rewards != null && summary.rewards!.balance > 0))) ...
-   ```
+3. AND this into the visibility condition for the payout info `BaseCard`.
+
+**(b) Always hide the "直近" row when the most recent payout has `status='skipped'`.**
+
+A skipped payout is bookkeeping for "we did nothing because the account wasn't ready". The skip event is already communicated to the user via the `notification_payout_connect_required_referee` push notification at skip time; re-surfacing it on the wallet — especially right after Connect setup completes — produces a "did my setup not work?" moment of confusion. `success` / `pending` / `failed` continue to show.
+
+This is implemented by introducing two local booleans in `_SummaryContent.build` and threading them through the existing condition tree:
+
+```dart
+final hasRecentPayoutToShow =
+    summary.recentPayout != null && summary.recentPayout!.status != 'skipped';
+final hasRewardBalance =
+    summary.rewards != null && summary.rewards!.balance > 0;
+```
+
+The outer guard, the inter-row spacer, and the inner "直近" `if` all key off these locals.
 
 The reward-balance + total-earned row, the trial/regular points card, and the obligations card are **not** changed — they remain visible regardless of payout setup state.
 
@@ -43,15 +55,24 @@ The reward-balance + total-earned row, the trial/regular points card, and the ob
 
 ### Visibility matrix
 
+Card-level (driven by `isPayoutSetupComplete`):
+
 | `PayoutSetupStatus` | Payout info card | Reward balance / total earned | Points card | Obligations |
 |---|---|---|---|---|
 | `isNotStarted` | hidden | shown | shown | shown |
 | `isInProgress` | hidden | shown | shown | shown |
 | `isPendingVerification` | hidden | shown | shown | shown |
-| `isComplete` (and existing condition) | shown | shown | shown | shown |
+| `isComplete` (and at least one inner row qualifies) | shown | shown | shown | shown |
 | AsyncLoading / AsyncError | hidden | shown | shown | shown |
 
 `isComplete` is defined as `chargesEnabled && payoutsEnabled` (see `peppercheck_flutter/lib/features/payout/domain/payout_setup_status.dart`). Only this state shows the payout card — the three intermediate states (`isInProgress`, `isPendingVerification`, `isNotStarted`) all hide it, since `prepare_monthly_payouts` skips them all.
+
+Row-level (within the card, when `isComplete`):
+
+| Row | Visible when |
+|---|---|
+| 直近 (recent payout) | `recentPayout != null` AND `recentPayout.status != 'skipped'` |
+| 次回振り込み予定 (next payout date) | `rewards != null` AND `rewards.balance > 0` |
 
 ### Loading and error handling
 
@@ -62,9 +83,11 @@ The reward-balance + total-earned row, the trial/regular points card, and the ob
 
 ### Edge cases
 
-- **Setup complete with `recentPayout.status='skipped'` in history.** The card shows "直近 ¥X (スキップ)". Intentional — we do not retroactively hide history once the user has earned the right to see their wallet activity.
+- **Setup just completed, most recent payout in history is `status='skipped'`.** The "直近" row stays hidden (per (b) above). The "次回振り込み予定" row shows. Without (b) the user would see "直近 ¥X (スキップ)" right after celebrating completion — the most acute confusion case observed in emulator testing.
+- **Setup complete, latest payout is `skipped` but an older payout was `success`.** Backend `get_payment_summary()` returns the latest row only, so the older success is not reachable through this view. The 直近 row is hidden; the user still sees 累計受取額 and 次回振り込み予定. Acceptable: this state is rare (success → re-verification → another skip cycle) and 累計受取額 still confirms past activity.
 - **Setup transitions from complete → not complete** (Stripe re-verification, account flagged). The card disappears while in that state. This matches reality: the next month's payout *will* be skipped if the state persists.
-- **Setup just completed, reward balance is 0, no past payouts.** The existing inner condition (`recentPayout != null || balance > 0`) already keeps the card hidden. Behavior unchanged.
+- **Setup just completed, reward balance is 0, no past payouts.** Outer guard `hasRecentPayoutToShow || hasRewardBalance` is false → card hidden. Behavior unchanged from before.
+- **`status='failed'` or `status='pending'` recent payout.** Shown unchanged. Failure requires user attention; pending is informational ("transfer in transit").
 
 ### Files changed
 
@@ -87,8 +110,9 @@ On the Android emulator, with a test user, walk through each state:
 1. **`isNotStarted`** (no `stripe_accounts` row): payout info card is absent; reward balance + total earned are still shown.
 2. **`isInProgress`** (`charges_enabled=true`, `payouts_enabled=false`): card absent.
 3. **`isPendingVerification`** (`pending_verification` non-empty): card absent.
-4. **`isComplete`** (`charges_enabled=true`, `payouts_enabled=true`) with a non-zero reward balance: card present with "次回振り込み予定" row.
-5. **`isComplete`** with a `status='skipped'` historical row: "直近 ¥X (スキップ)" is shown alongside the next-payout row. (Intentional.)
+4. **`isComplete`** (`charges_enabled=true`, `payouts_enabled=true`) with a non-zero reward balance and no past payouts: card present with **only** "次回振り込み予定" row.
+5. **`isComplete`** with a `status='skipped'` recent row: 直近 row is **hidden**, next-payout row is shown. (Skipped suppression behavior — case (b).)
+6. **`isComplete`** with a `status='success'` recent row: 直近 row is shown ("直近 ¥X (成功) — YYYY/M/D"), next-payout row is shown.
 
 Build verification: `cd peppercheck_flutter && flutter build apk --debug -t lib/main_debug.dart`.
 

--- a/peppercheck_flutter/lib/features/payment_dashboard/presentation/widgets/payment_summary_section.dart
+++ b/peppercheck_flutter/lib/features/payment_dashboard/presentation/widgets/payment_summary_section.dart
@@ -10,6 +10,7 @@ import 'package:peppercheck_flutter/common_widgets/base_section.dart';
 import 'package:peppercheck_flutter/common_widgets/help_icon_button.dart';
 import 'package:peppercheck_flutter/features/payment_dashboard/domain/payment_summary.dart';
 import 'package:peppercheck_flutter/features/payment_dashboard/presentation/payment_summary_controller.dart';
+import 'package:peppercheck_flutter/features/payout/presentation/payout_controller.dart';
 import 'package:peppercheck_flutter/gen/slang/strings.g.dart';
 
 class PaymentSummarySection extends ConsumerWidget {
@@ -35,14 +36,16 @@ class PaymentSummarySection extends ConsumerWidget {
   }
 }
 
-class _SummaryContent extends StatelessWidget {
+class _SummaryContent extends ConsumerWidget {
   final PaymentSummary summary;
 
   const _SummaryContent({required this.summary});
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final hasTrial = summary.trialPoints != null;
+    final isPayoutSetupComplete =
+        ref.watch(payoutControllerProvider).value?.isComplete ?? false;
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
@@ -192,9 +195,13 @@ class _SummaryContent extends StatelessWidget {
             ),
           ],
         ),
-        // Payout info — conditional rows
-        if (summary.recentPayout != null ||
-            (summary.rewards != null && summary.rewards!.balance > 0)) ...[
+        // Payout info — conditional rows. Hidden until Stripe Connect setup is complete
+        // so we don't show "next payout date" / skipped-payout history to users whose
+        // payouts will be skipped by prepare_monthly_payouts(). See spec
+        // 2026-05-03-payout-card-gating-design.md.
+        if (isPayoutSetupComplete &&
+            (summary.recentPayout != null ||
+                (summary.rewards != null && summary.rewards!.balance > 0))) ...[
           const SizedBox(height: AppSizes.baseCardGap),
           BaseCard(
             child: Row(

--- a/peppercheck_flutter/lib/features/payment_dashboard/presentation/widgets/payment_summary_section.dart
+++ b/peppercheck_flutter/lib/features/payment_dashboard/presentation/widgets/payment_summary_section.dart
@@ -195,10 +195,10 @@ class _SummaryContent extends ConsumerWidget {
             ),
           ],
         ),
-        // Payout info — conditional rows. Hidden until Stripe Connect setup is complete
-        // so we don't show "next payout date" / skipped-payout history to users whose
-        // payouts will be skipped by prepare_monthly_payouts(). See spec
-        // 2026-05-03-payout-card-gating-design.md.
+        // Payout info — conditional rows. Hidden until Stripe Connect setup is
+        // complete — prepare_monthly_payouts() skips these users, so a "next
+        // payout date" would mislead and a skipped past payout would look like
+        // a failure. See spec 2026-05-03-payout-card-gating-design.md.
         if (isPayoutSetupComplete &&
             (summary.recentPayout != null ||
                 (summary.rewards != null && summary.rewards!.balance > 0))) ...[

--- a/peppercheck_flutter/lib/features/payment_dashboard/presentation/widgets/payment_summary_section.dart
+++ b/peppercheck_flutter/lib/features/payment_dashboard/presentation/widgets/payment_summary_section.dart
@@ -202,10 +202,10 @@ class _SummaryContent extends ConsumerWidget {
         ),
         // Payout info — conditional rows. Hidden until Stripe Connect setup is
         // complete — prepare_monthly_payouts() skips these users, so a "next
-        // payout date" would mislead. The 直近 row also hides when the latest
-        // payout is 'skipped' since the skip event was already communicated
-        // via push notification and re-surfacing it on the wallet creates
-        // "did setup not work?" confusion. See spec
+        // payout date" would mislead. The recent-payout row also hides when
+        // the latest payout is 'skipped' since the skip event was already
+        // communicated via push notification and re-surfacing it on the
+        // wallet creates "did setup not work?" confusion. See spec
         // 2026-05-03-payout-card-gating-design.md.
         if (isPayoutSetupComplete &&
             (hasRecentPayoutToShow || hasRewardBalance)) ...[

--- a/peppercheck_flutter/lib/features/payment_dashboard/presentation/widgets/payment_summary_section.dart
+++ b/peppercheck_flutter/lib/features/payment_dashboard/presentation/widgets/payment_summary_section.dart
@@ -46,6 +46,11 @@ class _SummaryContent extends ConsumerWidget {
     final hasTrial = summary.trialPoints != null;
     final isPayoutSetupComplete =
         ref.watch(payoutControllerProvider).value?.isComplete ?? false;
+    final hasRecentPayoutToShow =
+        summary.recentPayout != null &&
+        summary.recentPayout!.status != 'skipped';
+    final hasRewardBalance =
+        summary.rewards != null && summary.rewards!.balance > 0;
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
@@ -197,11 +202,13 @@ class _SummaryContent extends ConsumerWidget {
         ),
         // Payout info — conditional rows. Hidden until Stripe Connect setup is
         // complete — prepare_monthly_payouts() skips these users, so a "next
-        // payout date" would mislead and a skipped past payout would look like
-        // a failure. See spec 2026-05-03-payout-card-gating-design.md.
+        // payout date" would mislead. The 直近 row also hides when the latest
+        // payout is 'skipped' since the skip event was already communicated
+        // via push notification and re-surfacing it on the wallet creates
+        // "did setup not work?" confusion. See spec
+        // 2026-05-03-payout-card-gating-design.md.
         if (isPayoutSetupComplete &&
-            (summary.recentPayout != null ||
-                (summary.rewards != null && summary.rewards!.balance > 0))) ...[
+            (hasRecentPayoutToShow || hasRewardBalance)) ...[
           const SizedBox(height: AppSizes.baseCardGap),
           BaseCard(
             child: Row(
@@ -216,19 +223,16 @@ class _SummaryContent extends ConsumerWidget {
                   child: Column(
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
-                      if (summary.recentPayout != null) ...[
+                      if (hasRecentPayoutToShow) ...[
                         _PayoutRow(
                           label: t.dashboard.recentPayout,
                           value:
                               '${_formatCurrency(summary.recentPayout!.amountMinor, summary.recentPayout!.currencyCode, summary.recentPayout!.currencyExponent)} (${_payoutStatusLabel(summary.recentPayout!.status)}) — ${_formatDate(summary.recentPayout!.batchDate)}',
                         ),
                       ],
-                      if (summary.recentPayout != null &&
-                          summary.rewards != null &&
-                          summary.rewards!.balance > 0)
+                      if (hasRecentPayoutToShow && hasRewardBalance)
                         const SizedBox(height: 4),
-                      if (summary.rewards != null &&
-                          summary.rewards!.balance > 0) ...[
+                      if (hasRewardBalance) ...[
                         _PayoutRow(
                           label: t.dashboard.nextPayout,
                           value: _formatDate(summary.nextPayoutDate),


### PR DESCRIPTION
## Summary

- On the Wallet screen's points & rewards card, hide the payout info rows (recent payout / next payout date) until Stripe Connect onboarding is complete (`payouts_enabled=true`). The reward balance and total earned remain visible in all states.
- Within the card, always hide the recent-payout row when the most recent `reward_payouts.status == 'skipped'`. The skip event is already communicated via the `notification_payout_connect_required_referee` push notification at skip time, and re-surfacing it on the wallet — especially right after Connect setup completes — reads as failure on top of fresh success. `success` / `pending` / `failed` continue to display.
- Frontend-only change. No backend, no migrations, no new providers.

## Why

`prepare_monthly_payouts()` already skips users whose Connect account is not ready (`status='skipped'`, no Stripe transfer). The UI was nevertheless showing a future "next payout date" and a past "recent (skipped)" row to those users, which contradicted the same screen's payout-setup section telling them to finish onboarding.

## Spec

`docs/superpowers/specs/2026-05-03-payout-card-gating-design.md`

## Related

Issue #383 — `chore(supabase): return next_payout_date as null when Connect setup is not complete`. The frontend gate in this PR is sufficient for the Flutter app; #383 covers making the SQL function honest at the data layer for any future consumer.

## Test Plan

Manual verification on Android emulator:

- [x] `isNotStarted` (no `stripe_accounts` row): payout card absent; reward balance + total earned visible.
- [x] `isInProgress` (`charges_enabled=true`, `payouts_enabled=false`): payout card absent.
- [x] `isComplete` with non-zero reward balance, no past payouts: card shows only the next-payout-date row.
- [x] `isComplete` with `status='skipped'` recent row: recent-payout row hidden, next-payout-date row visible.
- [x] `isComplete` with `status='success'` recent row: recent-payout row visible.
- [x] `flutter analyze` clean on modified file.
- [x] `flutter build apk --debug -t lib/main_debug.dart` builds successfully.
- [x] `flutter test`: all 104 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)