### PR TITLE
feat: order home task cards by due_date then created_at

### DIFF
--- a/docs/superpowers/specs/2026-05-04-home-task-card-ordering-design.md
+++ b/docs/superpowers/specs/2026-05-04-home-task-card-ordering-design.md
@@ -1,0 +1,80 @@
+# Home Screen Task Card Ordering
+
+**Date:** 2026-05-04
+
+## Problem
+
+The home screen lists tasks in an order that does not reflect urgency:
+
+- **Your Tasks** (`activeUserTasksProvider`) is sorted by `created_at DESC` (newest first), so a task due tomorrow can sit below a freshly created draft.
+- **Referee Tasks** (`activeRefereeTasksProvider`) has no `ORDER BY` in the RPC, so the order is undefined and may change between calls.
+
+The `tasks.due_date` column already exists on every task and is the natural signal for "what should I look at next?". It is currently used only for display in `TaskCard`.
+
+## Design
+
+### Sort rule (applied to both sections)
+
+```
+1. due_date IS NOT NULL → ascending by due_date (closest first; past-due tasks naturally float to the top)
+2. due_date IS NULL     → ascending by created_at (oldest drafts first)
+3. NULL bucket sits below the non-NULL bucket
+```
+
+Tie-break inside each bucket is `created_at ASC`.
+
+### Why this rule
+
+- The user's mental model on home is "what is most urgent". Soonest `due_date` matches that.
+- Past-due (overdue) tasks have the smallest `due_date` value, so ascending order surfaces them first without a separate code path.
+- For drafts (`due_date` is currently only NULL on tasker-side drafts), older drafts float higher because they have been sitting unattended longest. Pushing them below scheduled tasks keeps the "next action" focus near the top.
+
+### Implementation
+
+**1. Your Tasks — DB query (`task_repository.dart:103`)**
+
+Replace the single `.order('created_at', ascending: false)` with a chained order:
+
+```dart
+.order('due_date', ascending: true, nullsFirst: false)
+.order('created_at', ascending: true)
+```
+
+`nullsFirst: false` puts NULL `due_date` rows at the bottom; the second `.order()` becomes the tie-breaker.
+
+**2. Referee Tasks — RPC function (`get_active_referee_tasks.sql`)**
+
+Add an `ORDER BY` inside the `jsonb_agg(...)`:
+
+```sql
+jsonb_agg(
+  jsonb_build_object(...)
+  ORDER BY t.due_date ASC NULLS LAST, t.created_at ASC
+)
+```
+
+Generate the migration with `supabase db diff -f reorder_active_referee_tasks_by_due_date` and review before commit.
+
+### Tests
+
+- **pgTAP test (`supabase/tests/database/`)**: insert a fixture set with mixed `due_date` values (past, near, far, NULL) and assert that `get_active_referee_tasks` returns them in the expected order, including the `created_at` tie-break.
+- **Flutter side**: no new automated test. Verified manually on emulator at the integration step (per the consolidated emulator verification policy).
+
+### Files changed
+
+```
+peppercheck_flutter/
+  lib/features/task/data/task_repository.dart        # MODIFY: chain order by due_date then created_at
+
+supabase/
+  schemas/matching/functions/get_active_referee_tasks.sql  # MODIFY: ORDER BY inside jsonb_agg
+  migrations/<generated>_reorder_active_referee_tasks_by_due_date.sql  # NEW: auto-generated
+  tests/database/<new>.sql                           # NEW: pgTAP coverage for ordering
+```
+
+### Out of scope
+
+- Adding a UI affordance for overdue tasks (e.g., red badge).
+- Re-ordering other task lists (task detail, evidence list, payouts).
+- Letting users pick a sort order.
+- Backfilling `due_date` on legacy NULL rows.

--- a/peppercheck_flutter/lib/features/task/data/task_repository.dart
+++ b/peppercheck_flutter/lib/features/task/data/task_repository.dart
@@ -100,7 +100,8 @@ class TaskRepository {
           ''')
           .eq('tasker_id', userId)
           .neq('status', 'closed')
-          .order('created_at', ascending: false);
+          .order('due_date', ascending: true, nullsFirst: false)
+          .order('created_at', ascending: true);
 
       return (data as List).map((json) {
         final Map<String, dynamic> taskJson = Map<String, dynamic>.from(json);

--- a/supabase/migrations/20260503205120_reorder_active_referee_tasks_by_due_date.sql
+++ b/supabase/migrations/20260503205120_reorder_active_referee_tasks_by_due_date.sql
@@ -1,7 +1,10 @@
-CREATE OR REPLACE FUNCTION public.get_active_referee_tasks() RETURNS jsonb
-    LANGUAGE sql
-    SET search_path = ''
-    AS $$
+set check_function_bodies = off;
+
+CREATE OR REPLACE FUNCTION public.get_active_referee_tasks()
+ RETURNS jsonb
+ LANGUAGE sql
+ SET search_path TO ''
+AS $function$
   SELECT COALESCE(
     jsonb_agg(
       jsonb_build_object(
@@ -44,6 +47,7 @@ CREATE OR REPLACE FUNCTION public.get_active_referee_tasks() RETURNS jsonb
   WHERE
     trr.matched_referee_id = auth.uid()
     AND trr.status IN ('matched', 'accepted');
-$$;
+$function$
+;
 
-ALTER FUNCTION public.get_active_referee_tasks() OWNER TO postgres;
+

--- a/supabase/tests/database/get_active_referee_tasks.test.sql
+++ b/supabase/tests/database/get_active_referee_tasks.test.sql
@@ -1,9 +1,10 @@
 begin;
 create extension if not exists pgtap with schema extensions;
-select plan(5);
+select plan(6);
 
 -- ============================================================
--- Setup: one tasker + one referee + 4 matched tasks with mixed due_date values
+-- Setup: one tasker + one referee + 6 matched tasks covering every
+-- branch of the ordering rule (overdue, non-NULL-bucket tie, far, NULL-bucket tie)
 -- ============================================================
 delete from auth.users where id in (
   'bb000001-0000-0000-0000-000000000000',
@@ -15,16 +16,18 @@ values
   ('bb000001-0000-0000-0000-000000000000', 'tasker@test.com',  '00000000-0000-0000-0000-000000000000', 'authenticated', 'authenticated', crypt('password123', gen_salt('bf')), now(), now(), now()),
   ('bb000002-0000-0000-0000-000000000000', 'referee@test.com', '00000000-0000-0000-0000-000000000000', 'authenticated', 'authenticated', crypt('password123', gen_salt('bf')), now(), now(), now());
 
--- Insert tasks in the OPPOSITE of the expected return order so the test
--- fails reliably without an explicit ORDER BY in the RPC.
--- created_at offsets are also crafted so the NULL-bucket tie-break (created_at ASC) is observable.
+-- Insert tasks in roughly the OPPOSITE of the expected return order so the
+-- test would fail reliably without an explicit ORDER BY in the RPC.
+-- "Near Older" / "Near Newer" share the same due_date so the non-NULL-bucket
+-- tie-break (created_at ASC) is observable; same idea for "Null Older" / "Null Newer".
 insert into public.tasks (id, tasker_id, title, status, due_date, created_at)
 values
-  ('bb100001-0000-0000-0000-000000000000', 'bb000001-0000-0000-0000-000000000000', 'Null Older',  'open', null,                        now() - interval '10 days'),
-  ('bb100002-0000-0000-0000-000000000000', 'bb000001-0000-0000-0000-000000000000', 'Null Newer',  'open', null,                        now() - interval '1 day'),
-  ('bb100003-0000-0000-0000-000000000000', 'bb000001-0000-0000-0000-000000000000', 'Far Future',  'open', now() + interval '30 days',  now() - interval '5 days'),
-  ('bb100004-0000-0000-0000-000000000000', 'bb000001-0000-0000-0000-000000000000', 'Near Future', 'open', now() + interval '1 day',    now() - interval '4 days'),
-  ('bb100005-0000-0000-0000-000000000000', 'bb000001-0000-0000-0000-000000000000', 'Overdue',     'open', now() - interval '2 days',   now() - interval '3 days');
+  ('bb100001-0000-0000-0000-000000000000', 'bb000001-0000-0000-0000-000000000000', 'Null Older', 'open', null,                       now() - interval '10 days'),
+  ('bb100002-0000-0000-0000-000000000000', 'bb000001-0000-0000-0000-000000000000', 'Null Newer', 'open', null,                       now() - interval '1 day'),
+  ('bb100003-0000-0000-0000-000000000000', 'bb000001-0000-0000-0000-000000000000', 'Far Future', 'open', now() + interval '30 days', now() - interval '5 days'),
+  ('bb100004-0000-0000-0000-000000000000', 'bb000001-0000-0000-0000-000000000000', 'Near Older', 'open', now() + interval '1 day',   now() - interval '4 days'),
+  ('bb100006-0000-0000-0000-000000000000', 'bb000001-0000-0000-0000-000000000000', 'Near Newer', 'open', now() + interval '1 day',   now() - interval '2 days'),
+  ('bb100005-0000-0000-0000-000000000000', 'bb000001-0000-0000-0000-000000000000', 'Overdue',    'open', now() - interval '2 days',  now() - interval '3 days');
 
 insert into public.task_referee_requests (id, task_id, matching_strategy, matched_referee_id, status)
 values
@@ -32,6 +35,7 @@ values
   ('bb200002-0000-0000-0000-000000000000', 'bb100002-0000-0000-0000-000000000000', 'standard', 'bb000002-0000-0000-0000-000000000000', 'matched'),
   ('bb200003-0000-0000-0000-000000000000', 'bb100003-0000-0000-0000-000000000000', 'standard', 'bb000002-0000-0000-0000-000000000000', 'matched'),
   ('bb200004-0000-0000-0000-000000000000', 'bb100004-0000-0000-0000-000000000000', 'standard', 'bb000002-0000-0000-0000-000000000000', 'matched'),
+  ('bb200006-0000-0000-0000-000000000000', 'bb100006-0000-0000-0000-000000000000', 'standard', 'bb000002-0000-0000-0000-000000000000', 'matched'),
   ('bb200005-0000-0000-0000-000000000000', 'bb100005-0000-0000-0000-000000000000', 'standard', 'bb000002-0000-0000-0000-000000000000', 'matched');
 
 -- Authenticate as the referee
@@ -40,66 +44,57 @@ select set_config('request.jwt.claims', '{"sub": "bb000002-0000-0000-0000-000000
 -- ============================================================
 -- Test: get_active_referee_tasks returns tasks ordered by
 --       due_date ASC NULLS LAST, created_at ASC
--- Expected order: Overdue → Near Future → Far Future → Null Older → Null Newer
+-- Expected order:
+--   1. Overdue     (smallest due_date)
+--   2. Near Older  (next due_date; older created_at within the tie)
+--   3. Near Newer  (same due_date as Near Older; newer created_at)
+--   4. Far Future
+--   5. Null Older  (NULL bucket; older created_at)
+--   6. Null Newer  (NULL bucket; newer created_at)
 -- ============================================================
-with ordered as (
-  select
-    (elem ->> 'task')::jsonb ->> 'id' as task_id,
-    row_number() over () as pos
-  from jsonb_array_elements(public.get_active_referee_tasks()) as elem
-)
+
+-- Materialise the RPC output once and assert each position against the temp
+-- table; avoids re-running the function (and its joins) for every assertion.
+create temp table ordered_result on commit drop as
+select
+  (elem -> 'task') ->> 'id' as task_id,
+  row_number() over () as pos
+from jsonb_array_elements(public.get_active_referee_tasks()) as elem;
+
 select is(
-    (select task_id from ordered where pos = 1),
+    (select task_id from ordered_result where pos = 1),
     'bb100005-0000-0000-0000-000000000000',
     'Test 1: overdue task is first (smallest due_date)'
 );
 
-with ordered as (
-  select
-    (elem ->> 'task')::jsonb ->> 'id' as task_id,
-    row_number() over () as pos
-  from jsonb_array_elements(public.get_active_referee_tasks()) as elem
-)
 select is(
-    (select task_id from ordered where pos = 2),
+    (select task_id from ordered_result where pos = 2),
     'bb100004-0000-0000-0000-000000000000',
-    'Test 2: near-future task is second'
+    'Test 2: non-NULL bucket — older created_at first (Near Older)'
 );
 
-with ordered as (
-  select
-    (elem ->> 'task')::jsonb ->> 'id' as task_id,
-    row_number() over () as pos
-  from jsonb_array_elements(public.get_active_referee_tasks()) as elem
-)
 select is(
-    (select task_id from ordered where pos = 3),
+    (select task_id from ordered_result where pos = 3),
+    'bb100006-0000-0000-0000-000000000000',
+    'Test 3: non-NULL bucket — same due_date, newer created_at second (Near Newer)'
+);
+
+select is(
+    (select task_id from ordered_result where pos = 4),
     'bb100003-0000-0000-0000-000000000000',
-    'Test 3: far-future task is third'
+    'Test 4: far-future task is fourth'
 );
 
-with ordered as (
-  select
-    (elem ->> 'task')::jsonb ->> 'id' as task_id,
-    row_number() over () as pos
-  from jsonb_array_elements(public.get_active_referee_tasks()) as elem
-)
 select is(
-    (select task_id from ordered where pos = 4),
+    (select task_id from ordered_result where pos = 5),
     'bb100001-0000-0000-0000-000000000000',
-    'Test 4: NULL bucket — older created_at first (Null Older)'
+    'Test 5: NULL bucket — older created_at first (Null Older)'
 );
 
-with ordered as (
-  select
-    (elem ->> 'task')::jsonb ->> 'id' as task_id,
-    row_number() over () as pos
-  from jsonb_array_elements(public.get_active_referee_tasks()) as elem
-)
 select is(
-    (select task_id from ordered where pos = 5),
+    (select task_id from ordered_result where pos = 6),
     'bb100002-0000-0000-0000-000000000000',
-    'Test 5: NULL bucket — newer created_at last (Null Newer)'
+    'Test 6: NULL bucket — newer created_at last (Null Newer)'
 );
 
 select * from finish();

--- a/supabase/tests/database/get_active_referee_tasks.test.sql
+++ b/supabase/tests/database/get_active_referee_tasks.test.sql
@@ -1,0 +1,106 @@
+begin;
+create extension if not exists pgtap with schema extensions;
+select plan(5);
+
+-- ============================================================
+-- Setup: one tasker + one referee + 4 matched tasks with mixed due_date values
+-- ============================================================
+delete from auth.users where id in (
+  'bb000001-0000-0000-0000-000000000000',
+  'bb000002-0000-0000-0000-000000000000'
+);
+
+insert into auth.users (id, email, instance_id, aud, role, encrypted_password, email_confirmed_at, created_at, updated_at)
+values
+  ('bb000001-0000-0000-0000-000000000000', 'tasker@test.com',  '00000000-0000-0000-0000-000000000000', 'authenticated', 'authenticated', crypt('password123', gen_salt('bf')), now(), now(), now()),
+  ('bb000002-0000-0000-0000-000000000000', 'referee@test.com', '00000000-0000-0000-0000-000000000000', 'authenticated', 'authenticated', crypt('password123', gen_salt('bf')), now(), now(), now());
+
+-- Insert tasks in the OPPOSITE of the expected return order so the test
+-- fails reliably without an explicit ORDER BY in the RPC.
+-- created_at offsets are also crafted so the NULL-bucket tie-break (created_at ASC) is observable.
+insert into public.tasks (id, tasker_id, title, status, due_date, created_at)
+values
+  ('bb100001-0000-0000-0000-000000000000', 'bb000001-0000-0000-0000-000000000000', 'Null Older',  'open', null,                        now() - interval '10 days'),
+  ('bb100002-0000-0000-0000-000000000000', 'bb000001-0000-0000-0000-000000000000', 'Null Newer',  'open', null,                        now() - interval '1 day'),
+  ('bb100003-0000-0000-0000-000000000000', 'bb000001-0000-0000-0000-000000000000', 'Far Future',  'open', now() + interval '30 days',  now() - interval '5 days'),
+  ('bb100004-0000-0000-0000-000000000000', 'bb000001-0000-0000-0000-000000000000', 'Near Future', 'open', now() + interval '1 day',    now() - interval '4 days'),
+  ('bb100005-0000-0000-0000-000000000000', 'bb000001-0000-0000-0000-000000000000', 'Overdue',     'open', now() - interval '2 days',   now() - interval '3 days');
+
+insert into public.task_referee_requests (id, task_id, matching_strategy, matched_referee_id, status)
+values
+  ('bb200001-0000-0000-0000-000000000000', 'bb100001-0000-0000-0000-000000000000', 'standard', 'bb000002-0000-0000-0000-000000000000', 'matched'),
+  ('bb200002-0000-0000-0000-000000000000', 'bb100002-0000-0000-0000-000000000000', 'standard', 'bb000002-0000-0000-0000-000000000000', 'matched'),
+  ('bb200003-0000-0000-0000-000000000000', 'bb100003-0000-0000-0000-000000000000', 'standard', 'bb000002-0000-0000-0000-000000000000', 'matched'),
+  ('bb200004-0000-0000-0000-000000000000', 'bb100004-0000-0000-0000-000000000000', 'standard', 'bb000002-0000-0000-0000-000000000000', 'matched'),
+  ('bb200005-0000-0000-0000-000000000000', 'bb100005-0000-0000-0000-000000000000', 'standard', 'bb000002-0000-0000-0000-000000000000', 'matched');
+
+-- Authenticate as the referee
+select set_config('request.jwt.claims', '{"sub": "bb000002-0000-0000-0000-000000000000"}', true);
+
+-- ============================================================
+-- Test: get_active_referee_tasks returns tasks ordered by
+--       due_date ASC NULLS LAST, created_at ASC
+-- Expected order: Overdue → Near Future → Far Future → Null Older → Null Newer
+-- ============================================================
+with ordered as (
+  select
+    (elem ->> 'task')::jsonb ->> 'id' as task_id,
+    row_number() over () as pos
+  from jsonb_array_elements(public.get_active_referee_tasks()) as elem
+)
+select is(
+    (select task_id from ordered where pos = 1),
+    'bb100005-0000-0000-0000-000000000000',
+    'Test 1: overdue task is first (smallest due_date)'
+);
+
+with ordered as (
+  select
+    (elem ->> 'task')::jsonb ->> 'id' as task_id,
+    row_number() over () as pos
+  from jsonb_array_elements(public.get_active_referee_tasks()) as elem
+)
+select is(
+    (select task_id from ordered where pos = 2),
+    'bb100004-0000-0000-0000-000000000000',
+    'Test 2: near-future task is second'
+);
+
+with ordered as (
+  select
+    (elem ->> 'task')::jsonb ->> 'id' as task_id,
+    row_number() over () as pos
+  from jsonb_array_elements(public.get_active_referee_tasks()) as elem
+)
+select is(
+    (select task_id from ordered where pos = 3),
+    'bb100003-0000-0000-0000-000000000000',
+    'Test 3: far-future task is third'
+);
+
+with ordered as (
+  select
+    (elem ->> 'task')::jsonb ->> 'id' as task_id,
+    row_number() over () as pos
+  from jsonb_array_elements(public.get_active_referee_tasks()) as elem
+)
+select is(
+    (select task_id from ordered where pos = 4),
+    'bb100001-0000-0000-0000-000000000000',
+    'Test 4: NULL bucket — older created_at first (Null Older)'
+);
+
+with ordered as (
+  select
+    (elem ->> 'task')::jsonb ->> 'id' as task_id,
+    row_number() over () as pos
+  from jsonb_array_elements(public.get_active_referee_tasks()) as elem
+)
+select is(
+    (select task_id from ordered where pos = 5),
+    'bb100002-0000-0000-0000-000000000000',
+    'Test 5: NULL bucket — newer created_at last (Null Newer)'
+);
+
+select * from finish();
+rollback;


### PR DESCRIPTION
## Summary
- Sort home-screen task cards by `due_date ASC NULLS LAST`, with `created_at ASC` as the tie-break, on both Your Tasks and Referee Tasks sections.
- Adds an `ORDER BY` clause inside `jsonb_agg(...)` in `public.get_active_referee_tasks` and chains the PostgREST `.order()` call in `TaskRepository.fetchActiveUserTasks`.
- Adds a pgTAP test that locks in the new ordering contract for the RPC (overdue / non-NULL tie / far / NULL tie — 6 assertions).

Spec: `docs/superpowers/specs/2026-05-04-home-task-card-ordering-design.md`

## Test plan
- [x] New pgTAP test passes (6/6 assertions) and full pgTAP suite has no regressions
- [x] `flutter build apk --debug -t lib/main_debug.dart` succeeds
- [x] Seed mixed-`due_date` tasks and verify Your Tasks order on Android emulator
- [x] Seed matched referee tasks and verify Referee Tasks order on Android emulator
- [x] Pull-to-refresh preserves order on both sections

🤖 Generated with [Claude Code](https://claude.com/claude-code)