### PR TITLE
fix(flutter): add breathing room under floating bottom nav bar

### DIFF
--- a/docs/superpowers/specs/2026-05-05-bottom-nav-bottom-margin-design.md
+++ b/docs/superpowers/specs/2026-05-05-bottom-nav-bottom-margin-design.md
@@ -1,0 +1,128 @@
+# Bottom Navigation Bar Bottom Margin
+
+**Date:** 2026-05-05 (revised after first emulator verification)
+**Related issues:** Found during real-device testing on Android (3-button vs gesture navigation)
+
+## Problem
+
+The floating bottom navigation bar in `AppScaffold` looks visibly cramped on Android 3-button navigation and iOS home-button devices: the bar's rounded bottom edge sits only ~4px above the system UI strip (or screen edge). On Android gesture and iOS home-indicator devices, the same 4px gap looks fine because the system UI strip there is a thin gesture line rather than a bulky bar.
+
+## Root cause
+
+Original implementation in `lib/common_widgets/app_scaffold.dart`:
+
+```dart
+bottomNavigationBar: SafeArea(
+  child: Padding(
+    padding: const EdgeInsets.symmetric(
+      horizontal: AppSizes.screenHorizontalPadding,  // 16
+      vertical: AppSizes.screenVerticalPadding,      // 4
+    ),
+    child: Container(...),
+  ),
+),
+```
+
+Modern Flutter on Android (target SDK 35+) is edge-to-edge by default. `MediaQuery.padding.bottom` therefore reflects the *height of the system UI strip*, not zero:
+
+| Mode | `MediaQuery.padding.bottom` |
+|---|---|
+| Android 3-button | ~48dp (system nav bar height) |
+| Android gesture | ~24dp (gesture indicator height) |
+| iOS home indicator | ~34px |
+| iOS home button | 0 |
+
+`SafeArea` consumes that inset by pushing the bar up by exactly that much, so the bar's outer bottom edge ends up at the **top of the system UI strip**. The only visible breathing room above that strip is the `vertical: 4` bottom of the wrapping `Padding`. That 4px feels fine when the strip is a thin line (gesture / home indicator) and feels cramped when the strip is a bulky bar (3-button / home button — though "home button" devices have no inset, so the bar sits 4px from the screen edge, which also feels tight).
+
+The first attempted fix (`SafeArea(minimum: 12)`) was based on the incorrect assumption that `padding.bottom = 0` on 3-button mode, where the `minimum` would have raised the bar by 12px. In reality `padding.bottom = 48` on 3-button mode, so `max(48, 12) = 48` and the `minimum` never kicks in. Combined with dropping the `Padding`'s 4px bottom contribution, the bar ended up flush with the system nav bar (zero gap). This rewrite corrects that.
+
+## Design
+
+Treat the bottom margin as **system inset + breathing room**, not as a single max. The breathing room is the constant gap above whatever system UI strip exists at the bottom:
+
+```
+visible margin = MediaQuery.padding.bottom + breathingRoom
+```
+
+- On 3-button: `48 + 8 = 56px` total below the bar (8px breathing above the system nav bar).
+- On gesture: `24 + 8 = 32px` total (8px above the gesture indicator).
+- On iOS home indicator: `34 + 8 = 42px` total (8px above the indicator).
+- On iOS home button: `0 + 8 = 8px` total (8px above the screen edge).
+
+Implementation: keep the bare `SafeArea` (which consumes the inset), and set the wrapping `Padding`'s bottom to `breathingRoom` (12px). Apply the same `breathingRoom` term to the scroll-content bottom padding so the last list item never slides behind the bar.
+
+A renamed `AppSizes` constant centralizes the breathing room value. The previous misnamed `bottomNavigationBarMinBottomMargin` is replaced (it was implying `max(...)` semantics that we no longer use).
+
+### Changes
+
+**1. `lib/app/theme/app_sizes.dart`** — add constant
+
+```dart
+// Breathing room below the floating bottom navigation bar, applied
+// on top of the system safe-area inset. Keeps a visible gap above
+// the system nav strip (Android 3-button bar, gesture indicator,
+// iOS home indicator) and a non-cramped margin from the screen edge
+// on devices with no inset (iOS home button).
+static const double bottomNavigationBarBreathingRoom = 8.0;
+```
+
+**2. `lib/common_widgets/app_scaffold.dart`** — bare `SafeArea` + `Padding` with `bottom: breathingRoom`
+
+```dart
+bottomNavigationBar: SafeArea(
+  child: Padding(
+    padding: const EdgeInsets.fromLTRB(
+      AppSizes.screenHorizontalPadding,
+      AppSizes.screenVerticalPadding,                 // top: 4
+      AppSizes.screenHorizontalPadding,
+      AppSizes.bottomNavigationBarBreathingRoom,      // bottom: 12
+    ),
+    child: Container(...),
+  ),
+),
+```
+
+**3. `lib/common_widgets/app_scaffold.dart`** — scroll-content bottom padding adds the same breathing room
+
+```dart
+final bottomPadding =
+    AppSizes.bottomNavigationBarHeight +
+    MediaQuery.paddingOf(context).bottom +
+    AppSizes.bottomNavigationBarBreathingRoom;
+```
+
+### Resulting margins
+
+Margin = `MediaQuery.padding.bottom + breathingRoom`. The `+4` deltas come from breathing room growing 4 → 8.
+
+| Mode | Original | New | Delta |
+|---|---|---|---|
+| Android 3-button | ~52px (4px breathing) | ~56px (8px breathing) | +4 |
+| Android gesture | ~28px (4px breathing) | ~32px (8px breathing) | +4 |
+| iOS home indicator | ~38px (4px breathing) | ~42px (8px breathing) | +4 |
+| iOS home button | ~4px (4px breathing) | ~8px (8px breathing) | +4 |
+
+The +4 delta is a deliberate compromise: just enough to ease the cramped feel above the chunky 3-button system nav bar without noticeably altering the already-acceptable gesture/home-indicator look. The constant is the single tuning knob — adjust if real-device viewing suggests another value.
+
+### Files changed
+
+```
+peppercheck_flutter/
+  lib/app/theme/app_sizes.dart              # ADD: bottomNavigationBarBreathingRoom (replaces ...MinBottomMargin)
+  lib/common_widgets/app_scaffold.dart      # MODIFY: bare SafeArea + Padding bottom + scroll bottomPadding
+  test/common_widgets/app_scaffold_test.dart  # MODIFY: assertions reflect inset + breathingRoom formula
+```
+
+## Verification
+
+- Android 3-button emulator: visible breathing room above the system nav bar (was ~4px, now ~12px).
+- Android gesture emulator: bar sits a touch higher than before (28→36px), no regression in usability.
+- iOS simulator with home indicator (e.g. iPhone 15): bar sits a touch higher than before (38→46px).
+- iOS simulator without home indicator (e.g. iPhone SE): visible 12px gap from screen edge (was ~4px).
+- Last item of a long scroll list is fully visible above the bar in all modes.
+
+## Out of scope
+
+- Top padding (`screenVerticalPadding = 4`) of the bar — unchanged.
+- Tuning `bottomNavigationBarBreathingRoom` away from `12.0`. May revisit after real-device viewing.
+- Per-mode breathing rooms (e.g. smaller in gesture, larger in 3-button). Single value is intentional for simplicity.

--- a/peppercheck_flutter/lib/app/theme/app_sizes.dart
+++ b/peppercheck_flutter/lib/app/theme/app_sizes.dart
@@ -18,6 +18,12 @@ class AppSizes {
   // Height of the floating navigation bar container + padding
   static const double bottomNavigationBarHeight = 80.0;
   static const double bottomNavigationBarBorderRadius = 16.0;
+  // Breathing room below the floating bottom navigation bar, applied
+  // on top of the system safe-area inset. Keeps a visible gap above
+  // the system nav strip (Android 3-button bar, gesture indicator,
+  // iOS home indicator) and a non-cramped margin from the screen edge
+  // on devices with no inset (iOS home button).
+  static const double bottomNavigationBarBreathingRoom = 8.0;
 
   // BaseSection
   static const double baseSectionHorizontalPadding = 12.0;

--- a/peppercheck_flutter/lib/common_widgets/app_scaffold.dart
+++ b/peppercheck_flutter/lib/common_widgets/app_scaffold.dart
@@ -99,10 +99,11 @@ class AppScaffold extends StatelessWidget {
       body: _buildBody(context),
       bottomNavigationBar: SafeArea(
         child: Padding(
-          // Removed bottom padding as requested (was 8)
-          padding: const EdgeInsets.symmetric(
-            horizontal: AppSizes.screenHorizontalPadding,
-            vertical: AppSizes.screenVerticalPadding,
+          padding: const EdgeInsets.fromLTRB(
+            AppSizes.screenHorizontalPadding,
+            AppSizes.screenVerticalPadding,
+            AppSizes.screenHorizontalPadding,
+            AppSizes.bottomNavigationBarBreathingRoom,
           ),
           child: Container(
             decoration: BoxDecoration(
@@ -162,7 +163,8 @@ class AppScaffold extends StatelessWidget {
 
       final bottomPadding =
           AppSizes.bottomNavigationBarHeight +
-          MediaQuery.paddingOf(context).bottom;
+          MediaQuery.paddingOf(context).bottom +
+          AppSizes.bottomNavigationBarBreathingRoom;
 
       final scrollView = CustomScrollView(
         slivers: [

--- a/peppercheck_flutter/test/common_widgets/app_scaffold_test.dart
+++ b/peppercheck_flutter/test/common_widgets/app_scaffold_test.dart
@@ -1,0 +1,75 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:peppercheck_flutter/app/theme/app_sizes.dart';
+import 'package:peppercheck_flutter/common_widgets/app_scaffold.dart';
+import 'package:peppercheck_flutter/gen/slang/strings.g.dart';
+
+Widget _harness({required double bottomPadding, required Widget child}) {
+  return MaterialApp(
+    home: Builder(
+      builder: (context) {
+        return MediaQuery(
+          data: MediaQuery.of(
+            context,
+          ).copyWith(padding: EdgeInsets.only(bottom: bottomPadding)),
+          child: child,
+        );
+      },
+    ),
+  );
+}
+
+void main() {
+  setUpAll(() {
+    LocaleSettings.useDeviceLocale();
+  });
+
+  testWidgets(
+    'AppScaffold leaves breathing room when there is no system inset',
+    (tester) async {
+      await tester.pumpWidget(
+        _harness(
+          bottomPadding: 0,
+          child: const AppScaffold.fixed(body: SizedBox.shrink()),
+        ),
+      );
+
+      final scaffoldBottom = tester.getRect(find.byType(Scaffold)).bottom;
+      final navBarBottom = tester.getRect(find.byType(NavigationBar)).bottom;
+      final gap = scaffoldBottom - navBarBottom;
+
+      expect(
+        gap,
+        AppSizes.bottomNavigationBarBreathingRoom,
+        reason:
+            'With padding.bottom = 0, the only contribution to the gap is '
+            'the breathing room.',
+      );
+    },
+  );
+
+  testWidgets('AppScaffold adds breathing room on top of the system inset', (
+    tester,
+  ) async {
+    const systemInset = 30.0;
+
+    await tester.pumpWidget(
+      _harness(
+        bottomPadding: systemInset,
+        child: const AppScaffold.fixed(body: SizedBox.shrink()),
+      ),
+    );
+
+    final scaffoldBottom = tester.getRect(find.byType(Scaffold)).bottom;
+    final navBarBottom = tester.getRect(find.byType(NavigationBar)).bottom;
+    final gap = scaffoldBottom - navBarBottom;
+
+    expect(
+      gap,
+      systemInset + AppSizes.bottomNavigationBarBreathingRoom,
+      reason:
+          'The bar should sit breathingRoom above the system inset, not '
+          'flush with it.',
+    );
+  });
+}


### PR DESCRIPTION
## Summary

- Floating bottom nav bar felt cramped above the Android 3-button system nav bar (and on iOS home-button devices); the 4px bottom padding inside `SafeArea` wasn't enough breathing room above a chunky system UI strip.
- Replace the inner 4px bottom with an 8px breathing room added on top of `MediaQuery.padding.bottom`, so every navigation mode gets the same visible gap above whatever system UI is below the bar.
- New constant `AppSizes.bottomNavigationBarBreathingRoom = 8.0` is the single tuning knob; same value is applied to scroll-content bottomPadding so the last list item is never hidden behind the bar.

## Resulting margins

| Mode | Original (4px) | New (8px) |
|---|---|---|
| Android 3-button | ~52px (4px breathing) | ~56px (8px breathing) |
| Android gesture | ~28px (4px breathing) | ~32px (8px breathing) |
| iOS home indicator | ~38px (4px breathing) | ~42px (8px breathing) |
| iOS home button | ~4px (4px breathing) | ~8px (8px breathing) |

## Verification status

- Widget tests in `test/common_widgets/app_scaffold_test.dart` cover the `gap == padding.bottom + breathingRoom` formula for `inset = 0` and `inset > 0`. ✅ Passing.
- `flutter analyze` clean on all changed files. ✅
- `flutter build apk --debug` succeeds. ✅
- Android 3-button emulator (clean restart, edge-to-edge confirmed): visible breathing above system nav bar. ✅
- Android gesture emulator: slightly taller than baseline (+4px), within acceptable range. ✅
- iOS simulator verification: deferred — local iOS deployment-target setup needs bumping to iOS 15.0+ before iOS sims can build (tracked separately).

## Investigation notes

The first attempt used `SafeArea(minimum: 12)` on the assumption that `MediaQuery.padding.bottom = 0` in Android 3-button mode. Empirical verification on a clean-restarted 3-button emulator showed `padding.bottom` is actually the system nav bar height (~48dp) — Flutter on target SDK 35+ is edge-to-edge by default — so `max(48, 12) = 48` and the minimum never kicked in. This PR uses the correct `padding.bottom + breathingRoom` formula instead, with breathing room tuned to 8px after on-device review (12px was visibly too tall in gesture mode).

## Test plan

- [x] Android 3-button (clean restart)
- [x] Android gesture (clean restart)
- [ ] iOS home indicator (after iOS deploy-target setup is fixed; see follow-up issue)
- [ ] iOS home button (after iOS deploy-target setup)
- [ ] Long-scroll regression check (last item visible above bar)

🤖 Generated with [Claude Code](https://claude.com/claude-code)