### PR TITLE
feat(supabase): payout top-up recommendation

### DIFF
--- a/docs/superpowers/specs/2026-05-06-operator-payout-topup-advisor-design.md
+++ b/docs/superpowers/specs/2026-05-06-operator-payout-topup-advisor-design.md
@@ -1,0 +1,257 @@
+# Operator Payout Top-Up Advisor
+
+**Date:** 2026-05-06
+**Status:** Draft
+**Issue:** [#351 chore: design fund flow from IAP revenue to Stripe balance for Connect payouts](https://github.com/mkuri/peppercheck/issues/351)
+
+## Context
+
+Subscription revenue moved to IAP-only (#342). IAP revenue flows: Google Play → Google payout → operator's bank account (monthly). Referee payouts still use Stripe Connect Transfers, which require funds in the platform's Stripe balance.
+
+The operator must therefore move funds: bank account → Stripe balance. In Japan, Stripe Top-up uses a VBAN (virtual bank account) destination and the actual transfer is initiated from the operator's bank — Stripe cannot auto-pull from a Japanese bank account. The transfer takes 1–7 business days to arrive.
+
+Existing schedule:
+- `prepare_monthly_payouts` cron runs on the last day of the month at 00:00 JST and inserts `pending` rows into `reward_payouts` for users with `payouts_enabled = true`.
+- `execute-pending-payouts` runs every 30 minutes and transfers funds from the platform Stripe balance to connected accounts.
+
+So the platform Stripe balance must be funded **before** month-end, with enough lead time to absorb the 1-week wire transfer delay.
+
+### Constraints (current scale)
+
+- Solo operator (CloveClove); pre-launch.
+- Initial monthly payout volume expected: low (¥thousands to low ¥hundred-thousands range).
+- Operator manages bank UI manually; full automation of bank → Stripe transfer is not feasible.
+
+## Decision
+
+Build an **operator-only Edge Function** (`operator-payout-topup-advisor`) that, when invoked, returns the recommended top-up amount and current state. The operator invokes it from an external task management tool around day 20 of each month, then manually executes a furikomi (bank transfer) to the Stripe VBAN by ~day 21.
+
+**This is operator tooling, not user-facing.** It exposes financial summary data (Stripe balance, outstanding obligations) and is protected by a dedicated shared secret.
+
+### Why pull-based over push-based
+
+- Eliminates email/notification infrastructure (operator's existing task tool already handles reminders).
+- Edge Function becomes stateless and idempotent — easy to test, no delivery failure handling.
+- Operator decides when to invoke; no risk of overlapping reminders or stale notifications.
+
+## Architecture
+
+```
+[operator's task tool]
+        │ scheduled task on day 20
+        │ curl -H "X-Operator-Secret: ..." ...
+        ▼
+[supabase/functions/operator-payout-topup-advisor]
+        │
+        ├──▶ Stripe SDK: balance.retrieve()
+        │      (current platform JPY balance)
+        │
+        └──▶ Postgres (service_role):
+               • SUM(reward_wallets.balance) × rate
+               • SUM(reward_ledger.amount) × rate
+                 WHERE reason ∈ ('review_completed', 'evidence_timeout',
+                                 'manual_adjustment')
+                   AND amount > 0
+                   AND created_at >= date_trunc('month', now())
+               • payout_topup_config.buffer_multiplier
+        │
+        ▼
+[JSON response with recommendation]
+```
+
+### New: `payout_topup_config` table
+
+Singleton config table for runtime-tunable parameters. Located alongside other reward-domain tables (precedent: `trial_point_config` lives inside `supabase/schemas/trial_point/tables/`).
+
+- Table definition: `supabase/schemas/reward/tables/payout_topup_config.sql`
+- RLS policies: `supabase/schemas/reward/policies/payout_topup_config_policies.sql`
+
+```sql
+CREATE TABLE public.payout_topup_config (
+    id boolean PRIMARY KEY DEFAULT true CHECK (id = true),
+    buffer_multiplier numeric NOT NULL DEFAULT 1.3
+        CHECK (buffer_multiplier >= 1.0),
+    updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+INSERT INTO public.payout_topup_config (id) VALUES (true);
+```
+
+Follows the existing singleton pattern (`BOOLEAN PK DEFAULT true CHECK (id = true)`). No upper bound on `buffer_multiplier` — quarterly or less frequent top-up cadences may require multipliers of 3× or 4×.
+
+RLS: no SELECT/INSERT/UPDATE/DELETE policies — only `service_role` (used by the Edge Function) can access. Authenticated client roles have no policy granting access, so they are blocked by default.
+
+### New: `operator-payout-topup-advisor` Edge Function
+
+Created via `supabase functions new operator-payout-topup-advisor`. Standard project structure: `index.ts`, `deno.json`, optional `index_test.ts`.
+
+#### Request
+
+```
+POST /functions/v1/operator-payout-topup-advisor
+Headers:
+  apikey: <supabase publishable key>             # required by Supabase gateway
+  Authorization: Bearer <supabase publishable key>  # required by Supabase gateway
+  X-Operator-Secret: <OPERATOR_API_SECRET>       # ← actual auth check
+  Content-Type: application/json
+
+Body: {} (none required)
+```
+
+#### Authentication
+
+The function verifies `X-Operator-Secret` against `Deno.env.get('OPERATOR_API_SECRET')` using a constant-time comparison. The Supabase gateway-level `apikey`/`Authorization` headers are required by Supabase's edge runtime but provide no real access control — the publishable key is, by design, public.
+
+The secret is generated once via `openssl rand -hex 32` and registered with `supabase secrets set OPERATOR_API_SECRET=...`. It is stored in the operator's task management tool only; it is never committed to git or exposed in client code.
+
+If the header is missing or mismatched, the function returns `401 Unauthorized` with no body.
+
+#### Response
+
+```json
+{
+  "as_of": "2026-05-20T09:00:00+09:00",
+  "stripe_balance_jpy": 87500,
+  "current_total_obligation_jpy": 23500,
+  "month_to_date_earnings_jpy": 18000,
+  "day_of_month": 20,
+  "last_day_of_month": 31,
+  "extrapolated_remaining_earnings_jpy": 9900,
+  "projected_balance_at_month_end_jpy": 33400,
+  "buffer_multiplier": 1.3,
+  "recommended_balance_jpy": 43420,
+  "recommended_topup_jpy": 0,
+  "next_payout_run_at": "2026-05-31T15:00:00Z",
+  "transfer_initiate_deadline": "2026-05-21",
+  "notes": [
+    "Recommended top-up considers buffer_multiplier=1.3.",
+    "Deadline is 7 weekdays before the payout run — JP public holidays are NOT auto-detected. If Golden Week, Obon, year-end/new-year, or other multi-day holidays fall in this window, initiate earlier."
+  ]
+}
+```
+
+Field semantics:
+
+| Field | Meaning |
+|---|---|
+| `stripe_balance_jpy` | Current platform balance in JPY from Stripe API |
+| `current_total_obligation_jpy` | `SUM(reward_wallets.balance) × rate_per_point` (all users) |
+| `month_to_date_earnings_jpy` | Positive `reward_ledger` entries this calendar month, in JPY |
+| `extrapolated_remaining_earnings_jpy` | `month_to_date_earnings × (L - D) / D` where L is the last day of the current month |
+| `projected_balance_at_month_end_jpy` | `current_total_obligation + extrapolated_remaining_earnings` |
+| `recommended_balance_jpy` | `projected × buffer_multiplier` |
+| `recommended_topup_jpy` | `max(0, recommended_balance - stripe_balance)` |
+| `transfer_initiate_deadline` | `next_payout_run_at` minus 7 **business days** (Mon–Fri, weekends only — JP public holidays not auto-detected), formatted as ISO date |
+
+If `D >= L` (last day of month), `extrapolated_remaining_earnings_jpy` = 0 (clamp to non-negative).
+
+If there is no active `reward_exchange_rates` row for `JPY`, return `503 Service Unavailable` with a clear error.
+
+## Calculation Logic
+
+```
+D = current day of the month (1..31)
+rate = SELECT rate_per_point FROM reward_exchange_rates WHERE currency='JPY' AND active=true
+
+current_total_obligation_jpy =
+  SUM(reward_wallets.balance) * rate
+
+month_to_date_earnings_jpy =
+  SUM(reward_ledger.amount) * rate
+  WHERE reason IN ('review_completed', 'evidence_timeout', 'manual_adjustment')
+    AND amount > 0
+    AND created_at >= date_trunc('month', now() AT TIME ZONE 'Asia/Tokyo')
+
+L = last day of the current month (28, 29, 30, or 31)
+
+extrapolated_remaining_earnings_jpy =
+  month_to_date_earnings_jpy * (L - D) / D     -- 0 when D >= L
+
+projected_balance_at_month_end_jpy =
+  current_total_obligation_jpy + extrapolated_remaining_earnings_jpy
+
+recommended_balance_jpy =
+  projected_balance_at_month_end_jpy * buffer_multiplier
+
+recommended_topup_jpy =
+  max(0, recommended_balance_jpy - stripe_balance_jpy)
+```
+
+### Why this formula
+
+- **Baseline = current total balance** — already reflects carry-over from prior unpaid months (e.g., users without Connect set up); does not need to be re-projected.
+- **Project only the future** — `(L - D) / D` extrapolates *additional* earnings expected from now to month-end at the current daily pace. The carry-over portion is not extrapolated. `L` adapts to the actual month length so February (28/29 days) and 31-day months don't introduce systematic bias.
+- **Use `reward_ledger`, not wallet diffs** — wallet balance changes confound earning, payouts, and adjustments. Filtering ledger entries by positive earning reasons gives a clean rate.
+- **Buffer multiplier** absorbs linear-projection noise (back-loaded months, sudden Connect activations of dormant balances). 1.3 is the default; can be tuned in `payout_topup_config`.
+
+### Sanity check
+
+Assume a 30-day month, `rate=50 JPY/pt`, carry-over balance = 400 JPY (8 pts), monthly earning ~3000 JPY (60 pts) at steady pace. So daily earnings ≈ 100 JPY, current-balance = carry-over + MtD earnings.
+
+| D | MtD earned | Extrapolated remaining `(L-D)/D` | Projected end | × 1.3 |
+|---|---|---|---|---|
+| 1  | 100  | 100 × 29/1 = 2900 | (400+100) + 2900 = 3400 | 4420 |
+| 15 | 1500 | 1500 × 15/15 = 1500 | (400+1500) + 1500 = 3400 | 4420 |
+| 30 | 3000 | 3000 × 0/30 = 0 | (400+3000) + 0 = 3400 | 4420 |
+
+Projection is internally consistent across the month under steady-state earning.
+
+## Operational Workflow
+
+1. Operator's external task management tool fires a recurring task on day 20 of each month at 09:00 JST.
+2. The task invokes the Edge Function with `X-Operator-Secret`.
+3. The response shows `recommended_topup_jpy` and `transfer_initiate_deadline`.
+4. If `recommended_topup_jpy > 0`, the operator initiates a furikomi from their bank to the Stripe VBAN for that amount (rounded to a clean figure if desired).
+5. The transfer arrives in the platform Stripe balance within 1–7 business days.
+6. On the last day of the month, `prepare_monthly_payouts` and `execute-pending-payouts` run as scheduled.
+
+If the operator misses a month, the buffer (defaulting to 30% over projected demand) provides a safety margin. The `recommended_topup_jpy` for the following month will naturally be larger to compensate.
+
+### Deadline calculation
+
+`transfer_initiate_deadline` is computed in TypeScript inside the Edge Function:
+
+```ts
+function subtractBusinessDays(date: Date, days: number): Date {
+  const d = new Date(date);
+  let remaining = days;
+  while (remaining > 0) {
+    d.setDate(d.getDate() - 1);
+    const dow = d.getDay();  // 0 = Sun, 6 = Sat
+    if (dow !== 0 && dow !== 6) remaining--;
+  }
+  return d;
+}
+
+const transferInitiateDeadline = subtractBusinessDays(nextPayoutRunAt, 7);
+```
+
+Returns the date 7 weekdays before `next_payout_run_at`. **Japanese public holidays are not detected.** During Golden Week, Obon, year-end/new-year, or other multi-day holiday clusters, the operator should initiate the transfer earlier than the displayed deadline. The static reminder in `notes` calls this out on every response.
+
+## Out of Scope
+
+- Auto top-up (Stripe pulling from bank automatically) — not supported for Japanese accounts.
+- Email / push notifications — handled by the operator's existing task tool.
+- Multi-currency support — JPY only for now.
+- Slack/Discord webhook delivery of the recommendation — operator's task tool can render the JSON.
+- A web dashboard for the operator — JSON response is sufficient at current scale.
+- Historical recommendation tracking — each invocation is independent; no audit trail beyond Edge Function logs.
+- Automatic creation of a `Top-up` object via Stripe API — Japan VBAN flow does not benefit from this; the actual fund movement is the bank-side furikomi.
+
+## Future Considerations
+
+- **Frequency reduction**: As payout volume grows, switching to bimonthly or quarterly top-ups reduces bank fees. The advisor formula is already date-agnostic — only the operator's task tool cadence changes.
+- **Auto-tuning `buffer_multiplier`**: After several months of operation, observed (actual / projected) ratios can inform a data-driven multiplier.
+- **Low balance alert**: A separate cron-driven Edge Function could push a warning to a notification channel if `stripe_balance_jpy` drops below `current_total_obligation_jpy × 0.5` between top-up cycles.
+- **Stripe Top-up object integration**: If Japan ever supports auto-debit, the same advisor logic could pivot to automatically issuing top-ups via Stripe API.
+
+## Testing
+
+- Edge Function: unit test with mocked `Stripe.balance.retrieve()` and a stubbed Supabase client. Cover:
+  - Missing/incorrect `X-Operator-Secret` → 401
+  - Missing `OPERATOR_API_SECRET` env → 500
+  - Empty wallets and zero earnings → recommended_topup = 0, no errors
+  - Steady-state scenario matching the sanity-check table above
+  - `D >= L` clamps `extrapolated_remaining_earnings_jpy` to 0
+  - `subtractBusinessDays`: weekday inputs, weekend inputs, month-boundary crossings, deadline computed across multiple weekends (e.g. last day of month falls on a Sunday)
+- DB: pgTAP test (`supabase/tests/database/`) for `payout_topup_config` constraints — singleton enforcement (second insert fails) and `buffer_multiplier >= 1.0` rejection.

--- a/docs/superpowers/specs/2026-05-06-recommend-payout-topup-design.md
+++ b/docs/superpowers/specs/2026-05-06-recommend-payout-topup-design.md
@@ -1,4 +1,4 @@
-# Operator Payout Top-Up Advisor
+# Payout Top-Up Recommendation
 
 **Date:** 2026-05-06
 **Status:** Draft
@@ -24,7 +24,7 @@ So the platform Stripe balance must be funded **before** month-end, with enough 
 
 ## Decision
 
-Build an **operator-only Edge Function** (`operator-payout-topup-advisor`) that, when invoked, returns the recommended top-up amount and current state. The operator invokes it from an external task management tool around day 20 of each month, then manually executes a furikomi (bank transfer) to the Stripe VBAN by ~day 21.
+Build an **operator-only Edge Function** (`recommend-payout-topup`) that, when invoked, returns the recommended top-up amount and current state. The operator invokes it from an external task management tool around day 20 of each month, then manually executes a furikomi (bank transfer) to the Stripe VBAN by ~day 21.
 
 **This is operator tooling, not user-facing.** It exposes financial summary data (Stripe balance, outstanding obligations) and is protected by a dedicated shared secret.
 
@@ -41,7 +41,7 @@ Build an **operator-only Edge Function** (`operator-payout-topup-advisor`) that,
         │ scheduled task on day 20
         │ curl -H "X-Operator-Secret: ..." ...
         ▼
-[supabase/functions/operator-payout-topup-advisor]
+[supabase/functions/recommend-payout-topup]
         │
         ├──▶ Stripe SDK: balance.retrieve()
         │      (current platform JPY balance)
@@ -81,14 +81,14 @@ Follows the existing singleton pattern (`BOOLEAN PK DEFAULT true CHECK (id = tru
 
 RLS: no SELECT/INSERT/UPDATE/DELETE policies — only `service_role` (used by the Edge Function) can access. Authenticated client roles have no policy granting access, so they are blocked by default.
 
-### New: `operator-payout-topup-advisor` Edge Function
+### New: `recommend-payout-topup` Edge Function
 
-Created via `supabase functions new operator-payout-topup-advisor`. Standard project structure: `index.ts`, `deno.json`, optional `index_test.ts`.
+Created via `supabase functions new recommend-payout-topup`. Standard project structure: `index.ts`, `deno.json`, optional `index_test.ts`.
 
 #### Request
 
 ```
-POST /functions/v1/operator-payout-topup-advisor
+POST /functions/v1/recommend-payout-topup
 Headers:
   apikey: <supabase publishable key>             # required by Supabase gateway
   Authorization: Bearer <supabase publishable key>  # required by Supabase gateway
@@ -240,10 +240,10 @@ Returns the date 7 weekdays before `next_payout_run_at`. **Japanese public holid
 
 ## Future Considerations
 
-- **Frequency reduction**: As payout volume grows, switching to bimonthly or quarterly top-ups reduces bank fees. The advisor formula is already date-agnostic — only the operator's task tool cadence changes.
+- **Frequency reduction**: As payout volume grows, switching to bimonthly or quarterly top-ups reduces bank fees. The recommendation formula is already date-agnostic — only the operator's task tool cadence changes.
 - **Auto-tuning `buffer_multiplier`**: After several months of operation, observed (actual / projected) ratios can inform a data-driven multiplier.
 - **Low balance alert**: A separate cron-driven Edge Function could push a warning to a notification channel if `stripe_balance_jpy` drops below `current_total_obligation_jpy × 0.5` between top-up cycles.
-- **Stripe Top-up object integration**: If Japan ever supports auto-debit, the same advisor logic could pivot to automatically issuing top-ups via Stripe API.
+- **Stripe Top-up object integration**: If Japan ever supports auto-debit, the same recommendation logic could pivot to automatically issuing top-ups via Stripe API.
 
 ## Testing
 

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -70,6 +70,7 @@ schema_paths = [
   "./schemas/reward/tables/reward_ledger.sql",
   "./schemas/reward/tables/reward_exchange_rates.sql",
   "./schemas/reward/tables/reward_payouts.sql",
+  "./schemas/reward/tables/payout_topup_config.sql",
 
   # Task
   "./schemas/task/tables/tasks.sql",
@@ -192,6 +193,7 @@ schema_paths = [
   "./schemas/reward/functions/grant_reward.sql",
   "./schemas/reward/functions/deduct_reward_for_payout.sql",
   "./schemas/reward/functions/prepare_monthly_payouts.sql",
+  "./schemas/reward/functions/get_payout_topup_metrics.sql",
 
   # Notification
   "./schemas/notification/functions/notify_event.sql",
@@ -249,6 +251,7 @@ schema_paths = [
   "./schemas/reward/triggers/on_reward_wallets_update_set_updated_at.sql",
   "./schemas/reward/triggers/on_reward_payouts_update_set_updated_at.sql",
   "./schemas/reward/triggers/on_reward_exchange_rates_update_set_updated_at.sql",
+  "./schemas/reward/triggers/on_payout_topup_config_update_set_updated_at.sql",
 
   # Subscription
   "./schemas/subscription/triggers/on_user_subscriptions_update_set_updated_at.sql",
@@ -296,6 +299,7 @@ schema_paths = [
   "./schemas/reward/policies/reward_ledger_policies.sql",
   "./schemas/reward/policies/reward_payouts_policies.sql",
   "./schemas/reward/policies/reward_exchange_rates_policies.sql",
+  "./schemas/reward/policies/payout_topup_config_policies.sql",
   "./schemas/notification/policies/user_fcm_tokens_policies.sql",
   "./schemas/notification/policies/notification_settings_policies.sql",
   "./schemas/report/policies/reports_policies.sql",

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -670,3 +670,14 @@ entrypoint = "./functions/delete-account/index.ts"
 # For example, if you want to serve static HTML pages in your function:
 # static_files = [ "./functions/delete-account/*.html" ]
 
+
+[functions.recommend-payout-topup]
+enabled = true
+verify_jwt = true
+import_map = "./functions/recommend-payout-topup/deno.json"
+# Uncomment to specify a custom file path to the entrypoint.
+# Supported file extensions are: .ts, .js, .mjs, .jsx, .tsx
+entrypoint = "./functions/recommend-payout-topup/index.ts"
+# Specifies static files to be bundled with the function. Supports glob patterns.
+# For example, if you want to serve static HTML pages in your function:
+# static_files = [ "./functions/recommend-payout-topup/*.html" ]

--- a/supabase/functions/.env.example
+++ b/supabase/functions/.env.example
@@ -12,3 +12,9 @@ STRIPE_ONBOARDING_REFRESH_URL=
 # Get this from Firebase Console > Project Settings > Service accounts
 # You must remove newlines so it is a single string.
 FIREBASE_SERVICE_ACCOUNT='{"type": "service_account", "project_id": "...", ...}'
+
+# Operator-only secret for invoking recommend-payout-topup.
+# Generate with: openssl rand -hex 32
+# Set in production via: supabase secrets set OPERATOR_API_SECRET=<value>
+# Used by operator's external task management tool only.
+OPERATOR_API_SECRET=

--- a/supabase/functions/recommend-payout-topup/.npmrc
+++ b/supabase/functions/recommend-payout-topup/.npmrc
@@ -1,0 +1,3 @@
+# Configuration for private npm package dependencies
+# For more information on using private registries with Edge Functions, see:
+# https://supabase.com/docs/guides/functions/import-maps#importing-from-private-registries

--- a/supabase/functions/recommend-payout-topup/deno.json
+++ b/supabase/functions/recommend-payout-topup/deno.json
@@ -1,0 +1,5 @@
+{
+  "imports": {
+    "@supabase/functions-js": "jsr:@supabase/functions-js@^2"
+  }
+}

--- a/supabase/functions/recommend-payout-topup/deno.json
+++ b/supabase/functions/recommend-payout-topup/deno.json
@@ -1,5 +1,11 @@
 {
   "imports": {
-    "@supabase/functions-js": "jsr:@supabase/functions-js@^2"
+    "@supabase/supabase-js": "jsr:@supabase/supabase-js@2",
+    "stripe": "npm:stripe@^20.0.0",
+    "@std/assert": "jsr:@std/assert@1",
+    "@std/testing": "jsr:@std/testing@^0.224.0"
+  },
+  "tasks": {
+    "test": "deno test --allow-all"
   }
 }

--- a/supabase/functions/recommend-payout-topup/index.ts
+++ b/supabase/functions/recommend-payout-topup/index.ts
@@ -1,4 +1,6 @@
 import 'jsr:@supabase/functions-js@^2/edge-runtime.d.ts'
+import { createClient, SupabaseClient } from '@supabase/supabase-js'
+import Stripe from 'stripe'
 
 /**
  * Subtract N business days (Mon–Fri) from a date.
@@ -9,7 +11,7 @@ export function subtractBusinessDays(date: Date, days: number): Date {
   let remaining = days
   while (remaining > 0) {
     d.setUTCDate(d.getUTCDate() - 1)
-    const dow = d.getUTCDay() // 0 = Sun, 6 = Sat
+    const dow = d.getUTCDay()
     if (dow !== 0 && dow !== 6) {
       remaining--
     }
@@ -18,16 +20,13 @@ export function subtractBusinessDays(date: Date, days: number): Date {
 }
 
 /**
- * Constant-time comparison of the X-Operator-Secret header against OPERATOR_API_SECRET env.
- * Returns false if either side is missing or empty.
+ * Constant-time check of the X-Operator-Secret header against OPERATOR_API_SECRET env.
  */
 export function verifyOperatorSecret(req: Request): boolean {
   const expected = Deno.env.get('OPERATOR_API_SECRET') ?? ''
   const provided = req.headers.get('X-Operator-Secret') ?? ''
   if (expected.length === 0 || provided.length === 0) return false
   if (expected.length !== provided.length) return false
-
-  // Constant-time comparison
   let diff = 0
   for (let i = 0; i < expected.length; i++) {
     diff |= expected.charCodeAt(i) ^ provided.charCodeAt(i)
@@ -54,22 +53,17 @@ export interface Recommendation {
 export function computeRecommendation(input: RecommendationInput): Recommendation {
   const { dayOfMonth: D, lastDayOfMonth: L } = input
   const remainingFactor = D >= L ? 0 : (L - D) / D
-
   const extrapolatedRemainingEarningsJpy = Math.round(
     input.monthToDateEarningsJpy * remainingFactor,
   )
-
   const projectedBalanceAtMonthEndJpy = input.totalObligationJpy + extrapolatedRemainingEarningsJpy
-
   const recommendedBalanceJpy = Math.round(
     projectedBalanceAtMonthEndJpy * input.bufferMultiplier,
   )
-
   const recommendedTopupJpy = Math.max(
     0,
     recommendedBalanceJpy - input.stripeBalanceJpy,
   )
-
   return {
     extrapolatedRemainingEarningsJpy,
     projectedBalanceAtMonthEndJpy,
@@ -78,4 +72,111 @@ export function computeRecommendation(input: RecommendationInput): Recommendatio
   }
 }
 
-Deno.serve(() => new Response('Not implemented', { status: 501 }))
+interface JstDateParts {
+  dayOfMonth: number
+  lastDayOfMonth: number
+  nextPayoutRunAt: Date
+}
+
+function jstDateParts(now: Date): JstDateParts {
+  // Convert "now" to JST calendar fields
+  const jstFmt = new Intl.DateTimeFormat('en-CA', {
+    timeZone: 'Asia/Tokyo',
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  })
+  const parts = jstFmt.formatToParts(now)
+  const year = parseInt(parts.find((p) => p.type === 'year')!.value, 10)
+  const month = parseInt(parts.find((p) => p.type === 'month')!.value, 10)
+  const day = parseInt(parts.find((p) => p.type === 'day')!.value, 10)
+
+  // Last day of current JST month
+  const lastDayOfMonth = new Date(Date.UTC(year, month, 0)).getUTCDate()
+
+  // prepare_monthly_payouts cron: '0 15 28-31 * *' → only fires on actual last day of month.
+  // The instant in UTC is 15:00 UTC of last_day_of_month, which equals 00:00 JST of last_day+1.
+  const nextPayoutRunAt = new Date(Date.UTC(year, month - 1, lastDayOfMonth, 15, 0, 0))
+
+  return { dayOfMonth: day, lastDayOfMonth, nextPayoutRunAt }
+}
+
+export interface Dependencies {
+  supabaseAdmin?: SupabaseClient
+  stripe?: Stripe
+  now?: Date
+}
+
+export async function handler(req: Request, deps: Dependencies = {}): Promise<Response> {
+  if (req.method !== 'POST') {
+    return new Response('Method Not Allowed', { status: 405 })
+  }
+
+  if (!verifyOperatorSecret(req)) {
+    return new Response('Unauthorized', { status: 401 })
+  }
+
+  const supabaseUrl = Deno.env.get('SUPABASE_URL') ?? ''
+  const serviceRoleKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') ?? ''
+  const stripeKey = Deno.env.get('STRIPE_SECRET_KEY') ?? ''
+
+  const supabaseAdmin = deps.supabaseAdmin ?? createClient(supabaseUrl, serviceRoleKey)
+  const stripe = deps.stripe ?? new Stripe(stripeKey, { apiVersion: '2025-11-17.clover' })
+  const now = deps.now ?? new Date()
+
+  const { data: metrics, error: rpcError } = await supabaseAdmin.rpc(
+    'get_payout_topup_metrics',
+    { p_currency: 'JPY' },
+  )
+
+  if (rpcError || !metrics) {
+    return new Response(
+      JSON.stringify({ error: rpcError?.message ?? 'metrics unavailable' }),
+      { status: 503, headers: { 'Content-Type': 'application/json' } },
+    )
+  }
+
+  const balance = await stripe.balance.retrieve()
+  const jpyAvailable = balance.available.find((b) => b.currency === 'jpy')
+  const stripeBalanceJpy = jpyAvailable?.amount ?? 0
+
+  const { dayOfMonth, lastDayOfMonth, nextPayoutRunAt } = jstDateParts(now)
+
+  const recommendation = computeRecommendation({
+    stripeBalanceJpy,
+    totalObligationJpy: Number(metrics.total_obligation_jpy ?? 0),
+    monthToDateEarningsJpy: Number(metrics.month_to_date_earnings_jpy ?? 0),
+    bufferMultiplier: Number(metrics.buffer_multiplier),
+    dayOfMonth,
+    lastDayOfMonth,
+  })
+
+  const transferInitiateDeadline = subtractBusinessDays(nextPayoutRunAt, 7)
+
+  const body = {
+    as_of: now.toISOString(),
+    stripe_balance_jpy: stripeBalanceJpy,
+    current_total_obligation_jpy: Number(metrics.total_obligation_jpy ?? 0),
+    month_to_date_earnings_jpy: Number(metrics.month_to_date_earnings_jpy ?? 0),
+    day_of_month: dayOfMonth,
+    last_day_of_month: lastDayOfMonth,
+    extrapolated_remaining_earnings_jpy: recommendation.extrapolatedRemainingEarningsJpy,
+    projected_balance_at_month_end_jpy: recommendation.projectedBalanceAtMonthEndJpy,
+    buffer_multiplier: Number(metrics.buffer_multiplier),
+    recommended_balance_jpy: recommendation.recommendedBalanceJpy,
+    recommended_topup_jpy: recommendation.recommendedTopupJpy,
+    next_payout_run_at: nextPayoutRunAt.toISOString(),
+    transfer_initiate_deadline: transferInitiateDeadline.toISOString().slice(0, 10),
+    notes: [
+      `Recommended top-up considers buffer_multiplier=${metrics.buffer_multiplier}.`,
+      'Deadline is 7 weekdays before the payout run — JP public holidays are NOT auto-detected. If Golden Week, Obon, year-end/new-year, or other multi-day holidays fall in this window, initiate earlier.',
+    ],
+  }
+
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+Deno.serve((req) => handler(req))

--- a/supabase/functions/recommend-payout-topup/index.ts
+++ b/supabase/functions/recommend-payout-topup/index.ts
@@ -1,32 +1,20 @@
-// Follow this setup guide to integrate the Deno language server with your editor:
-// https://deno.land/manual/getting_started/setup_your_environment
-// This enables autocomplete, go to definition, etc.
+import 'jsr:@supabase/functions-js@^2/edge-runtime.d.ts'
 
-// Setup type definitions for built-in Supabase Runtime APIs
-import '@supabase/functions-js/edge-runtime.d.ts'
-
-console.log('Hello from Functions!')
-
-Deno.serve(async (req) => {
-  const { name } = await req.json()
-  const data = {
-    message: `Hello ${name}!`,
+/**
+ * Subtract N business days (Mon–Fri) from a date.
+ * Note: Japanese public holidays are NOT detected.
+ */
+export function subtractBusinessDays(date: Date, days: number): Date {
+  const d = new Date(date)
+  let remaining = days
+  while (remaining > 0) {
+    d.setUTCDate(d.getUTCDate() - 1)
+    const dow = d.getUTCDay() // 0 = Sun, 6 = Sat
+    if (dow !== 0 && dow !== 6) {
+      remaining--
+    }
   }
+  return d
+}
 
-  return new Response(
-    JSON.stringify(data),
-    { headers: { 'Content-Type': 'application/json' } },
-  )
-})
-
-/* To invoke locally:
-
-  1. Run `supabase start` (see: https://supabase.com/docs/reference/cli/supabase-start)
-  2. Make an HTTP request:
-
-  curl -i --location --request POST 'http://127.0.0.1:54321/functions/v1/recommend-payout-topup' \
-    --header 'Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0' \
-    --header 'Content-Type: application/json' \
-    --data '{"name":"Functions"}'
-
-*/
+Deno.serve(() => new Response('Not implemented', { status: 501 }))

--- a/supabase/functions/recommend-payout-topup/index.ts
+++ b/supabase/functions/recommend-payout-topup/index.ts
@@ -35,4 +35,47 @@ export function verifyOperatorSecret(req: Request): boolean {
   return diff === 0
 }
 
+export interface RecommendationInput {
+  stripeBalanceJpy: number
+  totalObligationJpy: number
+  monthToDateEarningsJpy: number
+  bufferMultiplier: number
+  dayOfMonth: number
+  lastDayOfMonth: number
+}
+
+export interface Recommendation {
+  extrapolatedRemainingEarningsJpy: number
+  projectedBalanceAtMonthEndJpy: number
+  recommendedBalanceJpy: number
+  recommendedTopupJpy: number
+}
+
+export function computeRecommendation(input: RecommendationInput): Recommendation {
+  const { dayOfMonth: D, lastDayOfMonth: L } = input
+  const remainingFactor = D >= L ? 0 : (L - D) / D
+
+  const extrapolatedRemainingEarningsJpy = Math.round(
+    input.monthToDateEarningsJpy * remainingFactor,
+  )
+
+  const projectedBalanceAtMonthEndJpy = input.totalObligationJpy + extrapolatedRemainingEarningsJpy
+
+  const recommendedBalanceJpy = Math.round(
+    projectedBalanceAtMonthEndJpy * input.bufferMultiplier,
+  )
+
+  const recommendedTopupJpy = Math.max(
+    0,
+    recommendedBalanceJpy - input.stripeBalanceJpy,
+  )
+
+  return {
+    extrapolatedRemainingEarningsJpy,
+    projectedBalanceAtMonthEndJpy,
+    recommendedBalanceJpy,
+    recommendedTopupJpy,
+  }
+}
+
 Deno.serve(() => new Response('Not implemented', { status: 501 }))

--- a/supabase/functions/recommend-payout-topup/index.ts
+++ b/supabase/functions/recommend-payout-topup/index.ts
@@ -1,0 +1,32 @@
+// Follow this setup guide to integrate the Deno language server with your editor:
+// https://deno.land/manual/getting_started/setup_your_environment
+// This enables autocomplete, go to definition, etc.
+
+// Setup type definitions for built-in Supabase Runtime APIs
+import '@supabase/functions-js/edge-runtime.d.ts'
+
+console.log('Hello from Functions!')
+
+Deno.serve(async (req) => {
+  const { name } = await req.json()
+  const data = {
+    message: `Hello ${name}!`,
+  }
+
+  return new Response(
+    JSON.stringify(data),
+    { headers: { 'Content-Type': 'application/json' } },
+  )
+})
+
+/* To invoke locally:
+
+  1. Run `supabase start` (see: https://supabase.com/docs/reference/cli/supabase-start)
+  2. Make an HTTP request:
+
+  curl -i --location --request POST 'http://127.0.0.1:54321/functions/v1/recommend-payout-topup' \
+    --header 'Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0' \
+    --header 'Content-Type: application/json' \
+    --data '{"name":"Functions"}'
+
+*/

--- a/supabase/functions/recommend-payout-topup/index.ts
+++ b/supabase/functions/recommend-payout-topup/index.ts
@@ -17,4 +17,22 @@ export function subtractBusinessDays(date: Date, days: number): Date {
   return d
 }
 
+/**
+ * Constant-time comparison of the X-Operator-Secret header against OPERATOR_API_SECRET env.
+ * Returns false if either side is missing or empty.
+ */
+export function verifyOperatorSecret(req: Request): boolean {
+  const expected = Deno.env.get('OPERATOR_API_SECRET') ?? ''
+  const provided = req.headers.get('X-Operator-Secret') ?? ''
+  if (expected.length === 0 || provided.length === 0) return false
+  if (expected.length !== provided.length) return false
+
+  // Constant-time comparison
+  let diff = 0
+  for (let i = 0; i < expected.length; i++) {
+    diff |= expected.charCodeAt(i) ^ provided.charCodeAt(i)
+  }
+  return diff === 0
+}
+
 Deno.serve(() => new Response('Not implemented', { status: 501 }))

--- a/supabase/functions/recommend-payout-topup/index.ts
+++ b/supabase/functions/recommend-payout-topup/index.ts
@@ -72,6 +72,14 @@ export function computeRecommendation(input: RecommendationInput): Recommendatio
   }
 }
 
+interface PayoutTopupMetrics {
+  currency: string
+  rate_per_point: number
+  total_obligation_jpy: number | string
+  month_to_date_earnings_jpy: number | string
+  buffer_multiplier: number | string
+}
+
 interface JstDateParts {
   dayOfMonth: number
   lastDayOfMonth: number
@@ -124,14 +132,23 @@ export async function handler(req: Request, deps: Dependencies = {}): Promise<Re
   const stripe = deps.stripe ?? new Stripe(stripeKey, { apiVersion: '2025-11-17.clover' })
   const now = deps.now ?? new Date()
 
-  const { data: metrics, error: rpcError } = await supabaseAdmin.rpc(
+  const { data, error: rpcError } = await supabaseAdmin.rpc(
     'get_payout_topup_metrics',
     { p_currency: 'JPY' },
   )
+  const metrics = data as PayoutTopupMetrics | null
 
   if (rpcError || !metrics) {
     return new Response(
       JSON.stringify({ error: rpcError?.message ?? 'metrics unavailable' }),
+      { status: 503, headers: { 'Content-Type': 'application/json' } },
+    )
+  }
+
+  const bufferMultiplier = Number(metrics.buffer_multiplier)
+  if (!Number.isFinite(bufferMultiplier) || bufferMultiplier <= 0) {
+    return new Response(
+      JSON.stringify({ error: 'buffer_multiplier missing or invalid in metrics' }),
       { status: 503, headers: { 'Content-Type': 'application/json' } },
     )
   }
@@ -146,7 +163,7 @@ export async function handler(req: Request, deps: Dependencies = {}): Promise<Re
     stripeBalanceJpy,
     totalObligationJpy: Number(metrics.total_obligation_jpy ?? 0),
     monthToDateEarningsJpy: Number(metrics.month_to_date_earnings_jpy ?? 0),
-    bufferMultiplier: Number(metrics.buffer_multiplier),
+    bufferMultiplier,
     dayOfMonth,
     lastDayOfMonth,
   })
@@ -162,13 +179,13 @@ export async function handler(req: Request, deps: Dependencies = {}): Promise<Re
     last_day_of_month: lastDayOfMonth,
     extrapolated_remaining_earnings_jpy: recommendation.extrapolatedRemainingEarningsJpy,
     projected_balance_at_month_end_jpy: recommendation.projectedBalanceAtMonthEndJpy,
-    buffer_multiplier: Number(metrics.buffer_multiplier),
+    buffer_multiplier: bufferMultiplier,
     recommended_balance_jpy: recommendation.recommendedBalanceJpy,
     recommended_topup_jpy: recommendation.recommendedTopupJpy,
     next_payout_run_at: nextPayoutRunAt.toISOString(),
     transfer_initiate_deadline: transferInitiateDeadline.toISOString().slice(0, 10),
     notes: [
-      `Recommended top-up considers buffer_multiplier=${metrics.buffer_multiplier}.`,
+      `Recommended top-up considers buffer_multiplier=${bufferMultiplier}.`,
       'Deadline is 7 weekdays before the payout run — JP public holidays are NOT auto-detected. If Golden Week, Obon, year-end/new-year, or other multi-day holidays fall in this window, initiate earlier.',
     ],
   }

--- a/supabase/functions/recommend-payout-topup/index_test.ts
+++ b/supabase/functions/recommend-payout-topup/index_test.ts
@@ -1,0 +1,30 @@
+import { assertEquals } from '@std/assert'
+import { subtractBusinessDays } from './index.ts'
+
+Deno.test('subtractBusinessDays: subtracts 7 weekdays from a Sunday', () => {
+  // 2026-05-31 is a Sunday. 7 weekdays back = 2026-05-21 (Thursday).
+  const from = new Date('2026-05-31T15:00:00Z')
+  const result = subtractBusinessDays(from, 7)
+  assertEquals(result.toISOString().slice(0, 10), '2026-05-21')
+})
+
+Deno.test('subtractBusinessDays: zero days returns same date', () => {
+  const from = new Date('2026-05-15T00:00:00Z')
+  const result = subtractBusinessDays(from, 0)
+  assertEquals(result.toISOString().slice(0, 10), '2026-05-15')
+})
+
+Deno.test('subtractBusinessDays: skips a single weekend', () => {
+  // 2026-05-15 is Friday. Subtract 1 business day → Thursday 2026-05-14.
+  const from = new Date('2026-05-15T00:00:00Z')
+  const result = subtractBusinessDays(from, 1)
+  assertEquals(result.toISOString().slice(0, 10), '2026-05-14')
+})
+
+Deno.test('subtractBusinessDays: crosses a month boundary', () => {
+  // 2026-06-02 is Tuesday. Subtract 5 business days:
+  //   Tue 6/2 → Mon 6/1 → Fri 5/29 → Thu 5/28 → Wed 5/27 → Tue 5/26.
+  const from = new Date('2026-06-02T00:00:00Z')
+  const result = subtractBusinessDays(from, 5)
+  assertEquals(result.toISOString().slice(0, 10), '2026-05-26')
+})

--- a/supabase/functions/recommend-payout-topup/index_test.ts
+++ b/supabase/functions/recommend-payout-topup/index_test.ts
@@ -1,5 +1,6 @@
 import { assertEquals } from '@std/assert'
 import { subtractBusinessDays } from './index.ts'
+import { verifyOperatorSecret } from './index.ts'
 
 Deno.test('subtractBusinessDays: subtracts 7 weekdays from a Sunday', () => {
   // 2026-05-31 is a Sunday. 7 weekdays back = 2026-05-21 (Thursday).
@@ -27,4 +28,37 @@ Deno.test('subtractBusinessDays: crosses a month boundary', () => {
   const from = new Date('2026-06-02T00:00:00Z')
   const result = subtractBusinessDays(from, 5)
   assertEquals(result.toISOString().slice(0, 10), '2026-05-26')
+})
+
+Deno.test('verifyOperatorSecret: returns true when header matches env', () => {
+  Deno.env.set('OPERATOR_API_SECRET', 'matching-secret')
+  const req = new Request('http://localhost/', {
+    method: 'POST',
+    headers: { 'X-Operator-Secret': 'matching-secret' },
+  })
+  assertEquals(verifyOperatorSecret(req), true)
+})
+
+Deno.test('verifyOperatorSecret: returns false when header is missing', () => {
+  Deno.env.set('OPERATOR_API_SECRET', 'matching-secret')
+  const req = new Request('http://localhost/', { method: 'POST' })
+  assertEquals(verifyOperatorSecret(req), false)
+})
+
+Deno.test('verifyOperatorSecret: returns false when header mismatches', () => {
+  Deno.env.set('OPERATOR_API_SECRET', 'matching-secret')
+  const req = new Request('http://localhost/', {
+    method: 'POST',
+    headers: { 'X-Operator-Secret': 'wrong-secret' },
+  })
+  assertEquals(verifyOperatorSecret(req), false)
+})
+
+Deno.test('verifyOperatorSecret: returns false when env is unset', () => {
+  Deno.env.delete('OPERATOR_API_SECRET')
+  const req = new Request('http://localhost/', {
+    method: 'POST',
+    headers: { 'X-Operator-Secret': 'anything' },
+  })
+  assertEquals(verifyOperatorSecret(req), false)
 })

--- a/supabase/functions/recommend-payout-topup/index_test.ts
+++ b/supabase/functions/recommend-payout-topup/index_test.ts
@@ -1,7 +1,10 @@
 import { assertEquals } from '@std/assert'
-import { subtractBusinessDays } from './index.ts'
-import { verifyOperatorSecret } from './index.ts'
-import { computeRecommendation } from './index.ts'
+import {
+  computeRecommendation,
+  handler,
+  subtractBusinessDays,
+  verifyOperatorSecret,
+} from './index.ts'
 
 Deno.test('subtractBusinessDays: subtracts 7 weekdays from a Sunday', () => {
   // 2026-05-31 is a Sunday. 7 weekdays back = 2026-05-21 (Thursday).
@@ -136,7 +139,6 @@ Deno.test('computeRecommendation: matches the spec example (May 20, 31-day month
   assertEquals(r.recommendedTopupJpy, 0)
 })
 
-import { handler } from './index.ts'
 import type { SupabaseClient } from '@supabase/supabase-js'
 import type Stripe from 'stripe'
 
@@ -235,4 +237,11 @@ Deno.test('handler: returns 503 when SQL helper raises (no exchange rate)', asyn
     now: new Date('2026-05-20T00:00:00+09:00'),
   })
   assertEquals(res.status, 503)
+})
+
+Deno.test('handler: returns 405 for non-POST methods', async () => {
+  Deno.env.set('OPERATOR_API_SECRET', 'shh')
+  const req = new Request('http://localhost/', { method: 'GET' })
+  const res = await handler(req)
+  assertEquals(res.status, 405)
 })

--- a/supabase/functions/recommend-payout-topup/index_test.ts
+++ b/supabase/functions/recommend-payout-topup/index_test.ts
@@ -135,3 +135,104 @@ Deno.test('computeRecommendation: matches the spec example (May 20, 31-day month
   assertEquals(r.recommendedBalanceJpy, 43420)
   assertEquals(r.recommendedTopupJpy, 0)
 })
+
+import { handler } from './index.ts'
+import type { SupabaseClient } from '@supabase/supabase-js'
+import type Stripe from 'stripe'
+
+function makeMockSupabase(metrics: Record<string, unknown>): SupabaseClient {
+  return {
+    rpc: (_fn: string, _args: unknown) => Promise.resolve({ data: metrics, error: null }),
+  } as unknown as SupabaseClient
+}
+
+function makeMockStripe(balanceJpy: number): Stripe {
+  return {
+    balance: {
+      retrieve: () =>
+        Promise.resolve({
+          available: [{ amount: balanceJpy, currency: 'jpy' }],
+          pending: [],
+        }),
+    },
+  } as unknown as Stripe
+}
+
+const validMetrics = {
+  currency: 'JPY',
+  rate_per_point: 50,
+  total_obligation_jpy: 23500,
+  month_to_date_earnings_jpy: 18000,
+  buffer_multiplier: 1.3,
+}
+
+Deno.test('handler: returns 401 when X-Operator-Secret is missing', async () => {
+  Deno.env.set('OPERATOR_API_SECRET', 'shh')
+  const req = new Request('http://localhost/', { method: 'POST' })
+  const res = await handler(req, {
+    supabaseAdmin: makeMockSupabase(validMetrics),
+    stripe: makeMockStripe(87500),
+    now: new Date('2026-05-20T00:00:00+09:00'),
+  })
+  assertEquals(res.status, 401)
+})
+
+Deno.test('handler: returns 401 when X-Operator-Secret mismatches', async () => {
+  Deno.env.set('OPERATOR_API_SECRET', 'shh')
+  const req = new Request('http://localhost/', {
+    method: 'POST',
+    headers: { 'X-Operator-Secret': 'nope' },
+  })
+  const res = await handler(req, {
+    supabaseAdmin: makeMockSupabase(validMetrics),
+    stripe: makeMockStripe(87500),
+    now: new Date('2026-05-20T00:00:00+09:00'),
+  })
+  assertEquals(res.status, 401)
+})
+
+Deno.test('handler: returns 200 with full JSON payload on valid request', async () => {
+  Deno.env.set('OPERATOR_API_SECRET', 'shh')
+  const req = new Request('http://localhost/', {
+    method: 'POST',
+    headers: { 'X-Operator-Secret': 'shh' },
+  })
+  const res = await handler(req, {
+    supabaseAdmin: makeMockSupabase(validMetrics),
+    stripe: makeMockStripe(87500),
+    now: new Date('2026-05-20T00:00:00+09:00'),
+  })
+  assertEquals(res.status, 200)
+  const body = await res.json()
+  assertEquals(body.stripe_balance_jpy, 87500)
+  assertEquals(body.current_total_obligation_jpy, 23500)
+  assertEquals(body.month_to_date_earnings_jpy, 18000)
+  assertEquals(body.day_of_month, 20)
+  assertEquals(body.last_day_of_month, 31)
+  assertEquals(body.extrapolated_remaining_earnings_jpy, 9900)
+  assertEquals(body.projected_balance_at_month_end_jpy, 33400)
+  assertEquals(body.buffer_multiplier, 1.3)
+  assertEquals(body.recommended_balance_jpy, 43420)
+  assertEquals(body.recommended_topup_jpy, 0)
+})
+
+Deno.test('handler: returns 503 when SQL helper raises (no exchange rate)', async () => {
+  Deno.env.set('OPERATOR_API_SECRET', 'shh')
+  const req = new Request('http://localhost/', {
+    method: 'POST',
+    headers: { 'X-Operator-Secret': 'shh' },
+  })
+  const errorSupabase = {
+    rpc: () =>
+      Promise.resolve({
+        data: null,
+        error: { message: 'No active exchange rate for currency: JPY' },
+      }),
+  } as unknown as SupabaseClient
+  const res = await handler(req, {
+    supabaseAdmin: errorSupabase,
+    stripe: makeMockStripe(87500),
+    now: new Date('2026-05-20T00:00:00+09:00'),
+  })
+  assertEquals(res.status, 503)
+})

--- a/supabase/functions/recommend-payout-topup/index_test.ts
+++ b/supabase/functions/recommend-payout-topup/index_test.ts
@@ -1,6 +1,7 @@
 import { assertEquals } from '@std/assert'
 import { subtractBusinessDays } from './index.ts'
 import { verifyOperatorSecret } from './index.ts'
+import { computeRecommendation } from './index.ts'
 
 Deno.test('subtractBusinessDays: subtracts 7 weekdays from a Sunday', () => {
   // 2026-05-31 is a Sunday. 7 weekdays back = 2026-05-21 (Thursday).
@@ -61,4 +62,76 @@ Deno.test('verifyOperatorSecret: returns false when env is unset', () => {
     headers: { 'X-Operator-Secret': 'anything' },
   })
   assertEquals(verifyOperatorSecret(req), false)
+})
+
+Deno.test('computeRecommendation: matches sanity check at D=1', () => {
+  // Steady-state: 30-day month, rate=50, carry=400, monthly earnings 3000.
+  // D=1, MtD = 100, current_balance = 500.
+  const r = computeRecommendation({
+    stripeBalanceJpy: 0,
+    totalObligationJpy: 500,
+    monthToDateEarningsJpy: 100,
+    bufferMultiplier: 1.3,
+    dayOfMonth: 1,
+    lastDayOfMonth: 30,
+  })
+  assertEquals(r.extrapolatedRemainingEarningsJpy, 2900)
+  assertEquals(r.projectedBalanceAtMonthEndJpy, 3400)
+  assertEquals(r.recommendedBalanceJpy, 4420)
+  assertEquals(r.recommendedTopupJpy, 4420)
+})
+
+Deno.test('computeRecommendation: matches sanity check at D=15', () => {
+  const r = computeRecommendation({
+    stripeBalanceJpy: 0,
+    totalObligationJpy: 1900,
+    monthToDateEarningsJpy: 1500,
+    bufferMultiplier: 1.3,
+    dayOfMonth: 15,
+    lastDayOfMonth: 30,
+  })
+  assertEquals(r.extrapolatedRemainingEarningsJpy, 1500)
+  assertEquals(r.projectedBalanceAtMonthEndJpy, 3400)
+  assertEquals(r.recommendedBalanceJpy, 4420)
+  assertEquals(r.recommendedTopupJpy, 4420)
+})
+
+Deno.test('computeRecommendation: clamps extrapolation when D >= L', () => {
+  const r = computeRecommendation({
+    stripeBalanceJpy: 0,
+    totalObligationJpy: 3400,
+    monthToDateEarningsJpy: 3000,
+    bufferMultiplier: 1.3,
+    dayOfMonth: 31,
+    lastDayOfMonth: 30, // late edge case; D > L
+  })
+  assertEquals(r.extrapolatedRemainingEarningsJpy, 0)
+  assertEquals(r.projectedBalanceAtMonthEndJpy, 3400)
+})
+
+Deno.test('computeRecommendation: recommended_topup is never negative', () => {
+  const r = computeRecommendation({
+    stripeBalanceJpy: 100000,
+    totalObligationJpy: 1900,
+    monthToDateEarningsJpy: 1500,
+    bufferMultiplier: 1.3,
+    dayOfMonth: 15,
+    lastDayOfMonth: 30,
+  })
+  assertEquals(r.recommendedTopupJpy, 0)
+})
+
+Deno.test('computeRecommendation: matches the spec example (May 20, 31-day month)', () => {
+  const r = computeRecommendation({
+    stripeBalanceJpy: 87500,
+    totalObligationJpy: 23500,
+    monthToDateEarningsJpy: 18000,
+    bufferMultiplier: 1.3,
+    dayOfMonth: 20,
+    lastDayOfMonth: 31,
+  })
+  assertEquals(r.extrapolatedRemainingEarningsJpy, 9900)
+  assertEquals(r.projectedBalanceAtMonthEndJpy, 33400)
+  assertEquals(r.recommendedBalanceJpy, 43420)
+  assertEquals(r.recommendedTopupJpy, 0)
 })

--- a/supabase/migrations/20260506145231_add_payout_topup_recommendation.sql
+++ b/supabase/migrations/20260506145231_add_payout_topup_recommendation.sql
@@ -127,3 +127,11 @@ CREATE TRIGGER on_payout_topup_config_update_set_updated_at BEFORE UPDATE ON pub
 -- DML, not detected by schema diff
 INSERT INTO public.payout_topup_config (id) VALUES (true)
 ON CONFLICT (id) DO NOTHING;
+
+-- Permissions hardening, may not be detected by schema diff
+ALTER FUNCTION public.get_payout_topup_metrics(text) OWNER TO postgres;
+
+REVOKE EXECUTE ON FUNCTION public.get_payout_topup_metrics(text) FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION public.get_payout_topup_metrics(text) FROM anon;
+REVOKE EXECUTE ON FUNCTION public.get_payout_topup_metrics(text) FROM authenticated;
+GRANT EXECUTE ON FUNCTION public.get_payout_topup_metrics(text) TO service_role;

--- a/supabase/migrations/20260506145231_add_payout_topup_recommendation.sql
+++ b/supabase/migrations/20260506145231_add_payout_topup_recommendation.sql
@@ -1,0 +1,129 @@
+
+  create table "public"."payout_topup_config" (
+    "id" boolean not null default true,
+    "buffer_multiplier" numeric not null default 1.3,
+    "created_at" timestamp with time zone not null default now(),
+    "updated_at" timestamp with time zone not null default now()
+      );
+
+
+alter table "public"."payout_topup_config" enable row level security;
+
+CREATE UNIQUE INDEX payout_topup_config_pkey ON public.payout_topup_config USING btree (id);
+
+alter table "public"."payout_topup_config" add constraint "payout_topup_config_pkey" PRIMARY KEY using index "payout_topup_config_pkey";
+
+alter table "public"."payout_topup_config" add constraint "buffer_multiplier_min" CHECK ((buffer_multiplier >= 1.0)) not valid;
+
+alter table "public"."payout_topup_config" validate constraint "buffer_multiplier_min";
+
+alter table "public"."payout_topup_config" add constraint "singleton" CHECK ((id = true)) not valid;
+
+alter table "public"."payout_topup_config" validate constraint "singleton";
+
+set check_function_bodies = off;
+
+CREATE OR REPLACE FUNCTION public.get_payout_topup_metrics(p_currency text DEFAULT 'JPY'::text)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO ''
+AS $function$
+DECLARE
+    v_rate integer;
+    v_total_obligation_pts numeric;
+    v_mtd_earnings_pts numeric;
+    v_buffer_multiplier numeric;
+    v_month_start_jst timestamptz;
+BEGIN
+    -- Get active exchange rate
+    SELECT rate_per_point INTO v_rate
+    FROM public.reward_exchange_rates
+    WHERE currency = p_currency AND active = true;
+
+    IF v_rate IS NULL THEN
+        RAISE EXCEPTION 'No active exchange rate for currency: %', p_currency;
+    END IF;
+
+    -- Sum of all wallet balances (carry-over from prior months + current)
+    SELECT COALESCE(SUM(balance), 0) INTO v_total_obligation_pts
+    FROM public.reward_wallets;
+
+    -- Beginning of current month in Asia/Tokyo, then back to timestamptz
+    v_month_start_jst := (date_trunc('month', (now() AT TIME ZONE 'Asia/Tokyo')))
+                         AT TIME ZONE 'Asia/Tokyo';
+
+    -- Month-to-date positive earnings (only earning reasons, not payouts)
+    SELECT COALESCE(SUM(amount), 0) INTO v_mtd_earnings_pts
+    FROM public.reward_ledger
+    WHERE reason IN ('review_completed', 'evidence_timeout', 'manual_adjustment')
+      AND amount > 0
+      AND created_at >= v_month_start_jst;
+
+    -- Singleton config row
+    SELECT buffer_multiplier INTO v_buffer_multiplier
+    FROM public.payout_topup_config
+    WHERE id = true;
+
+    IF v_buffer_multiplier IS NULL THEN
+        RAISE EXCEPTION 'payout_topup_config singleton row missing';
+    END IF;
+
+    RETURN jsonb_build_object(
+        'currency', p_currency,
+        'rate_per_point', v_rate,
+        'total_obligation_jpy', v_total_obligation_pts * v_rate,
+        'month_to_date_earnings_jpy', v_mtd_earnings_pts * v_rate,
+        'buffer_multiplier', v_buffer_multiplier
+    );
+END;
+$function$
+;
+
+grant delete on table "public"."payout_topup_config" to "anon";
+
+grant insert on table "public"."payout_topup_config" to "anon";
+
+grant references on table "public"."payout_topup_config" to "anon";
+
+grant select on table "public"."payout_topup_config" to "anon";
+
+grant trigger on table "public"."payout_topup_config" to "anon";
+
+grant truncate on table "public"."payout_topup_config" to "anon";
+
+grant update on table "public"."payout_topup_config" to "anon";
+
+grant delete on table "public"."payout_topup_config" to "authenticated";
+
+grant insert on table "public"."payout_topup_config" to "authenticated";
+
+grant references on table "public"."payout_topup_config" to "authenticated";
+
+grant select on table "public"."payout_topup_config" to "authenticated";
+
+grant trigger on table "public"."payout_topup_config" to "authenticated";
+
+grant truncate on table "public"."payout_topup_config" to "authenticated";
+
+grant update on table "public"."payout_topup_config" to "authenticated";
+
+grant delete on table "public"."payout_topup_config" to "service_role";
+
+grant insert on table "public"."payout_topup_config" to "service_role";
+
+grant references on table "public"."payout_topup_config" to "service_role";
+
+grant select on table "public"."payout_topup_config" to "service_role";
+
+grant trigger on table "public"."payout_topup_config" to "service_role";
+
+grant truncate on table "public"."payout_topup_config" to "service_role";
+
+grant update on table "public"."payout_topup_config" to "service_role";
+
+CREATE TRIGGER on_payout_topup_config_update_set_updated_at BEFORE UPDATE ON public.payout_topup_config FOR EACH ROW EXECUTE FUNCTION public.handle_updated_at();
+
+-- DML, not detected by schema diff
+INSERT INTO public.payout_topup_config (id) VALUES (true)
+ON CONFLICT (id) DO NOTHING;

--- a/supabase/schemas/reward/functions/get_payout_topup_metrics.sql
+++ b/supabase/schemas/reward/functions/get_payout_topup_metrics.sql
@@ -1,0 +1,56 @@
+CREATE OR REPLACE FUNCTION public.get_payout_topup_metrics(p_currency text DEFAULT 'JPY'::text)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO ''
+AS $function$
+DECLARE
+    v_rate integer;
+    v_total_obligation_pts numeric;
+    v_mtd_earnings_pts numeric;
+    v_buffer_multiplier numeric;
+    v_month_start_jst timestamptz;
+BEGIN
+    -- Get active exchange rate
+    SELECT rate_per_point INTO v_rate
+    FROM public.reward_exchange_rates
+    WHERE currency = p_currency AND active = true;
+
+    IF v_rate IS NULL THEN
+        RAISE EXCEPTION 'No active exchange rate for currency: %', p_currency;
+    END IF;
+
+    -- Sum of all wallet balances (carry-over from prior months + current)
+    SELECT COALESCE(SUM(balance), 0) INTO v_total_obligation_pts
+    FROM public.reward_wallets;
+
+    -- Beginning of current month in Asia/Tokyo, then back to timestamptz
+    v_month_start_jst := (date_trunc('month', (now() AT TIME ZONE 'Asia/Tokyo')))
+                         AT TIME ZONE 'Asia/Tokyo';
+
+    -- Month-to-date positive earnings (only earning reasons, not payouts)
+    SELECT COALESCE(SUM(amount), 0) INTO v_mtd_earnings_pts
+    FROM public.reward_ledger
+    WHERE reason IN ('review_completed', 'evidence_timeout', 'manual_adjustment')
+      AND amount > 0
+      AND created_at >= v_month_start_jst;
+
+    -- Singleton config row
+    SELECT buffer_multiplier INTO v_buffer_multiplier
+    FROM public.payout_topup_config
+    WHERE id = true;
+
+    IF v_buffer_multiplier IS NULL THEN
+        RAISE EXCEPTION 'payout_topup_config singleton row missing';
+    END IF;
+
+    RETURN jsonb_build_object(
+        'currency', p_currency,
+        'rate_per_point', v_rate,
+        'total_obligation_jpy', v_total_obligation_pts * v_rate,
+        'month_to_date_earnings_jpy', v_mtd_earnings_pts * v_rate,
+        'buffer_multiplier', v_buffer_multiplier
+    );
+END;
+$function$
+;

--- a/supabase/schemas/reward/functions/get_payout_topup_metrics.sql
+++ b/supabase/schemas/reward/functions/get_payout_topup_metrics.sql
@@ -54,3 +54,10 @@ BEGIN
 END;
 $function$
 ;
+
+ALTER FUNCTION public.get_payout_topup_metrics(text) OWNER TO postgres;
+
+REVOKE EXECUTE ON FUNCTION public.get_payout_topup_metrics(text) FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION public.get_payout_topup_metrics(text) FROM anon;
+REVOKE EXECUTE ON FUNCTION public.get_payout_topup_metrics(text) FROM authenticated;
+GRANT EXECUTE ON FUNCTION public.get_payout_topup_metrics(text) TO service_role;

--- a/supabase/schemas/reward/policies/payout_topup_config_policies.sql
+++ b/supabase/schemas/reward/policies/payout_topup_config_policies.sql
@@ -1,0 +1,5 @@
+ALTER TABLE public.payout_topup_config ENABLE ROW LEVEL SECURITY;
+
+-- No SELECT/INSERT/UPDATE/DELETE policies are defined for any client role.
+-- Only service_role (used by the operator Edge Function) bypasses RLS.
+-- Authenticated clients are blocked by RLS default-deny.

--- a/supabase/schemas/reward/tables/payout_topup_config.sql
+++ b/supabase/schemas/reward/tables/payout_topup_config.sql
@@ -1,0 +1,12 @@
+CREATE TABLE IF NOT EXISTS public.payout_topup_config (
+    id boolean PRIMARY KEY DEFAULT true,
+    buffer_multiplier numeric NOT NULL DEFAULT 1.3,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL,
+    CONSTRAINT singleton CHECK (id = true),
+    CONSTRAINT buffer_multiplier_min CHECK (buffer_multiplier >= 1.0)
+);
+
+ALTER TABLE public.payout_topup_config OWNER TO postgres;
+
+COMMENT ON TABLE public.payout_topup_config IS 'Singleton config for the payout top-up recommendation feature. buffer_multiplier scales projected month-end balance to determine recommended Stripe top-up amount.';

--- a/supabase/schemas/reward/triggers/on_payout_topup_config_update_set_updated_at.sql
+++ b/supabase/schemas/reward/triggers/on_payout_topup_config_update_set_updated_at.sql
@@ -1,0 +1,4 @@
+CREATE TRIGGER on_payout_topup_config_update_set_updated_at
+    BEFORE UPDATE ON public.payout_topup_config
+    FOR EACH ROW
+    EXECUTE FUNCTION public.handle_updated_at();

--- a/supabase/tests/database/get_payout_topup_metrics.test.sql
+++ b/supabase/tests/database/get_payout_topup_metrics.test.sql
@@ -1,0 +1,89 @@
+begin;
+create extension if not exists pgtap with schema extensions;
+select plan(6);
+
+-- ============================================================
+-- Setup: two test users, exchange rate already seeded by migration
+-- ============================================================
+INSERT INTO auth.users (id, email) VALUES
+    ('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', 'a@test.com'),
+    ('bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb', 'b@test.com');
+
+-- Create wallets (carry-over balances from prior months)
+INSERT INTO public.reward_wallets (user_id, balance) VALUES
+    ('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', 8),    -- 8 pts = 400 JPY
+    ('bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb', 0);
+
+-- Add reward_ledger entries:
+--   user A: 8 pts of carry-over (created_at = last month, NOT counted in MtD)
+INSERT INTO public.reward_ledger (user_id, amount, reason, created_at)
+VALUES (
+    'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', 8, 'review_completed',
+    (now() AT TIME ZONE 'Asia/Tokyo' - INTERVAL '40 days') AT TIME ZONE 'Asia/Tokyo'
+);
+
+-- Add MtD earnings: user A earns 30 pts this month, user B earns 10 pts this month
+INSERT INTO public.reward_ledger (user_id, amount, reason, created_at)
+VALUES
+    ('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', 30, 'review_completed', now()),
+    ('bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb', 10, 'evidence_timeout', now());
+
+-- Update wallets to reflect new earnings (in real flow, grant_reward does both)
+UPDATE public.reward_wallets SET balance = 38 WHERE user_id = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
+UPDATE public.reward_wallets SET balance = 10 WHERE user_id = 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb';
+
+-- ============================================================
+-- Test 1: Function returns expected currency and rate
+-- ============================================================
+SELECT is(
+    (SELECT public.get_payout_topup_metrics('JPY')->>'currency'),
+    'JPY',
+    'Currency is JPY'
+);
+
+SELECT is(
+    (SELECT (public.get_payout_topup_metrics('JPY')->>'rate_per_point')::integer),
+    50,
+    'rate_per_point is 50 (seeded)'
+);
+
+-- ============================================================
+-- Test 2: total_obligation_jpy = (8 + 30 + 10) * 50 = 2400
+-- ============================================================
+SELECT is(
+    (SELECT (public.get_payout_topup_metrics('JPY')->>'total_obligation_jpy')::numeric),
+    2400::numeric,
+    'total_obligation_jpy = sum(wallet.balance) * rate'
+);
+
+-- ============================================================
+-- Test 3: month_to_date_earnings_jpy = (30 + 10) * 50 = 2000
+--   (carry-over entry from 40 days ago is excluded)
+-- ============================================================
+SELECT is(
+    (SELECT (public.get_payout_topup_metrics('JPY')->>'month_to_date_earnings_jpy')::numeric),
+    2000::numeric,
+    'month_to_date_earnings_jpy excludes prior-month entries'
+);
+
+-- ============================================================
+-- Test 4: buffer_multiplier comes from singleton config
+-- ============================================================
+SELECT is(
+    (SELECT (public.get_payout_topup_metrics('JPY')->>'buffer_multiplier')::numeric),
+    1.3::numeric,
+    'buffer_multiplier = 1.3 (default seeded)'
+);
+
+-- ============================================================
+-- Test 5: Unknown currency raises an exception
+-- ============================================================
+SELECT throws_ok(
+    $$SELECT public.get_payout_topup_metrics('USD')$$,
+    'P0001',  -- raise_exception
+    'No active exchange rate for currency: USD',
+    'Unknown currency raises exception'
+);
+
+select * from finish();
+rollback;

--- a/supabase/tests/database/payout_topup_config.test.sql
+++ b/supabase/tests/database/payout_topup_config.test.sql
@@ -12,7 +12,7 @@ SELECT is(
 );
 
 -- ============================================================
--- Test 2: Cannot insert a second row (singleton constraint)
+-- Test 2: Cannot insert a second row (PK uniqueness)
 -- ============================================================
 SELECT throws_ok(
     $$INSERT INTO public.payout_topup_config (id, buffer_multiplier) VALUES (true, 2.0)$$,
@@ -36,6 +36,8 @@ SELECT throws_ok(
 -- ============================================================
 -- Test 4: buffer_multiplier < 1.0 is rejected
 -- ============================================================
+-- Defensive delete so Test 4 does not depend on Test 3's side effect
+DELETE FROM public.payout_topup_config;
 SELECT throws_ok(
     $$INSERT INTO public.payout_topup_config (id, buffer_multiplier) VALUES (true, 0.5)$$,
     '23514',  -- check_violation

--- a/supabase/tests/database/payout_topup_config.test.sql
+++ b/supabase/tests/database/payout_topup_config.test.sql
@@ -1,0 +1,47 @@
+begin;
+create extension if not exists pgtap with schema extensions;
+select plan(4);
+
+-- ============================================================
+-- Test 1: Default singleton row exists with default buffer_multiplier
+-- ============================================================
+SELECT is(
+    (SELECT buffer_multiplier FROM public.payout_topup_config WHERE id = true),
+    1.3::numeric,
+    'Default buffer_multiplier is 1.3'
+);
+
+-- ============================================================
+-- Test 2: Cannot insert a second row (singleton constraint)
+-- ============================================================
+SELECT throws_ok(
+    $$INSERT INTO public.payout_topup_config (id, buffer_multiplier) VALUES (true, 2.0)$$,
+    '23505',  -- unique_violation
+    NULL,
+    'Second row insert violates primary key'
+);
+
+-- ============================================================
+-- Test 3: Cannot insert with id=false (singleton CHECK)
+-- ============================================================
+-- First delete the existing row so PK does not block
+DELETE FROM public.payout_topup_config;
+SELECT throws_ok(
+    $$INSERT INTO public.payout_topup_config (id, buffer_multiplier) VALUES (false, 1.5)$$,
+    '23514',  -- check_violation
+    NULL,
+    'id=false violates singleton CHECK'
+);
+
+-- ============================================================
+-- Test 4: buffer_multiplier < 1.0 is rejected
+-- ============================================================
+SELECT throws_ok(
+    $$INSERT INTO public.payout_topup_config (id, buffer_multiplier) VALUES (true, 0.5)$$,
+    '23514',  -- check_violation
+    NULL,
+    'buffer_multiplier < 1.0 violates buffer_multiplier_min CHECK'
+);
+
+select * from finish();
+rollback;


### PR DESCRIPTION
## Summary

Implements an operator-only Edge Function `recommend-payout-topup` that recommends how much to transfer from the operator's bank to the Stripe platform balance to fund monthly Connect payouts to referees. Adds a singleton config table `payout_topup_config` with a tunable `buffer_multiplier`, and a `SECURITY DEFINER` SQL helper `get_payout_topup_metrics(p_currency)` that aggregates wallet obligations and month-to-date earnings (JST month boundary).

Refs #351. Design: `docs/superpowers/specs/2026-05-06-recommend-payout-topup-design.md`.

## Auth model

Operator-only access via the `X-Operator-Secret` header verified against `OPERATOR_API_SECRET` (constant-time comparison). The Supabase gateway-level `apikey` / `Authorization` headers (publishable key) provide no real access control — by design. `config.toml` keeps `verify_jwt = true` (the CLI default) so the gateway accepts the publishable key just like other functions; the actual operator auth is the custom secret.

## Top-up math

```
recommended_balance = (current_total_obligation + month_to_date_earnings × (L − D) / D) × buffer_multiplier
recommended_topup   = max(0, recommended_balance − stripe_balance)
```

where `D` is the JST day of month, `L` is the last day of the JST month, clamped to 0 when `D ≥ L`. Defaults to `buffer_multiplier = 1.3` (lower-bounded at 1.0; no upper bound so quarterly cadences remain possible).

## Cron alignment

`next_payout_run_at` is computed from JST calendar fields and matches the existing `prepare-monthly-payouts` cron (`'0 15 28-31 * *'` with internal last-day-of-month guard). `transfer_initiate_deadline` is **7 weekdays** before that instant — JP public holidays are NOT auto-detected, so the response always includes a static reminder note about Golden Week / Obon / year-end.

## Security

- `payout_topup_config` is RLS-default-deny (no policies — only `service_role` bypasses).
- `get_payout_topup_metrics` has `EXECUTE` revoked from PUBLIC, anon, and authenticated; granted only to `service_role`. Verified at runtime: `SET ROLE authenticated; SELECT public.get_payout_topup_metrics('JPY');` returns \`permission denied\`.
- `OPERATOR_API_SECRET` is documented in `supabase/functions/.env.example` but never committed with a value.

## Tests

- **18 Deno unit tests** for the Edge Function (helpers + auth + math + full handler with mocked Supabase + Stripe + injected \`now\`; covers 200 / 401 / 405 / 503).
- **10 new pgTAP assertions** (4 for `payout_topup_config` constraints — singleton, PK, CHECK; 6 for `get_payout_topup_metrics` — currency, rate, total obligation, MtD earnings prior-month exclusion, buffer, unknown-currency error).
- All 12 pre-existing pgTAP files in `supabase/tests/database/` continue to pass (no regressions).

## Plan deviations (justified)

- Exported \`Dependencies\` interface to avoid \`as any\` in tests (\`no-explicit-any\` lint rule).
- Used versioned import \`jsr:@supabase/functions-js@^2/edge-runtime.d.ts\` (matches existing functions, satisfies \`no-unversioned-import\`).
- Added \`PayoutTopupMetrics\` typed interface for the RPC return value.
- Added defensive \`bufferMultiplier\` validation (\`Number.isFinite && > 0\`) — guards against future SQL drift producing NaN-laden 200 responses.
- Added 405 method-gate test (cheap regression coverage).
- Extended \`REVOKE EXECUTE\` to anon and authenticated explicitly — Supabase pre-grants these separately from PUBLIC, so PUBLIC alone wouldn't have actually locked them out.

## Test plan

- [x] All Deno unit tests pass (18/18)
- [x] All pgTAP tests pass (12 files in \`tests/database/\`, including 2 new files with 10 new assertions)
- [x] \`supabase db reset\` applies migrations cleanly from scratch
- [x] Runtime ACL verified — only \`service_role\` can EXECUTE \`get_payout_topup_metrics\`
- [ ] Local E2E smoke test: append \`OPERATOR_API_SECRET=<dev-value>\` to \`supabase/functions/.env\`, run \`supabase functions serve recommend-payout-topup --env-file supabase/functions/.env\`, then \`curl\` without secret → 401, with secret → 200 + JSON
- [ ] After merge: \`supabase secrets set OPERATOR_API_SECRET=\$(openssl rand -hex 32)\` and store the value in the operator's task management tool; smoke-test against staging

🤖 Generated with [Claude Code](https://claude.com/claude-code)