### PR TITLE
feat(supabase): daily R2 stale-object sweep

### DIFF
--- a/docs/superpowers/specs/2026-05-07-r2-stale-object-sweep-design.md
+++ b/docs/superpowers/specs/2026-05-07-r2-stale-object-sweep-design.md
@@ -1,0 +1,274 @@
+# R2 Stale-Object Sweep — Daily Cron for Evidence Lifecycle and Avatar Cleanup
+
+**Date:** 2026-05-07
+**Issues:** #390 (evidence lifecycle), #403 (avatar update orphan), #404 (R2 orphan-sweep cron)
+
+## Terminology
+
+"Stale objects" covers both:
+
+- **Expired files** — evidence images past `due_date + 90 days` (the parent task still exists; retention has lapsed).
+- **Orphan files** — avatar objects no longer referenced by any live `profiles` row (either the user has been deleted, or the object has been superseded by a newer avatar upload).
+
+The function name is `sweep-r2-stale-objects` rather than `sweep-r2-orphans` because "orphan" strictly means "parent gone," which fits the avatar cases but not the evidence-lifecycle case (the parent task is still alive). "Stale" cleanly covers both. Issue #404 was filed under the "orphan-sweep" label, but its scope explicitly includes evidence lifecycle, hence the rename.
+
+## Problem
+
+Three related R2 cleanup gaps exist:
+
+1. **Evidence files have no expiration.** The privacy policy (effective 2026-05-05, key `retention.evidenceFiles`) discloses that evidence images are deleted 90 days after the corresponding task's `due_date`. Not yet implemented.
+2. **Avatar update leaves orphans.** Each avatar upload writes a new object at `avatar/<userId>/<uuid>.<ext>` and overwrites `profiles.avatar_url`. The previous object is left in place. UUID-per-upload is intentional (CDN cache busting), so the prior key cannot be deduced from the current `avatar_url`.
+3. **Avatar deletion on account removal is best-effort.** `delete-account/index.ts` deletes the user's avatar prefix before `auth.admin.deleteUser`, but logs and continues on R2 failure. Persistent R2 outages would leave orphan objects despite the privacy policy's prompt-deletion claim.
+
+A single periodic sweep can address all three.
+
+## Design
+
+### Approach
+
+A new Edge Function `sweep-r2-stale-objects` runs daily via `pg_cron`, invoked through `pg_net` with credentials retrieved from Supabase Vault. The function performs three independent sweeps:
+
+| Sub-task | Target | Source issue |
+|---|---|---|
+| Evidence prefix sweep | `evidence/<YYYY-MM-DD>/` directories where `today - prefix_date > 90 days` | #390 |
+| Avatar dead-user sweep | `avatar/<userId>/` prefixes where `userId` is no longer in `profiles` | #404 (#391 best-effort safety net) |
+| Avatar live-user orphan sweep | objects under `avatar/<userId>/` other than the one referenced by `profiles.avatar_url` | #403 |
+
+Per-request avatar deletion (#403's literal acceptance criterion) is **not** implemented. The privacy policy's "速やかに削除" commitment applies only to account deletion, not avatar updates, so a daily sweep satisfies the actual policy obligations. Per-request deletion can be added later as a follow-up if needed; deferring it keeps Edge Function count and client-side surface lower.
+
+### Naming
+
+- Edge Function: `sweep-r2-stale-objects` (verb-first, matches dominant convention: `execute-pending-payouts`, `generate-upload-url`, `delete-account`)
+- Cron job name: `sweep-r2-stale-objects` (matches function name)
+- Cron SQL file: `cron_sweep_r2_stale_objects.sql`
+
+### Cron schedule and invocation
+
+```sql
+SELECT cron.schedule(
+    'sweep-r2-stale-objects',
+    '0 18 * * *',  -- daily 18:00 UTC = 03:00 JST (off-peak)
+    $$SELECT net.http_post(
+        url := (SELECT decrypted_secret FROM vault.decrypted_secrets WHERE name = 'supabase_url')
+              || '/functions/v1/sweep-r2-stale-objects',
+        headers := jsonb_build_object(
+            'Content-Type', 'application/json',
+            'Authorization', 'Bearer ' || (SELECT decrypted_secret FROM vault.decrypted_secrets WHERE name = 'service_role_key')
+        ),
+        body := '{}'::jsonb,
+        timeout_milliseconds := 300000
+    )$$
+);
+```
+
+The pattern matches `cron_execute_pending_payouts.sql`. Vault secrets `supabase_url` and `service_role_key` already exist from prior cron work — no new secret setup required.
+
+`service_role_key` is used as the Bearer token (rather than `anon_key`) because the function performs admin-level reads (`SELECT id, avatar_url FROM profiles` across all users) that bypass RLS. Using `service_role_key` end-to-end keeps the gateway JWT verification (`verify_jwt = true`) and the in-function client consistent.
+
+`timeout_milliseconds` is 5 minutes — longer than `execute-pending-payouts` (2 min) because the sweep iterates all R2 prefixes.
+
+### Sweep logic
+
+#### Evidence prefix sweep
+
+```
+1. ListObjectsV2(Prefix='evidence/', Delimiter='/')
+   → CommonPrefixes contains 'evidence/2025-12-15/' style entries
+2. For each CommonPrefix:
+   - Parse YYYY-MM-DD via regex
+   - On parse failure: log warn, do NOT delete (defensive — protects against unexpected directory names)
+   - If (today - parsedDate) > 90 days:
+       ListObjectsV2(Prefix=<full date prefix>) with pagination
+       DeleteObjects in chunks of 1000
+```
+
+`generate-upload-url` derives the prefix from `task.due_date`, so the prefix name IS the due date. No DB lookup needed.
+
+#### Avatar dead-user sweep
+
+```
+1. ListObjectsV2(Prefix='avatar/', Delimiter='/')
+   → CommonPrefixes contains 'avatar/<userId>/' entries
+2. Collect all userIds from prefix names
+3. SELECT id FROM profiles WHERE id = ANY($1)  -- live users
+4. Set difference: R2 userIds minus live userIds = dead users
+5. For each dead user prefix:
+   - ListObjectsV2(Prefix='avatar/<userId>/') with pagination
+   - DeleteObjects in chunks of 1000
+```
+
+#### Avatar live-user orphan sweep
+
+```
+1. SELECT id, avatar_url FROM profiles WHERE avatar_url IS NOT NULL
+2. For each user:
+   - Extract current key from avatar_url (URL.pathname.slice(1))
+   - ListObjectsV2(Prefix='avatar/<userId>/') with pagination
+   - For each object:
+       Skip if key === currentKey (keep current avatar)
+       Skip if (now - LastModified) < 10 minutes (race protection — see below)
+       Otherwise mark for deletion
+   - DeleteObjects in chunks of 1000
+```
+
+**Race protection — `LastModified` grace period.** The avatar update flow in `profile_repository.dart:65-111` is:
+
+```
+1. generate-upload-url → new r2_key returned
+2. PUT bytes to R2          ← new file appears in R2
+3. UPDATE profiles.avatar_url ← DB row reflects new URL
+```
+
+A sweep running between steps 2 and 3 would see the OLD `avatar_url` while the R2 list contains the NEW file, causing the new file to be deleted as an "orphan." The window is normally <1 second but is not zero.
+
+The grace period (10 minutes) excludes recently-uploaded objects from deletion, collapsing the race window. Orphans aged less than 10 minutes are simply carried over to the next day's sweep. The grace value gives a ~600× safety margin over the typical PUT→UPDATE latency.
+
+This protection applies only to the live-user orphan sweep:
+- Evidence sweep targets `due_date + 90 days` ago — no current uploads possible at that age.
+- Dead-user sweep targets users that already passed `auth.admin.deleteUser` — no future uploads possible.
+
+#### Implementation note: dead-user and live-user sweeps merged in code
+
+The two avatar sweeps are described separately above for clarity, but in `index.ts` they share a single pass over `avatar/` prefixes. For each prefix's userId:
+- If userId not in `profiles`: delete all objects under prefix.
+- If userId in `profiles`: delete all objects under prefix except the current `avatar_url` key, applying the grace-period filter.
+
+This avoids a duplicate `ListObjectsV2(Prefix='avatar/')` call.
+
+### Edge Function structure
+
+```
+supabase/functions/sweep-r2-stale-objects/
+  index.ts          # orchestration: HTTP entry, sweep coordination, summary response
+  helpers.ts        # pure functions (date parsing, URL parsing, predicates)
+  helpers.test.ts   # Deno.test unit tests for helpers
+  deno.json
+```
+
+`index.ts` skeleton:
+
+```typescript
+Deno.serve(async (req) => {
+  if (req.method !== 'POST') return new Response('Method not allowed', { status: 405 })
+
+  // env validation, S3Client + supabase admin client init (same pattern as delete-account)
+
+  const summary = {
+    evidence: emptyResult(),
+    avatar_dead_user: emptyResult(),
+    avatar_live_orphan: emptyResult(),
+  }
+
+  try { await sweepEvidencePrefixes(s3, summary.evidence) } catch (e) { logAndRecord(e, summary.evidence) }
+  try { await sweepAvatarPrefixes(s3, supabase, summary.avatar_dead_user, summary.avatar_live_orphan) } catch (e) { /* ... */ }
+
+  return new Response(JSON.stringify(summary), { status: 200 })
+})
+```
+
+The summary response is for manual debug invocation; pg_net does not consume it. Each sub-task records `{ prefixes_scanned, prefixes_deleted, objects_deleted, errors[] }`.
+
+R2 client initialization mirrors `supabase/functions/delete-account/index.ts:248-257` and uses the existing env vars: `CLOUDFLARE_ACCOUNT_ID`, `R2_ACCESS_KEY_ID`, `R2_SECRET_ACCESS_KEY`, `R2_BUCKET_NAME`, `R2_PUBLIC_DOMAIN`.
+
+`config.toml` adds:
+
+```toml
+[functions.sweep-r2-stale-objects]
+enabled = true
+verify_jwt = true
+import_map = "./functions/sweep-r2-stale-objects/deno.json"
+```
+
+### Pagination
+
+Both `ListObjectsV2` and `DeleteObjects` cap at 1000 entries per call. Production data will exceed this. A shared helper handles list pagination:
+
+```typescript
+async function listAllObjects(s3: S3Client, params: ListObjectsV2CommandInput) {
+  const contents: _Object[] = []
+  const commonPrefixes: CommonPrefix[] = []
+  let token: string | undefined
+  do {
+    const res = await s3.send(new ListObjectsV2Command({ ...params, ContinuationToken: token }))
+    contents.push(...(res.Contents ?? []))
+    commonPrefixes.push(...(res.CommonPrefixes ?? []))
+    token = res.IsTruncated ? res.NextContinuationToken : undefined
+  } while (token)
+  return { contents, commonPrefixes }
+}
+```
+
+Deletion chunks the to-delete keys into 1000-entry batches before each `DeleteObjectsCommand` send.
+
+### Error handling
+
+Three independence levels:
+
+1. **Sub-task level.** The three sweeps each have a top-level try/catch. One failing does not block the others.
+2. **Prefix level.** Within a sweep, each prefix's list/delete is wrapped in a try/catch. Errors push to `errors[]` and the loop continues to the next prefix.
+3. **Object-batch level.** A failed `DeleteObjects` chunk does not abort the prefix; it is recorded and the next chunk proceeds.
+
+`console.error` and `console.warn` produce structured logs visible in the Supabase Functions Dashboard. The summary JSON gives at-a-glance counts on manual invocation.
+
+### Testing
+
+**Pure-logic helpers** (`helpers.ts`) are covered by unit tests in `helpers.test.ts` using Deno's built-in test runner:
+
+- `parseEvidencePrefixDate(prefix: string): Date | null` — valid date, malformed prefix, missing trailing slash, leap-year date.
+- `isOlderThanDays(date: Date, days: number, now: Date): boolean` — exactly N days, N+1 days, future date.
+- `extractKeyFromAvatarUrl(url: string, publicDomain: string): string | null` — well-formed URL, mismatched domain, malformed URL.
+- `isWithinGracePeriod(lastModified: Date, now: Date, graceMs: number): boolean` — recent, exact boundary, old.
+
+Run via:
+
+```bash
+cd supabase/functions/sweep-r2-stale-objects && deno test
+```
+
+**Orchestration code** (`index.ts`) is verified manually on staging. Mocking R2 / Postgres for orchestration tests has low fidelity for this kind of code, so the cost-benefit favors manual end-to-end checks over mocked tests.
+
+Manual verification steps (staging):
+
+1. Seed R2 with: an old `evidence/2024-01-01/` prefix (>90 days), an `avatar/<deletedUserId>/` prefix where the user is not in `profiles`, an `avatar/<liveUserId>/` prefix containing both the current avatar and an old UUID file.
+2. Manually invoke `sweep-r2-stale-objects` (curl with service_role bearer or Supabase Functions Dashboard "Run").
+3. Inspect the response summary — confirm non-zero deletion counts.
+4. Inspect R2 console — confirm: old evidence prefix gone, dead-user prefix gone, live user retains current avatar only.
+5. Re-invoke and confirm zero deletions (idempotence).
+
+### Files changed
+
+```
+supabase/
+  functions/
+    sweep-r2-stale-objects/
+      index.ts            # NEW
+      helpers.ts          # NEW
+      helpers.test.ts     # NEW
+      deno.json           # NEW
+  config.toml             # MODIFY: add [functions.sweep-r2-stale-objects]
+  schemas/
+    common/
+      cron/
+        cron_sweep_r2_stale_objects.sql  # NEW (directory + file)
+  migrations/
+    <generated>.sql       # NEW: via `supabase db diff`, then manually append cron.schedule DML
+                          #      with `-- DML, not detected by schema diff` comment
+```
+
+`supabase/config.toml` `[db.migrations]` registers `common/cron/cron_sweep_r2_stale_objects.sql` so `db diff` picks up the new schema file.
+
+## Issue closure
+
+| Issue | Disposition |
+|---|---|
+| #390 (evidence lifecycle) | Close — acceptance criteria fully satisfied by evidence prefix sweep. |
+| #404 (R2 orphan-sweep cron) | Close — this PR is the issue's body of work. |
+| #403 (avatar update orphan) | Close as covered-by-sweep — daily cleanup satisfies the acceptance criterion ("After a second avatar upload, the first avatar object is no longer present") on a daily cadence. Per-request deletion can be filed as a new issue if immediate cleanup is desired in the future. |
+
+## Out of scope
+
+- **Per-request avatar deletion in the upload flow.** Documented in §Approach. May be added later as a small Edge Function + Flutter client call if daily cadence becomes insufficient.
+- **Generic `invoke_edge_function(name text, body jsonb)` SQL helper.** With only two cron-invoked Edge Functions today (`execute-pending-payouts` and `sweep-r2-stale-objects`), inlining `net.http_post` in each cron file is below the rule-of-three threshold for extraction. To be reconsidered when a third cron-invoked Edge Function appears.
+- **Automated end-to-end tests for the orchestration code.** Mocking R2 / Postgres for this kind of I/O-heavy function has low fidelity; manual staging verification is the chosen substitute.
+- **Alarm / paging on sweep failures.** The function logs and returns a summary; observability beyond Functions Dashboard logs is deferred.
+- **Reporting metrics (objects deleted, bytes reclaimed).** The summary response includes counts but they are not persisted or aggregated.

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -681,3 +681,14 @@ entrypoint = "./functions/recommend-payout-topup/index.ts"
 # Specifies static files to be bundled with the function. Supports glob patterns.
 # For example, if you want to serve static HTML pages in your function:
 # static_files = [ "./functions/recommend-payout-topup/*.html" ]
+
+[functions.sweep-r2-stale-objects]
+enabled = true
+verify_jwt = true
+import_map = "./functions/sweep-r2-stale-objects/deno.json"
+# Uncomment to specify a custom file path to the entrypoint.
+# Supported file extensions are: .ts, .js, .mjs, .jsx, .tsx
+entrypoint = "./functions/sweep-r2-stale-objects/index.ts"
+# Specifies static files to be bundled with the function. Supports glob patterns.
+# For example, if you want to serve static HTML pages in your function:
+# static_files = [ "./functions/sweep-r2-stale-objects/*.html" ]

--- a/supabase/deno.lock
+++ b/supabase/deno.lock
@@ -1437,10 +1437,24 @@
           "npm:stripe@19.3.0"
         ]
       },
+      "functions/recommend-payout-topup": {
+        "dependencies": [
+          "jsr:@std/assert@1",
+          "jsr:@std/testing@0.224",
+          "jsr:@supabase/supabase-js@2",
+          "npm:stripe@20"
+        ]
+      },
       "functions/send-notification": {
         "dependencies": [
           "jsr:@supabase/supabase-js@2",
           "npm:firebase-admin@13.6.0"
+        ]
+      },
+      "functions/sweep-r2-stale-objects": {
+        "dependencies": [
+          "jsr:@supabase/supabase-js@2",
+          "npm:@aws-sdk/client-s3@3"
         ]
       }
     }

--- a/supabase/functions/sweep-r2-stale-objects/.npmrc
+++ b/supabase/functions/sweep-r2-stale-objects/.npmrc
@@ -1,0 +1,3 @@
+# Configuration for private npm package dependencies
+# For more information on using private registries with Edge Functions, see:
+# https://supabase.com/docs/guides/functions/import-maps#importing-from-private-registries

--- a/supabase/functions/sweep-r2-stale-objects/deno.json
+++ b/supabase/functions/sweep-r2-stale-objects/deno.json
@@ -1,0 +1,6 @@
+{
+  "imports": {
+    "@supabase/supabase-js": "jsr:@supabase/supabase-js@2",
+    "@aws-sdk/client-s3": "npm:@aws-sdk/client-s3@3"
+  }
+}

--- a/supabase/functions/sweep-r2-stale-objects/helpers.test.ts
+++ b/supabase/functions/sweep-r2-stale-objects/helpers.test.ts
@@ -94,6 +94,14 @@ Deno.test('extractKeyFromAvatarUrl: empty path returns null', () => {
   )
 })
 
+Deno.test('extractKeyFromAvatarUrl: URL with explicit port still matches', () => {
+  const url = 'https://files.peppercheck.com:443/avatar/abc/def.jpg'
+  assertEquals(
+    extractKeyFromAvatarUrl(url, 'files.peppercheck.com'),
+    'avatar/abc/def.jpg',
+  )
+})
+
 import { isWithinGracePeriod } from './helpers.ts'
 
 Deno.test('isWithinGracePeriod: 5 minutes ago, 10 min grace → within', () => {

--- a/supabase/functions/sweep-r2-stale-objects/helpers.test.ts
+++ b/supabase/functions/sweep-r2-stale-objects/helpers.test.ts
@@ -1,0 +1,121 @@
+import { assertEquals } from 'jsr:@std/assert@1'
+
+Deno.test('test runner smoke check', () => {
+  assertEquals(1 + 1, 2)
+})
+
+import { parseEvidencePrefixDate } from './helpers.ts'
+
+Deno.test('parseEvidencePrefixDate: valid date prefix returns UTC midnight', () => {
+  const result = parseEvidencePrefixDate('evidence/2025-12-15/')
+  assertEquals(result?.toISOString(), '2025-12-15T00:00:00.000Z')
+})
+
+Deno.test('parseEvidencePrefixDate: leap-year date is accepted', () => {
+  const result = parseEvidencePrefixDate('evidence/2024-02-29/')
+  assertEquals(result?.toISOString(), '2024-02-29T00:00:00.000Z')
+})
+
+Deno.test('parseEvidencePrefixDate: missing trailing slash returns null', () => {
+  assertEquals(parseEvidencePrefixDate('evidence/2025-12-15'), null)
+})
+
+Deno.test('parseEvidencePrefixDate: non-date directory returns null', () => {
+  assertEquals(parseEvidencePrefixDate('evidence/foo/'), null)
+})
+
+Deno.test('parseEvidencePrefixDate: invalid month returns null', () => {
+  assertEquals(parseEvidencePrefixDate('evidence/2025-13-01/'), null)
+})
+
+Deno.test('parseEvidencePrefixDate: invalid day returns null', () => {
+  assertEquals(parseEvidencePrefixDate('evidence/2025-02-30/'), null)
+})
+
+Deno.test('parseEvidencePrefixDate: empty string returns null', () => {
+  assertEquals(parseEvidencePrefixDate(''), null)
+})
+
+import { isOlderThanDays } from './helpers.ts'
+
+Deno.test('isOlderThanDays: exactly N days old is NOT older', () => {
+  const now = new Date('2026-05-07T00:00:00Z')
+  const date = new Date('2026-02-06T00:00:00Z') // 90 days before
+  assertEquals(isOlderThanDays(date, 90, now), false)
+})
+
+Deno.test('isOlderThanDays: N+1 days old IS older', () => {
+  const now = new Date('2026-05-07T00:00:00Z')
+  const date = new Date('2026-02-05T00:00:00Z') // 91 days before
+  assertEquals(isOlderThanDays(date, 90, now), true)
+})
+
+Deno.test('isOlderThanDays: same day is NOT older', () => {
+  const now = new Date('2026-05-07T12:00:00Z')
+  const date = new Date('2026-05-07T00:00:00Z')
+  assertEquals(isOlderThanDays(date, 90, now), false)
+})
+
+Deno.test('isOlderThanDays: future date is NOT older', () => {
+  const now = new Date('2026-05-07T00:00:00Z')
+  const date = new Date('2026-06-07T00:00:00Z')
+  assertEquals(isOlderThanDays(date, 90, now), false)
+})
+
+import { extractKeyFromAvatarUrl } from './helpers.ts'
+
+Deno.test('extractKeyFromAvatarUrl: well-formed URL returns the key', () => {
+  const url = 'https://files.peppercheck.com/avatar/abc-123/def-456.jpg'
+  assertEquals(
+    extractKeyFromAvatarUrl(url, 'files.peppercheck.com'),
+    'avatar/abc-123/def-456.jpg',
+  )
+})
+
+Deno.test('extractKeyFromAvatarUrl: mismatched host returns null', () => {
+  const url = 'https://other.example.com/avatar/abc/def.jpg'
+  assertEquals(
+    extractKeyFromAvatarUrl(url, 'files.peppercheck.com'),
+    null,
+  )
+})
+
+Deno.test('extractKeyFromAvatarUrl: not a URL returns null', () => {
+  assertEquals(
+    extractKeyFromAvatarUrl('not-a-url', 'files.peppercheck.com'),
+    null,
+  )
+})
+
+Deno.test('extractKeyFromAvatarUrl: empty path returns null', () => {
+  assertEquals(
+    extractKeyFromAvatarUrl('https://files.peppercheck.com/', 'files.peppercheck.com'),
+    null,
+  )
+})
+
+import { isWithinGracePeriod } from './helpers.ts'
+
+Deno.test('isWithinGracePeriod: 5 minutes ago, 10 min grace → within', () => {
+  const now = new Date('2026-05-07T12:00:00Z')
+  const lastModified = new Date('2026-05-07T11:55:00Z')
+  assertEquals(isWithinGracePeriod(lastModified, now, 10 * 60_000), true)
+})
+
+Deno.test('isWithinGracePeriod: exactly 10 minutes ago, 10 min grace → NOT within (strict <)', () => {
+  const now = new Date('2026-05-07T12:00:00Z')
+  const lastModified = new Date('2026-05-07T11:50:00Z')
+  assertEquals(isWithinGracePeriod(lastModified, now, 10 * 60_000), false)
+})
+
+Deno.test('isWithinGracePeriod: 20 minutes ago, 10 min grace → NOT within', () => {
+  const now = new Date('2026-05-07T12:00:00Z')
+  const lastModified = new Date('2026-05-07T11:40:00Z')
+  assertEquals(isWithinGracePeriod(lastModified, now, 10 * 60_000), false)
+})
+
+Deno.test('isWithinGracePeriod: future timestamp → within (defensive)', () => {
+  const now = new Date('2026-05-07T12:00:00Z')
+  const lastModified = new Date('2026-05-07T12:01:00Z')
+  assertEquals(isWithinGracePeriod(lastModified, now, 10 * 60_000), true)
+})

--- a/supabase/functions/sweep-r2-stale-objects/helpers.ts
+++ b/supabase/functions/sweep-r2-stale-objects/helpers.ts
@@ -46,7 +46,7 @@ export function extractKeyFromAvatarUrl(
   } catch {
     return null
   }
-  if (parsed.host !== publicDomain) return null
+  if (parsed.hostname !== publicDomain) return null
   const key = parsed.pathname.replace(/^\//, '')
   return key.length > 0 ? key : null
 }

--- a/supabase/functions/sweep-r2-stale-objects/helpers.ts
+++ b/supabase/functions/sweep-r2-stale-objects/helpers.ts
@@ -1,0 +1,61 @@
+// Pure helpers used by the sweep-r2-stale-objects Edge Function.
+// Kept separate from index.ts so they can be unit-tested in isolation.
+
+const EVIDENCE_PREFIX_PATTERN = /^evidence\/(\d{4})-(\d{2})-(\d{2})\/$/
+
+export function parseEvidencePrefixDate(prefix: string): Date | null {
+  const match = prefix.match(EVIDENCE_PREFIX_PATTERN)
+  if (!match) return null
+
+  const [, yearStr, monthStr, dayStr] = match
+  const year = Number(yearStr)
+  const month = Number(monthStr)
+  const day = Number(dayStr)
+
+  // Reject obviously invalid components before constructing the Date.
+  if (month < 1 || month > 12 || day < 1 || day > 31) return null
+
+  const date = new Date(Date.UTC(year, month - 1, day))
+
+  // Reject calendar-impossible dates (e.g., 2025-02-30 → JS rolls into March).
+  if (
+    date.getUTCFullYear() !== year ||
+    date.getUTCMonth() !== month - 1 ||
+    date.getUTCDate() !== day
+  ) {
+    return null
+  }
+
+  return date
+}
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000
+
+export function isOlderThanDays(date: Date, days: number, now: Date): boolean {
+  const ageMs = now.getTime() - date.getTime()
+  return ageMs > days * MS_PER_DAY
+}
+
+export function extractKeyFromAvatarUrl(
+  url: string,
+  publicDomain: string,
+): string | null {
+  let parsed: URL
+  try {
+    parsed = new URL(url)
+  } catch {
+    return null
+  }
+  if (parsed.host !== publicDomain) return null
+  const key = parsed.pathname.replace(/^\//, '')
+  return key.length > 0 ? key : null
+}
+
+export function isWithinGracePeriod(
+  lastModified: Date,
+  now: Date,
+  graceMs: number,
+): boolean {
+  const ageMs = now.getTime() - lastModified.getTime()
+  return ageMs < graceMs
+}

--- a/supabase/functions/sweep-r2-stale-objects/index.ts
+++ b/supabase/functions/sweep-r2-stale-objects/index.ts
@@ -93,7 +93,9 @@ async function deleteObjectsInChunks(
   s3: S3Client,
   bucket: string,
   keys: string[],
+  dryRun: boolean,
 ): Promise<number> {
+  if (dryRun) return keys.length // pretend we deleted them all
   let deleted = 0
   for (let i = 0; i < keys.length; i += S3_BATCH_LIMIT) {
     const chunk = keys.slice(i, i + S3_BATCH_LIMIT)
@@ -112,6 +114,7 @@ async function sweepEvidencePrefixes(
   s3: S3Client,
   bucket: string,
   now: Date,
+  dryRun: boolean,
   result: SweepResult,
 ): Promise<void> {
   const top = await listAllObjects(s3, {
@@ -139,7 +142,7 @@ async function sweepEvidencePrefixes(
       const keys = contents.map((c) => c.Key).filter((k): k is string => Boolean(k))
       if (keys.length === 0) continue
 
-      const deleted = await deleteObjectsInChunks(s3, bucket, keys)
+      const deleted = await deleteObjectsInChunks(s3, bucket, keys, dryRun)
       result.objects_deleted += deleted
       result.prefixes_deleted += 1
     } catch (err) {
@@ -193,6 +196,7 @@ async function sweepAvatarPrefixes(
   bucket: string,
   publicDomain: string,
   now: Date,
+  dryRun: boolean,
   result: SweepResult,
 ): Promise<void> {
   const { live, skip } = await fetchLiveUserAvatars(supabase, publicDomain)
@@ -245,7 +249,7 @@ async function sweepAvatarPrefixes(
 
       if (toDelete.length === 0) continue
 
-      const deleted = await deleteObjectsInChunks(s3, bucket, toDelete)
+      const deleted = await deleteObjectsInChunks(s3, bucket, toDelete, dryRun)
       result.objects_deleted += deleted
       result.prefixes_deleted += 1
     } catch (err) {
@@ -260,6 +264,17 @@ Deno.serve(async (req) => {
       JSON.stringify({ error: 'Method not allowed' }),
       { status: 405, headers: { 'Content-Type': 'application/json' } },
     )
+  }
+
+  let dryRun = false
+  try {
+    const body = await req.json()
+    if (body && typeof body === 'object' && body.dry_run === true) {
+      dryRun = true
+    }
+  } catch {
+    // No body or invalid JSON — default to dryRun=false. The cron sends '{}',
+    // which parses fine and naturally results in dryRun=false.
   }
 
   const r2 = buildS3Client()
@@ -287,7 +302,7 @@ Deno.serve(async (req) => {
   }
 
   try {
-    await sweepEvidencePrefixes(r2.s3, r2.env.bucket, now, summary.evidence)
+    await sweepEvidencePrefixes(r2.s3, r2.env.bucket, now, dryRun, summary.evidence)
   } catch (err) {
     recordError(summary.evidence, 'evidence sweep top-level', err)
   }
@@ -299,14 +314,15 @@ Deno.serve(async (req) => {
       r2.env.bucket,
       r2.env.publicDomain,
       now,
+      dryRun,
       summary.avatar,
     )
   } catch (err) {
     recordError(summary.avatar, 'avatar sweep top-level', err)
   }
 
-  return new Response(JSON.stringify(summary), {
-    status: 200,
-    headers: { 'Content-Type': 'application/json' },
-  })
+  return new Response(
+    JSON.stringify({ dry_run: dryRun, ...summary }),
+    { status: 200, headers: { 'Content-Type': 'application/json' } },
+  )
 })

--- a/supabase/functions/sweep-r2-stale-objects/index.ts
+++ b/supabase/functions/sweep-r2-stale-objects/index.ts
@@ -33,8 +33,12 @@ function emptyResult(): SweepResult {
 }
 
 function recordError(result: SweepResult, context: string, err: unknown): void {
-  const message = err instanceof Error ? err.message : String(err)
-  console.error(`[sweep-r2-stale-objects] ${context}: ${message}`)
+  // Pass the error object directly to console.error so Deno prints the class
+  // name, stack trace, and any nested fields (e.g. PostgrestError.code,
+  // S3ServiceException.$metadata). Without this, debugging cron failures
+  // requires redeploying with extra logging.
+  console.error(`[sweep-r2-stale-objects] ${context}:`, err)
+  const message = err instanceof Error ? `${err.name}: ${err.message}` : String(err)
   result.errors.push(`${context}: ${message}`)
 }
 
@@ -276,6 +280,8 @@ Deno.serve(async (req) => {
     // No body or invalid JSON — default to dryRun=false. The cron sends '{}',
     // which parses fine and naturally results in dryRun=false.
   }
+
+  console.log(`[sweep-r2-stale-objects] starting sweep (dry_run=${dryRun})`)
 
   const r2 = buildS3Client()
   if (!r2) {

--- a/supabase/functions/sweep-r2-stale-objects/index.ts
+++ b/supabase/functions/sweep-r2-stale-objects/index.ts
@@ -1,13 +1,311 @@
 import 'jsr:@supabase/functions-js@^2/edge-runtime.d.ts'
 
-Deno.serve((req) => {
+import { createClient, SupabaseClient } from '@supabase/supabase-js'
+import {
+  type _Object,
+  type CommonPrefix,
+  DeleteObjectsCommand,
+  ListObjectsV2Command,
+  type ListObjectsV2CommandInput,
+  S3Client,
+} from '@aws-sdk/client-s3'
+
+import {
+  extractKeyFromAvatarUrl,
+  isOlderThanDays,
+  isWithinGracePeriod,
+  parseEvidencePrefixDate,
+} from './helpers.ts'
+
+const EVIDENCE_RETENTION_DAYS = 90
+const AVATAR_GRACE_MS = 10 * 60 * 1000 // 10 minutes
+const S3_BATCH_LIMIT = 1000
+
+interface SweepResult {
+  prefixes_scanned: number
+  prefixes_deleted: number
+  objects_deleted: number
+  errors: string[]
+}
+
+function emptyResult(): SweepResult {
+  return { prefixes_scanned: 0, prefixes_deleted: 0, objects_deleted: 0, errors: [] }
+}
+
+function recordError(result: SweepResult, context: string, err: unknown): void {
+  const message = err instanceof Error ? err.message : String(err)
+  console.error(`[sweep-r2-stale-objects] ${context}: ${message}`)
+  result.errors.push(`${context}: ${message}`)
+}
+
+interface R2Env {
+  bucket: string
+  publicDomain: string
+}
+
+function buildS3Client(): { s3: S3Client; env: R2Env } | null {
+  const accountId = Deno.env.get('CLOUDFLARE_ACCOUNT_ID')
+  const accessKeyId = Deno.env.get('R2_ACCESS_KEY_ID')
+  const secretAccessKey = Deno.env.get('R2_SECRET_ACCESS_KEY')
+  const bucket = Deno.env.get('R2_BUCKET_NAME')
+  const publicDomain = Deno.env.get('R2_PUBLIC_DOMAIN')
+
+  if (!accountId || !accessKeyId || !secretAccessKey || !bucket || !publicDomain) {
+    console.error(
+      '[sweep-r2-stale-objects] R2 environment variables missing — aborting sweep.',
+    )
+    return null
+  }
+
+  const s3 = new S3Client({
+    region: 'auto',
+    endpoint: `https://${accountId}.r2.cloudflarestorage.com`,
+    credentials: { accessKeyId, secretAccessKey },
+  })
+
+  return { s3, env: { bucket, publicDomain } }
+}
+
+interface ListAllResult {
+  contents: _Object[]
+  commonPrefixes: CommonPrefix[]
+}
+
+async function listAllObjects(
+  s3: S3Client,
+  params: ListObjectsV2CommandInput,
+): Promise<ListAllResult> {
+  const contents: _Object[] = []
+  const commonPrefixes: CommonPrefix[] = []
+  let continuationToken: string | undefined
+  do {
+    const res = await s3.send(
+      new ListObjectsV2Command({ ...params, ContinuationToken: continuationToken }),
+    )
+    contents.push(...(res.Contents ?? []))
+    commonPrefixes.push(...(res.CommonPrefixes ?? []))
+    continuationToken = res.IsTruncated ? res.NextContinuationToken : undefined
+  } while (continuationToken)
+  return { contents, commonPrefixes }
+}
+
+async function deleteObjectsInChunks(
+  s3: S3Client,
+  bucket: string,
+  keys: string[],
+): Promise<number> {
+  let deleted = 0
+  for (let i = 0; i < keys.length; i += S3_BATCH_LIMIT) {
+    const chunk = keys.slice(i, i + S3_BATCH_LIMIT)
+    const res = await s3.send(
+      new DeleteObjectsCommand({
+        Bucket: bucket,
+        Delete: { Objects: chunk.map((Key) => ({ Key })) },
+      }),
+    )
+    deleted += res.Deleted?.length ?? 0
+  }
+  return deleted
+}
+
+async function sweepEvidencePrefixes(
+  s3: S3Client,
+  bucket: string,
+  now: Date,
+  result: SweepResult,
+): Promise<void> {
+  const top = await listAllObjects(s3, {
+    Bucket: bucket,
+    Prefix: 'evidence/',
+    Delimiter: '/',
+  })
+
+  for (const cp of top.commonPrefixes) {
+    const prefix = cp.Prefix
+    if (!prefix) continue
+    result.prefixes_scanned += 1
+
+    const date = parseEvidencePrefixDate(prefix)
+    if (!date) {
+      console.warn(
+        `[sweep-r2-stale-objects] Skipping unrecognized evidence prefix: ${prefix}`,
+      )
+      continue
+    }
+    if (!isOlderThanDays(date, EVIDENCE_RETENTION_DAYS, now)) continue
+
+    try {
+      const { contents } = await listAllObjects(s3, { Bucket: bucket, Prefix: prefix })
+      const keys = contents.map((c) => c.Key).filter((k): k is string => Boolean(k))
+      if (keys.length === 0) continue
+
+      const deleted = await deleteObjectsInChunks(s3, bucket, keys)
+      result.objects_deleted += deleted
+      result.prefixes_deleted += 1
+    } catch (err) {
+      recordError(result, `evidence prefix ${prefix}`, err)
+    }
+  }
+}
+
+interface LiveUserAvatars {
+  // userId → currentKey (or null when avatar_url IS NULL).
+  live: Map<string, string | null>
+  // Live users whose avatar_url was non-null but did not parse — defensively
+  // excluded from any deletion so we never delete their real current avatar.
+  skip: Set<string>
+}
+
+async function fetchLiveUserAvatars(
+  supabase: SupabaseClient,
+  publicDomain: string,
+): Promise<LiveUserAvatars> {
+  const { data, error } = await supabase
+    .from('profiles')
+    .select('id, avatar_url')
+  if (error) throw error
+
+  const live = new Map<string, string | null>()
+  const skip = new Set<string>()
+  for (const row of data ?? []) {
+    const id = row.id as string
+    const url = row.avatar_url as string | null
+    if (!url) {
+      live.set(id, null)
+      continue
+    }
+    const key = extractKeyFromAvatarUrl(url, publicDomain)
+    if (key === null) {
+      console.warn(
+        `[sweep-r2-stale-objects] Skipping user ${id}: avatar_url could not be parsed`,
+      )
+      skip.add(id)
+      continue
+    }
+    live.set(id, key)
+  }
+  return { live, skip }
+}
+
+async function sweepAvatarPrefixes(
+  s3: S3Client,
+  supabase: SupabaseClient,
+  bucket: string,
+  publicDomain: string,
+  now: Date,
+  result: SweepResult,
+): Promise<void> {
+  const { live, skip } = await fetchLiveUserAvatars(supabase, publicDomain)
+
+  const top = await listAllObjects(s3, {
+    Bucket: bucket,
+    Prefix: 'avatar/',
+    Delimiter: '/',
+  })
+
+  for (const cp of top.commonPrefixes) {
+    const prefix = cp.Prefix
+    if (!prefix) continue
+    result.prefixes_scanned += 1
+
+    // Extract userId from `avatar/<userId>/`.
+    const match = prefix.match(/^avatar\/([^/]+)\/$/)
+    if (!match) {
+      console.warn(`[sweep-r2-stale-objects] Skipping unrecognized avatar prefix: ${prefix}`)
+      continue
+    }
+    const userId = match[1]
+
+    if (skip.has(userId)) {
+      console.warn(
+        `[sweep-r2-stale-objects] Skipping prefix ${prefix}: avatar_url unparseable`,
+      )
+      continue
+    }
+
+    const isLive = live.has(userId)
+    const currentKey = isLive ? live.get(userId) ?? null : null
+
+    try {
+      const { contents } = await listAllObjects(s3, { Bucket: bucket, Prefix: prefix })
+
+      const toDelete: string[] = []
+      for (const obj of contents) {
+        const key = obj.Key
+        if (!key) continue
+        if (isLive) {
+          if (key === currentKey) continue
+          // Race protection: skip recently-uploaded objects.
+          if (obj.LastModified && isWithinGracePeriod(obj.LastModified, now, AVATAR_GRACE_MS)) {
+            continue
+          }
+        }
+        toDelete.push(key)
+      }
+
+      if (toDelete.length === 0) continue
+
+      const deleted = await deleteObjectsInChunks(s3, bucket, toDelete)
+      result.objects_deleted += deleted
+      result.prefixes_deleted += 1
+    } catch (err) {
+      recordError(result, `avatar prefix ${prefix}`, err)
+    }
+  }
+}
+
+Deno.serve(async (req) => {
   if (req.method !== 'POST') {
     return new Response(
       JSON.stringify({ error: 'Method not allowed' }),
       { status: 405, headers: { 'Content-Type': 'application/json' } },
     )
   }
-  return new Response(JSON.stringify({ ok: true }), {
+
+  const r2 = buildS3Client()
+  if (!r2) {
+    return new Response(
+      JSON.stringify({ error: 'R2 not configured' }),
+      { status: 500, headers: { 'Content-Type': 'application/json' } },
+    )
+  }
+
+  const supabaseUrl = Deno.env.get('SUPABASE_URL') ?? ''
+  const supabaseServiceRoleKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') ?? ''
+  if (!supabaseUrl || !supabaseServiceRoleKey) {
+    return new Response(
+      JSON.stringify({ error: 'Supabase env not configured' }),
+      { status: 500, headers: { 'Content-Type': 'application/json' } },
+    )
+  }
+  const supabase = createClient(supabaseUrl, supabaseServiceRoleKey)
+
+  const now = new Date()
+  const summary = {
+    evidence: emptyResult(),
+    avatar: emptyResult(),
+  }
+
+  try {
+    await sweepEvidencePrefixes(r2.s3, r2.env.bucket, now, summary.evidence)
+  } catch (err) {
+    recordError(summary.evidence, 'evidence sweep top-level', err)
+  }
+
+  try {
+    await sweepAvatarPrefixes(
+      r2.s3,
+      supabase,
+      r2.env.bucket,
+      r2.env.publicDomain,
+      now,
+      summary.avatar,
+    )
+  } catch (err) {
+    recordError(summary.avatar, 'avatar sweep top-level', err)
+  }
+
+  return new Response(JSON.stringify(summary), {
     status: 200,
     headers: { 'Content-Type': 'application/json' },
   })

--- a/supabase/functions/sweep-r2-stale-objects/index.ts
+++ b/supabase/functions/sweep-r2-stale-objects/index.ts
@@ -1,0 +1,14 @@
+import 'jsr:@supabase/functions-js@^2/edge-runtime.d.ts'
+
+Deno.serve((req) => {
+  if (req.method !== 'POST') {
+    return new Response(
+      JSON.stringify({ error: 'Method not allowed' }),
+      { status: 405, headers: { 'Content-Type': 'application/json' } },
+    )
+  }
+  return new Response(JSON.stringify({ ok: true }), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  })
+})

--- a/supabase/migrations/20260506183916_add_sweep_r2_stale_objects_cron.sql
+++ b/supabase/migrations/20260506183916_add_sweep_r2_stale_objects_cron.sql
@@ -1,0 +1,17 @@
+-- DML, not detected by schema diff.
+-- Schedules the daily sweep of stale R2 objects (evidence retention +
+-- avatar orphans). Canonical source: schemas/common/cron/cron_sweep_r2_stale_objects.sql
+SELECT cron.schedule(
+    'sweep-r2-stale-objects',
+    '0 18 * * *',
+    $$SELECT net.http_post(
+        url := (SELECT decrypted_secret FROM vault.decrypted_secrets WHERE name = 'supabase_url')
+              || '/functions/v1/sweep-r2-stale-objects',
+        headers := jsonb_build_object(
+            'Content-Type', 'application/json',
+            'Authorization', 'Bearer ' || (SELECT decrypted_secret FROM vault.decrypted_secrets WHERE name = 'service_role_key')
+        ),
+        body := '{}'::jsonb,
+        timeout_milliseconds := 300000
+    )$$
+);

--- a/supabase/schemas/common/cron/cron_sweep_r2_stale_objects.sql
+++ b/supabase/schemas/common/cron/cron_sweep_r2_stale_objects.sql
@@ -1,0 +1,20 @@
+-- Daily sweep of stale R2 objects: expired evidence files (>= due_date + 90 days)
+-- and orphan avatar objects (deleted-user prefixes + superseded versions for
+-- live users).
+--
+-- service_role_key is used as the Bearer token because the function performs
+-- admin reads on `profiles` that bypass RLS.
+SELECT cron.schedule(
+    'sweep-r2-stale-objects',
+    '0 18 * * *',  -- daily 18:00 UTC = 03:00 JST (off-peak)
+    $$SELECT net.http_post(
+        url := (SELECT decrypted_secret FROM vault.decrypted_secrets WHERE name = 'supabase_url')
+              || '/functions/v1/sweep-r2-stale-objects',
+        headers := jsonb_build_object(
+            'Content-Type', 'application/json',
+            'Authorization', 'Bearer ' || (SELECT decrypted_secret FROM vault.decrypted_secrets WHERE name = 'service_role_key')
+        ),
+        body := '{}'::jsonb,
+        timeout_milliseconds := 300000
+    )$$
+);


### PR DESCRIPTION
## Summary

- Adds `sweep-r2-stale-objects` Edge Function that performs three sweeps daily on R2: expired evidence directories (`due_date + 90 days`), avatar prefixes for deleted users, and superseded avatar versions for live users (with a 10-minute `LastModified` grace period to avoid the PUT→UPDATE race).
- Schedules the function daily at 03:00 JST via `pg_cron` + `pg_net` + Supabase Vault, mirroring the existing `cron_execute_pending_payouts` pattern.
- Pure helpers (`parseEvidencePrefixDate`, `isOlderThanDays`, `extractKeyFromAvatarUrl`, `isWithinGracePeriod`) are unit-tested with Deno's built-in test runner; orchestration is verified manually.
- Includes a `dry_run` body flag for safe local testing against the shared R2 bucket and as a first-run sanity check before enabling the cron in production.
- `recordError` now passes the error object directly to `console.error` so Deno prints class name, stack, and SDK metadata (`PostgrestError.code`, `S3ServiceException.$metadata`); a heartbeat log line announces dry-run mode at the start of every invocation.

Closes #390 (evidence lifecycle).
Closes #404 (R2 orphan-sweep cron).
Closes #403 (covered by daily sweep — per-request avatar-update deletion can be filed as a separate issue if immediate cleanup ever becomes desired).

Spec: `docs/superpowers/specs/2026-05-07-r2-stale-object-sweep-design.md`

## Test plan

- [x] `deno test` in `supabase/functions/sweep-r2-stale-objects/` passes (21 tests).
- [x] `./scripts/db-reset-and-clear-android-emulators-cache.sh` applies the migration cleanly and registers the cron job.
- [x] `cron.job` includes `sweep-r2-stale-objects` with schedule `0 18 * * *`.
- [x] Manual local invocation against a debug R2 bucket with seeded `evidence/<old-date>/` and `avatar/<dead-user>/` prefixes correctly identifies the stale objects in dry_run mode and deletes them in real mode.
- [x] Idempotent: re-running against an already-cleaned bucket reports zero deletions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)