### PR TITLE
chore: gitignore operator-private release checklist skill

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,7 +20,7 @@ scripts/github-secrets
 # Git worktrees
 .worktrees/
 
-# Operator-private release checklist (lives only on the operator's machine).
+# Operator-private release checklist skill (lives only on the operator's machine).
 # Backed up separately (1Password / private repo + symlink). Format and
-# maintenance policy live inside the file itself.
-.claude/rules/release-checklist.md
+# maintenance policy live inside the SKILL.md file itself.
+.claude/skills/release-checklist/

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,8 @@ scripts/github-secrets
 
 # Git worktrees
 .worktrees/
+
+# Operator-private release checklist (lives only on the operator's machine).
+# Backed up separately (1Password / private repo + symlink). Format and
+# maintenance policy live inside the file itself.
+.claude/rules/release-checklist.md


### PR DESCRIPTION
## Summary

Adds a `.gitignore` entry for `.claude/skills/release-checklist/`, an operator-private skill that tracks post-deploy actions tied to versioned tag cuts (set production secrets, manual smoke tests, etc.).

The history of this PR shows the design evolution:
- Commit `ad4da42` first placed it as a rule under `.claude/rules/release-checklist.md`
- Commit `784dd65` migrated it to a skill under `.claude/skills/release-checklist/SKILL.md`

Skills are a better fit because the checklist is workflow-triggered (tag cut, feature design, PR creation), not an always-on project convention.

## Why local-only

The file's content is operator-internal — it inventories pending one-shot deploy actions and recurring release-time checks. Keeping it out of git avoids signaling "here's what hasn't been done yet" on a public OSS repo, while still letting Claude Code load it (Claude reads the filesystem, not git).

The SKILL.md itself contains both:
- Runbook entries (Pending / Always sections)
- Maintenance policy Claude follows when adding/removing entries

## Why skill (not rule)

| | Rules | Skills |
|---|---|---|
| Loading | Always-on every conversation | On-demand via description match |
| Best for | Invariant project conventions | Workflows triggered by specific contexts |
| This file | Wasteful: ~4KB always loaded | Loads only when relevant |

The skill description triggers on: cutting a versioned tag, brainstorming features that may need post-deploy actions, creating a PR for such a feature, or explicit `/release-checklist` invocation.

## Future work

Plan is to manage operator-private rule/skill files in a private repo and symlink them into `peppercheck/`. The `.gitignore` rule remains useful even after the symlink is in place — symlinked files still need to be excluded from `peppercheck`'s tracking.

## Test plan

- [x] `git check-ignore -v .claude/skills/release-checklist/SKILL.md` resolves to the new rule (line 26)
- [x] Local file exists and is readable (Claude Code skill loading unaffected by gitignore)
- [x] Pre-commit hook passes (only `.gitignore` is staged)
- [x] SKILL.md frontmatter follows writing-skills conventions: third-person description starting with "Use when", concrete triggering conditions only (no workflow summary)

🤖 Generated with [Claude Code](https://claude.com/claude-code)