### PR TITLE
chore(stripe): add debug sandbox setup script

### DIFF
--- a/docs/superpowers/specs/2026-05-31-stripe-debug-sandbox-design.md
+++ b/docs/superpowers/specs/2026-05-31-stripe-debug-sandbox-design.md
@@ -29,21 +29,30 @@ Stripe Checkout / subscription is out of scope — PepperCheck's subscription is
 
 | Environment | Stripe mode | Webhook destination | Operator's stripe-cli profile |
 |---|---|---|---|
-| production | live | PROD Supabase `handle-stripe-webhook` (URL registered on live) | `peppercheck-live` (optional, read-only inspection) |
-| staging | existing sandbox | BETA Supabase `handle-stripe-webhook` (URL registered on the sandbox) | `peppercheck-staging` (optional, inspection only) |
-| debug | new sandbox | none registered; `stripe listen --forward-to localhost:54321/...` only | `peppercheck-debug` (**required**) |
+| production | live | PROD Supabase `handle-stripe-webhook` (URL registered on live) | `cloveclove-live` (optional, read-only inspection) |
+| staging | existing sandbox | BETA Supabase `handle-stripe-webhook` (URL registered on the sandbox) | `cloveclove-staging` (optional, inspection only) |
+| debug | new sandbox | none registered; `stripe listen --forward-to localhost:54321/...` only | `cloveclove-debug` (**required**) |
 
 Existing wiring for production and staging is unchanged. No secret rotation on the deploy side.
 
+## Sandbox naming
+
+Sandboxes are named without a product prefix:
+
+- `Staging` (existing — currently labeled `テスト環境`; rename is a separate Dashboard action, not gated by this PR)
+- `Debug` (new — created by the operator before running the setup script)
+
+Rationale: live mode is necessarily shared across all products in the CloveClove account (one Stripe account = one live mode). If a second CloveClove product appears in the future, the sandboxes can be either kept shared (with code-level `metadata.product` routing) or split out per product. Product-less names avoid forcing a rename when that decision is made.
+
 ## Stripe CLI profile naming
 
-CLI profile names follow Stripe's own vocabulary ("live") rather than PepperCheck's internal `production` term, since the consumer (`stripe` CLI) names the concept "live mode":
+CLI profile names are **account-scoped**, not product-scoped, to match the sandbox-naming logic above. The "live" vocabulary follows Stripe's own term (the CLI itself names the concept "live mode"):
 
-- `peppercheck-debug` — **required** for `stripe listen` against the new debug sandbox
-- `peppercheck-staging` — optional, only when inspecting the staging sandbox via CLI
-- `peppercheck-live` — optional, read-only inspection of live data
+- `cloveclove-debug` — **required** for `stripe listen` against the new debug sandbox
+- `cloveclove-staging` — optional, only when inspecting the staging sandbox via CLI
+- `cloveclove-live` — optional, read-only inspection of live data
 
-This PR only sets up `peppercheck-debug`. Setup commands for the other two profiles are documented for future operator reference but not executed as part of this PR.
+This PR only sets up `cloveclove-debug`. Setup commands for the other two profiles are documented for future operator reference but not executed as part of this PR.
 
 ## Secret placement
 
@@ -51,7 +60,7 @@ This PR only sets up `peppercheck-debug`. Setup commands for the other two profi
 |---|---|---|
 | `supabase/functions/.env` | `STRIPE_SECRET_KEY=sk_test_<debug>` | local Edge Function calls to Stripe API |
 | `supabase/functions/.env` | `STRIPE_WEBHOOK_SECRET=whsec_<stripe-listen>` | `handle-stripe-webhook` signature verification |
-| `~/.config/stripe/config.toml` | `[peppercheck-debug]` profile | `stripe` CLI commands |
+| `~/.config/stripe/config.toml` | `[cloveclove-debug]` profile | `stripe` CLI commands |
 
 All target files are gitignored. The script writes the CLI profile via `stripe login`; the `.env` lines are pasted by the operator (see "Script" below for the rationale).
 
@@ -66,10 +75,10 @@ Notably **not** updated by this PR:
 `stripe listen` generates a webhook signing secret that **is stable across command restarts** for a given CLI profile (per Stripe CLI documentation: "This process generates a webhook signing secret that remains consistent across command restarts"). Therefore:
 
 - No webhook endpoint registration is needed in the debug sandbox's Dashboard.
-- `stripe listen --project-name=peppercheck-debug --print-secret` is run once during setup, and the resulting `whsec_*` is written to `supabase/functions/.env` as `STRIPE_WEBHOOK_SECRET`.
+- `stripe listen --project-name=cloveclove-debug --print-secret` is run once during setup, and the resulting `whsec_*` is written to `supabase/functions/.env` as `STRIPE_WEBHOOK_SECRET`.
 - Subsequent `stripe listen --forward-to ...` runs reuse the same secret.
 
-If the operator ever runs `stripe login` again under the `peppercheck-debug` profile, the secret may rotate; the script supports re-running to reconcile.
+If the operator ever runs `stripe login` again under the `cloveclove-debug` profile, the secret may rotate; the script supports re-running to reconcile.
 
 ## Stripe Connect enablement
 
@@ -83,8 +92,8 @@ A small bash script that walks the operator through the setup and runs the steps
 
 1. **Preconditions check**: `stripe` CLI installed.
 2. **Prompt**: confirm the operator has created the sandbox in the Dashboard. If not, print the Dashboard URL and exit.
-3. **CLI profile setup**: run `stripe login --project-name=peppercheck-debug` (interactive browser-based flow that the operator approves on the Dashboard, scoped to the new sandbox).
-4. **Webhook secret retrieval**: run `stripe listen --project-name=peppercheck-debug --print-secret` and print the resulting `whsec_*` to the operator's terminal.
+3. **CLI profile setup**: run `stripe login --project-name=cloveclove-debug` (interactive browser-based flow that the operator approves on the Dashboard, scoped to the new sandbox).
+4. **Webhook secret retrieval**: run `stripe listen --project-name=cloveclove-debug --print-secret` and print the resulting `whsec_*` to the operator's terminal.
 5. **Instructions**: print the two lines the operator should add to or update in `supabase/functions/.env`:
 
    ```
@@ -92,7 +101,7 @@ A small bash script that walks the operator through the setup and runs the steps
    STRIPE_WEBHOOK_SECRET=<paste the whsec_... printed above>
    ```
 
-   Followed by copy-pasteable verification commands (`supabase functions serve handle-stripe-webhook`, `stripe listen --project-name=peppercheck-debug --forward-to ...`, `stripe trigger account.updated --project-name=peppercheck-debug`).
+   Followed by copy-pasteable verification commands (`supabase functions serve handle-stripe-webhook`, `stripe listen --project-name=cloveclove-debug --forward-to ...`, `stripe trigger account.updated --project-name=cloveclove-debug`).
 
 ### Properties
 
@@ -119,8 +128,8 @@ Currently lists `STRIPE_PUBLISHABLE_KEY=pk_test_...`. Leave unchanged in this PR
 
 Acceptance for this PR:
 
-- The script runs to completion: `peppercheck-debug` profile exists in `~/.config/stripe/config.toml`; the `whsec_*` is printed; the operator-facing `.env` instructions and verification commands are displayed.
-- After the operator pastes the two lines into `supabase/functions/.env`, running `stripe trigger account.updated --project-name=peppercheck-debug` with `stripe listen --project-name=peppercheck-debug --forward-to http://localhost:54321/functions/v1/handle-stripe-webhook` reaches the local Edge Function with a 200 response and signature verification passing (verify in `supabase functions serve` logs).
+- The script runs to completion: `cloveclove-debug` profile exists in `~/.config/stripe/config.toml`; the `whsec_*` is printed; the operator-facing `.env` instructions and verification commands are displayed.
+- After the operator pastes the two lines into `supabase/functions/.env`, running `stripe trigger account.updated --project-name=cloveclove-debug` with `stripe listen --project-name=cloveclove-debug --forward-to http://localhost:54321/functions/v1/handle-stripe-webhook` reaches the local Edge Function with a 200 response and signature verification passing (verify in `supabase functions serve` logs).
 - No edit to `BETA_STRIPE_*` GitHub Secrets, no edit to the existing sandbox's registered webhook endpoint.
 - The existing sandbox (now serving as staging) continues to deliver events to BETA Supabase after this change (regression check against a recent BETA event log).
 
@@ -137,7 +146,7 @@ Acceptance for this PR:
 
 - #443 dead-code cleanup, once landed, allows this spec's "leave unchanged" notes on `.env.example` files and `stripe/` directory to be retired.
 - #421 stripe-cli setup runbook will absorb the operator-facing prose for the workflow described here.
-- If `peppercheck-staging` / `peppercheck-live` CLI profiles see real use, codify their setup in the same script behind a `--profile=<name>` flag.
+- If `cloveclove-staging` / `cloveclove-live` CLI profiles see real use, codify their setup in the same script behind a `--profile=<name>` flag.
 
 ## References
 

--- a/docs/superpowers/specs/2026-05-31-stripe-debug-sandbox-design.md
+++ b/docs/superpowers/specs/2026-05-31-stripe-debug-sandbox-design.md
@@ -1,0 +1,161 @@
+# Stripe Debug Sandbox
+
+**Date:** 2026-05-31
+**Status:** Draft
+**Issue:** #422 (parent: #418 multi-environment setup roadmap)
+**Related:** #421 (stripe-cli setup runbook), #443 (dead Stripe subscription code cleanup)
+
+## Goal
+
+Create a dedicated Stripe sandbox for local debug development so that operator-local Stripe Connect / payout work no longer shares state with the staging sandbox wired to BETA Supabase. Standardize secret placement and Stripe CLI profile usage so the setup is reproducible.
+
+## Why
+
+The existing Stripe sandbox is wired to BETA Supabase as the staging webhook destination and is simultaneously used by the operator for local `stripe listen` forwarding. Events triggered from the operator's machine reach the BETA Supabase Edge Function, mixing local-debug noise with staging signal. This blocks confident staging-side validation of Stripe Connect / payout flows.
+
+This change isolates local debug into its own sandbox without touching staging-side secrets, deploy workflows, or the existing sandbox's webhook endpoint registration.
+
+## Use case for the debug sandbox
+
+Stripe Connect / payout local development:
+
+- `payout-setup` Edge Function (creates Connect Express accounts, generates onboarding link)
+- `execute-pending-payouts` Edge Function (creates Transfers / Payouts against Connect accounts)
+- `handle-stripe-webhook` Edge Function (signature verification + processing of `account.updated`, `payout.failed`, etc.)
+
+Stripe Checkout / subscription is out of scope — PepperCheck's subscription is IAP-only and Stripe-based subscription code paths are dead (tracked in #443).
+
+## Sandbox topology
+
+| Environment | Stripe mode | Webhook destination | Operator's stripe-cli profile |
+|---|---|---|---|
+| production | live | PROD Supabase `handle-stripe-webhook` (URL registered on live) | `peppercheck-live` (optional, read-only inspection) |
+| staging | existing sandbox | BETA Supabase `handle-stripe-webhook` (URL registered on the sandbox) | `peppercheck-staging` (optional, inspection only) |
+| debug | new sandbox | none registered; `stripe listen --forward-to localhost:54321/...` only | `peppercheck-debug` (**required**) |
+
+Existing wiring for production and staging is unchanged. No secret rotation on the deploy side.
+
+## Stripe CLI profile naming
+
+CLI profile names follow Stripe's own vocabulary ("live") rather than PepperCheck's internal `production` term, since the consumer (`stripe` CLI) names the concept "live mode":
+
+- `peppercheck-debug` — **required** for `stripe listen` against the new debug sandbox
+- `peppercheck-staging` — optional, only when inspecting the staging sandbox via CLI
+- `peppercheck-live` — optional, read-only inspection of live data
+
+This PR only sets up `peppercheck-debug`. Setup commands for the other two profiles are documented for future operator reference but not executed as part of this PR.
+
+## Secret placement
+
+| File | Key | Consumer |
+|---|---|---|
+| `supabase/functions/.env` | `STRIPE_SECRET_KEY=sk_test_<debug>` | local Edge Function calls to Stripe API |
+| `supabase/functions/.env` | `STRIPE_WEBHOOK_SECRET=whsec_<stripe-listen>` | `handle-stripe-webhook` signature verification |
+| `~/.config/stripe/config.toml` | `[peppercheck-debug]` profile | `stripe` CLI commands |
+
+All target files are gitignored. The script never prints secret values to stdout and never writes them to a tracked file.
+
+Notably **not** updated by this PR:
+
+- `peppercheck_flutter/assets/env/.env.debug` — `STRIPE_PUBLISHABLE_KEY` is left empty. The Flutter `flutter_stripe` integration is dead under the IAP-only policy and is scheduled for removal in #443.
+- `stripe/.env` — `sync-prices.ts` is dead under the IAP-only policy and is scheduled for removal in #443.
+- `supabase/.env` — does not contain Stripe keys; Stripe lives at `supabase/functions/.env`.
+
+## Webhook signing secret strategy
+
+`stripe listen` generates a webhook signing secret that **is stable across command restarts** for a given CLI profile (per Stripe CLI documentation: "This process generates a webhook signing secret that remains consistent across command restarts"). Therefore:
+
+- No webhook endpoint registration is needed in the debug sandbox's Dashboard.
+- `stripe listen --project-name=peppercheck-debug --print-secret` is run once during setup, and the resulting `whsec_*` is written to `supabase/functions/.env` as `STRIPE_WEBHOOK_SECRET`.
+- Subsequent `stripe listen --forward-to ...` runs reuse the same secret.
+
+If the operator ever runs `stripe login` again under the `peppercheck-debug` profile, the secret may rotate; the script supports re-running to reconcile.
+
+## Stripe Connect enablement
+
+The new sandbox must have Stripe Connect enabled (Dashboard, one-time toggle) so that `payout-setup` can create Express accounts. Test Connect accounts are created on demand via the existing `payout-setup` Edge Function — no separate bootstrap script is needed.
+
+## Script: `scripts/setup/configure-stripe-debug-sandbox.sh`
+
+A bash script that automates the local-side configuration. It does **not** create the sandbox itself (no public Stripe API exists for that). It only handles the steps after the sandbox exists in the Dashboard.
+
+### Behavior
+
+1. **Preconditions check**: `stripe` CLI installed; required dirs exist.
+2. **Prompt**: confirm the operator has created the sandbox in the Dashboard and noted the `sk_test_*` key. If not, print the Dashboard URL and exit. (The `pk_test_*` is not used by this PR — see "Secret placement" for the rationale.)
+3. **CLI profile setup**: prompt for `sk_test_*` and pipe into `stripe login --project-name=peppercheck-debug --interactive`.
+4. **Webhook secret retrieval**: run `stripe listen --project-name=peppercheck-debug --print-secret`, capture the `whsec_*`.
+5. **`.env` upsert**: for each target key in each target file, replace the existing line if present or append if absent. Use tempfile + atomic `mv`. Never echo the secret value to stdout.
+6. **Next-step hint**: print copy-pasteable commands for verification (`supabase functions serve`, `stripe listen --forward-to ...`, `stripe trigger account.updated`).
+
+### Idempotency
+
+Re-running the script with the same inputs produces the same `.env` content. Re-running with different inputs (e.g., after `stripe login` rotated the webhook secret) reconciles by replacing the existing line.
+
+### Safety properties
+
+- No secret value is printed to stdout or written to a tracked file.
+- The script does not delete or touch any other `.env` keys.
+- The script does not create or modify anything in the Stripe sandbox itself.
+
+## File and example updates
+
+### `supabase/functions/.env.example`
+
+Already lists `STRIPE_SECRET_KEY` and `STRIPE_WEBHOOK_SECRET` — no change needed.
+
+### `stripe/.env.example`
+
+Currently `STRIPE_SECRET_KEY=sk_test_...`. Leave unchanged in this PR; #443 will remove the file when `sync-prices.ts` is deleted.
+
+### `peppercheck_flutter/assets/env/.env.example`
+
+Currently lists `STRIPE_PUBLISHABLE_KEY=pk_test_...`. Leave unchanged in this PR; #443 will remove the entry when the Flutter Stripe integration is dropped.
+
+## Verification
+
+Acceptance for this PR:
+
+- The script runs to completion with the operator's input and writes the expected three updates (`STRIPE_SECRET_KEY`, `STRIPE_WEBHOOK_SECRET` to `supabase/functions/.env`; `peppercheck-debug` profile to `~/.config/stripe/config.toml`).
+- Running `stripe trigger account.updated --project-name=peppercheck-debug` with `stripe listen --project-name=peppercheck-debug --forward-to http://localhost:54321/functions/v1/handle-stripe-webhook` reaches the local Edge Function with a 200 response and signature verification passing (verify in `supabase functions serve` logs).
+- `git diff` against staging-side secrets shows no change: no edit to `BETA_STRIPE_*` GitHub Secrets, no edit to the existing sandbox's registered webhook endpoint.
+- The existing sandbox (now serving as staging) continues to deliver events to BETA Supabase after this change (regression check against a recent BETA event log).
+
+## Out of scope
+
+- **Stripe billing / Checkout / subscription rebuild** — IAP-only policy is in effect; Stripe-based subscription purchase is stopped. No `products` / `prices` seeding to the debug sandbox.
+- **`developer-docs` runbook prose** — `developer-docs/.../stripe-cli-setup.adoc` is owned by #421. This spec defines the operator workflow that #421 will document; the prose itself lives there.
+- **Sandbox creation automation** — no public Stripe API exists for creating sandboxes. The Dashboard step stays manual.
+- **Test Connect account bootstrap script** — `payout-setup` is idempotent and works as the on-demand bootstrap path.
+- **Staging sandbox rebuild** — existing sandbox is reused as staging; rotating BETA secrets is avoided.
+- **Removing dead Stripe Checkout / subscription code** — tracked in #443.
+
+## Future work
+
+- #443 dead-code cleanup, once landed, allows this spec's "leave unchanged" notes on `.env.example` files and `stripe/` directory to be retired.
+- #421 stripe-cli setup runbook will absorb the operator-facing prose for the workflow described here.
+- If `peppercheck-staging` / `peppercheck-live` CLI profiles see real use, codify their setup in the same script behind a `--profile=<name>` flag.
+
+## References
+
+### Existing design docs
+
+- `docs/superpowers/specs/2026-05-11-multi-environment-setup-roadmap-design.md` — the umbrella roadmap. Topology in this spec matches its `Stripe` row and "Webhook routing" subsection.
+- `docs/superpowers/specs/2026-04-12-stripe-account-updated-webhook-design.md` — the webhook event this sandbox is used to test locally.
+
+### External documentation
+
+- [Stripe Sandboxes](https://docs.stripe.com/sandboxes)
+- [Stripe CLI listen command](https://github.com/stripe/stripe-cli/wiki/Listen-command)
+- [Stripe CLI login command](https://github.com/stripe/stripe-cli/wiki/Login-command)
+
+### Project conventions
+
+- `.claude/rules/edge-functions.md`
+- `.claude/rules/supabase-workflow.md`
+
+## Revision log
+
+| Date | Change |
+|---|---|
+| 2026-05-31 | Initial draft. |

--- a/docs/superpowers/specs/2026-05-31-stripe-debug-sandbox-design.md
+++ b/docs/superpowers/specs/2026-05-31-stripe-debug-sandbox-design.md
@@ -53,7 +53,7 @@ This PR only sets up `peppercheck-debug`. Setup commands for the other two profi
 | `supabase/functions/.env` | `STRIPE_WEBHOOK_SECRET=whsec_<stripe-listen>` | `handle-stripe-webhook` signature verification |
 | `~/.config/stripe/config.toml` | `[peppercheck-debug]` profile | `stripe` CLI commands |
 
-All target files are gitignored. The script never prints secret values to stdout and never writes them to a tracked file.
+All target files are gitignored. The script writes the CLI profile via `stripe login`; the `.env` lines are pasted by the operator (see "Script" below for the rationale).
 
 Notably **not** updated by this PR:
 
@@ -77,26 +77,29 @@ The new sandbox must have Stripe Connect enabled (Dashboard, one-time toggle) so
 
 ## Script: `scripts/setup/configure-stripe-debug-sandbox.sh`
 
-A bash script that automates the local-side configuration. It does **not** create the sandbox itself (no public Stripe API exists for that). It only handles the steps after the sandbox exists in the Dashboard.
+A small bash script that walks the operator through the setup and runs the steps that are tedious to type by hand. It does **not** edit any `.env` file — the operator copies the printed values into `supabase/functions/.env` themselves so they remain in direct control of the secrets that land on disk. It also does **not** create the sandbox itself (no public Stripe API exists for that).
 
 ### Behavior
 
-1. **Preconditions check**: `stripe` CLI installed; required dirs exist.
-2. **Prompt**: confirm the operator has created the sandbox in the Dashboard and noted the `sk_test_*` key. If not, print the Dashboard URL and exit. (The `pk_test_*` is not used by this PR — see "Secret placement" for the rationale.)
-3. **CLI profile setup**: prompt for `sk_test_*` and pipe into `stripe login --project-name=peppercheck-debug --interactive`.
-4. **Webhook secret retrieval**: run `stripe listen --project-name=peppercheck-debug --print-secret`, capture the `whsec_*`.
-5. **`.env` upsert**: for each target key in each target file, replace the existing line if present or append if absent. Use tempfile + atomic `mv`. Never echo the secret value to stdout.
-6. **Next-step hint**: print copy-pasteable commands for verification (`supabase functions serve`, `stripe listen --forward-to ...`, `stripe trigger account.updated`).
+1. **Preconditions check**: `stripe` CLI installed.
+2. **Prompt**: confirm the operator has created the sandbox in the Dashboard. If not, print the Dashboard URL and exit.
+3. **CLI profile setup**: run `stripe login --project-name=peppercheck-debug` (interactive browser-based flow that the operator approves on the Dashboard, scoped to the new sandbox).
+4. **Webhook secret retrieval**: run `stripe listen --project-name=peppercheck-debug --print-secret` and print the resulting `whsec_*` to the operator's terminal.
+5. **Instructions**: print the two lines the operator should add to or update in `supabase/functions/.env`:
 
-### Idempotency
+   ```
+   STRIPE_SECRET_KEY=<paste the sk_test_... from the Dashboard>
+   STRIPE_WEBHOOK_SECRET=<paste the whsec_... printed above>
+   ```
 
-Re-running the script with the same inputs produces the same `.env` content. Re-running with different inputs (e.g., after `stripe login` rotated the webhook secret) reconciles by replacing the existing line.
+   Followed by copy-pasteable verification commands (`supabase functions serve handle-stripe-webhook`, `stripe listen --project-name=peppercheck-debug --forward-to ...`, `stripe trigger account.updated --project-name=peppercheck-debug`).
 
-### Safety properties
+### Properties
 
-- No secret value is printed to stdout or written to a tracked file.
-- The script does not delete or touch any other `.env` keys.
+- The script does not read, edit, or stat any `.env` file. Operator owns that file end-to-end.
 - The script does not create or modify anything in the Stripe sandbox itself.
+- Secrets printed in step 4 are visible only in the operator's own terminal. The script does not redirect, log, or persist them.
+- Re-running the script is safe and idempotent: `stripe login` updates the existing profile; `stripe listen --print-secret` returns the same `whsec_*` as before (stable across runs for the profile).
 
 ## File and example updates
 
@@ -116,9 +119,9 @@ Currently lists `STRIPE_PUBLISHABLE_KEY=pk_test_...`. Leave unchanged in this PR
 
 Acceptance for this PR:
 
-- The script runs to completion with the operator's input and writes the expected three updates (`STRIPE_SECRET_KEY`, `STRIPE_WEBHOOK_SECRET` to `supabase/functions/.env`; `peppercheck-debug` profile to `~/.config/stripe/config.toml`).
-- Running `stripe trigger account.updated --project-name=peppercheck-debug` with `stripe listen --project-name=peppercheck-debug --forward-to http://localhost:54321/functions/v1/handle-stripe-webhook` reaches the local Edge Function with a 200 response and signature verification passing (verify in `supabase functions serve` logs).
-- `git diff` against staging-side secrets shows no change: no edit to `BETA_STRIPE_*` GitHub Secrets, no edit to the existing sandbox's registered webhook endpoint.
+- The script runs to completion: `peppercheck-debug` profile exists in `~/.config/stripe/config.toml`; the `whsec_*` is printed; the operator-facing `.env` instructions and verification commands are displayed.
+- After the operator pastes the two lines into `supabase/functions/.env`, running `stripe trigger account.updated --project-name=peppercheck-debug` with `stripe listen --project-name=peppercheck-debug --forward-to http://localhost:54321/functions/v1/handle-stripe-webhook` reaches the local Edge Function with a 200 response and signature verification passing (verify in `supabase functions serve` logs).
+- No edit to `BETA_STRIPE_*` GitHub Secrets, no edit to the existing sandbox's registered webhook endpoint.
 - The existing sandbox (now serving as staging) continues to deliver events to BETA Supabase after this change (regression check against a recent BETA event log).
 
 ## Out of scope

--- a/scripts/setup/configure-stripe-debug-sandbox.sh
+++ b/scripts/setup/configure-stripe-debug-sandbox.sh
@@ -62,3 +62,35 @@ if [[ -z "${webhook_secret}" ]]; then
   echo "Check that the peppercheck-debug profile was set up correctly." >&2
   exit 1
 fi
+
+cat <<EOF
+
+------------------------------------------------------------
+Setup complete. Next steps for the operator:
+------------------------------------------------------------
+
+1. Open supabase/functions/.env (create it from supabase/functions/.env.example
+   if it does not exist) and add or update these two lines with the debug
+   sandbox values:
+
+   STRIPE_SECRET_KEY=<paste your sk_test_... from the Dashboard>
+   STRIPE_WEBHOOK_SECRET=${webhook_secret}
+
+2. Start the local Supabase Edge Function (in one terminal):
+
+   supabase functions serve handle-stripe-webhook \\
+     --env-file supabase/functions/.env
+
+3. Start the webhook forwarder (in a second terminal):
+
+   stripe listen --project-name=peppercheck-debug \\
+     --forward-to http://localhost:54321/functions/v1/handle-stripe-webhook
+
+4. Trigger a test event (in a third terminal):
+
+   stripe trigger account.updated --project-name=peppercheck-debug
+
+5. Verify in the 'supabase functions serve' logs that the event arrived
+   with a 200 response and signature verification passed.
+
+EOF

--- a/scripts/setup/configure-stripe-debug-sandbox.sh
+++ b/scripts/setup/configure-stripe-debug-sandbox.sh
@@ -4,8 +4,8 @@
 #
 # What this does:
 #   1. Confirms the debug sandbox has been created in the Stripe Dashboard.
-#   2. Runs `stripe login --project-name=peppercheck-debug` (browser-based).
-#   3. Runs `stripe listen --project-name=peppercheck-debug --print-secret`
+#   2. Runs `stripe login --project-name=cloveclove-debug` (browser-based).
+#   3. Runs `stripe listen --project-name=cloveclove-debug --print-secret`
 #      and prints the resulting webhook signing secret.
 #   4. Prints the two .env lines the operator should paste into
 #      supabase/functions/.env, plus verification commands.
@@ -47,19 +47,19 @@ case "${answer:-N}" in
 esac
 
 echo
-echo "Setting up the 'peppercheck-debug' Stripe CLI profile."
+echo "Setting up the 'cloveclove-debug' Stripe CLI profile."
 echo "A browser window will open — approve the pairing and SELECT THE DEBUG SANDBOX"
 echo "(not the staging sandbox or live mode)."
 echo
-stripe login --project-name=peppercheck-debug
+stripe login --project-name=cloveclove-debug
 
 echo
 echo "Fetching the local webhook signing secret..."
-webhook_secret=$(stripe listen --project-name=peppercheck-debug --print-secret)
+webhook_secret=$(stripe listen --project-name=cloveclove-debug --print-secret)
 
 if [[ -z "${webhook_secret}" ]]; then
   echo "Error: stripe listen --print-secret returned empty output." >&2
-  echo "Check that the peppercheck-debug profile was set up correctly." >&2
+  echo "Check that the cloveclove-debug profile was set up correctly." >&2
   exit 1
 fi
 
@@ -83,12 +83,12 @@ Setup complete. Next steps for the operator:
 
 3. Start the webhook forwarder (in a second terminal):
 
-   stripe listen --project-name=peppercheck-debug \\
+   stripe listen --project-name=cloveclove-debug \\
      --forward-to http://localhost:54321/functions/v1/handle-stripe-webhook
 
 4. Trigger a test event (in a third terminal):
 
-   stripe trigger account.updated --project-name=peppercheck-debug
+   stripe trigger account.updated --project-name=cloveclove-debug
 
 5. Verify in the 'supabase functions serve' logs that the event arrived
    with a 200 response and signature verification passed.

--- a/scripts/setup/configure-stripe-debug-sandbox.sh
+++ b/scripts/setup/configure-stripe-debug-sandbox.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+#
+# Guided setup for the PepperCheck debug Stripe sandbox.
+#
+# What this does:
+#   1. Confirms the debug sandbox has been created in the Stripe Dashboard.
+#   2. Runs `stripe login --project-name=peppercheck-debug` (browser-based).
+#   3. Runs `stripe listen --project-name=peppercheck-debug --print-secret`
+#      and prints the resulting webhook signing secret.
+#   4. Prints the two .env lines the operator should paste into
+#      supabase/functions/.env, plus verification commands.
+#
+# What this does NOT do:
+#   - Edit any .env file. The operator pastes secrets themselves.
+#   - Create or modify anything in the Stripe sandbox itself.
+#
+# Spec: docs/superpowers/specs/2026-05-31-stripe-debug-sandbox-design.md
+
+set -euo pipefail
+
+if ! command -v stripe >/dev/null 2>&1; then
+  echo "Error: the 'stripe' CLI is not on PATH." >&2
+  echo "Install it with: brew install stripe/stripe-cli/stripe" >&2
+  exit 1
+fi

--- a/scripts/setup/configure-stripe-debug-sandbox.sh
+++ b/scripts/setup/configure-stripe-debug-sandbox.sh
@@ -52,3 +52,13 @@ echo "A browser window will open — approve the pairing and SELECT THE DEBUG SA
 echo "(not the staging sandbox or live mode)."
 echo
 stripe login --project-name=peppercheck-debug
+
+echo
+echo "Fetching the local webhook signing secret..."
+webhook_secret=$(stripe listen --project-name=peppercheck-debug --print-secret)
+
+if [[ -z "${webhook_secret}" ]]; then
+  echo "Error: stripe listen --print-secret returned empty output." >&2
+  echo "Check that the peppercheck-debug profile was set up correctly." >&2
+  exit 1
+fi

--- a/scripts/setup/configure-stripe-debug-sandbox.sh
+++ b/scripts/setup/configure-stripe-debug-sandbox.sh
@@ -23,3 +23,25 @@ if ! command -v stripe >/dev/null 2>&1; then
   echo "Install it with: brew install stripe/stripe-cli/stripe" >&2
   exit 1
 fi
+
+cat <<'EOF'
+
+Before continuing, in the Stripe Dashboard:
+
+  1. Create a new sandbox dedicated to local debug.
+     URL: https://dashboard.stripe.com/test/sandboxes
+  2. Enable Stripe Connect for that sandbox
+     (Settings > Connect > Get started, in the new sandbox).
+  3. Note the sandbox-scoped sk_test_... key from
+     Developers > API keys (visible only after selecting the sandbox).
+
+EOF
+
+read -r -p "Have you created the debug sandbox and enabled Connect? [y/N]: " answer
+case "${answer:-N}" in
+  y|Y|yes|YES) ;;
+  *)
+    echo "Aborting. Re-run this script after creating the sandbox." >&2
+    exit 1
+    ;;
+esac

--- a/scripts/setup/configure-stripe-debug-sandbox.sh
+++ b/scripts/setup/configure-stripe-debug-sandbox.sh
@@ -45,3 +45,10 @@ case "${answer:-N}" in
     exit 1
     ;;
 esac
+
+echo
+echo "Setting up the 'peppercheck-debug' Stripe CLI profile."
+echo "A browser window will open — approve the pairing and SELECT THE DEBUG SANDBOX"
+echo "(not the staging sandbox or live mode)."
+echo
+stripe login --project-name=peppercheck-debug


### PR DESCRIPTION
## Summary

- Adds `scripts/setup/configure-stripe-debug-sandbox.sh`, a small guided script that walks the operator through creating a `cloveclove-debug` Stripe CLI profile against a new Debug sandbox and prints the local webhook signing secret. The script does not touch `.env` files — it shows the two lines and the operator pastes them into `supabase/functions/.env` themselves.
- Adds the design doc `docs/superpowers/specs/2026-05-31-stripe-debug-sandbox-design.md` covering sandbox topology, CLI profile naming (account-scoped, not product-scoped), secret placement, and the no-`.env`-edits script behavior.

Closes #422.

## Verification

- [x] `bash -n` and `shellcheck` clean.
- [x] Operator created a Debug sandbox, ran the script, pasted the two `.env` lines, and confirmed that `stripe trigger account.updated --project-name=cloveclove-debug` reaches a locally served `handle-stripe-webhook` with a 200 response and signature verification passing.
- [x] BETA Supabase `handle-stripe-webhook` logs show no activity from this smoke test — staging side is unaffected. No edits to `BETA_STRIPE_*` GitHub Secrets or the existing sandbox's webhook endpoint.

## Out of scope (see spec)

- Dead Stripe Checkout / subscription code cleanup → #443.
- \`developer-docs\` runbook prose → #421.

🤖 Generated with [Claude Code](https://claude.com/claude-code)