### PR TITLE
chore(flutter): rename "debug" environment to "dev"

### DIFF
--- a/.claude/rules/flutter.md
+++ b/.claude/rules/flutter.md
@@ -5,10 +5,10 @@
 After modifying Dart source files, verify the app compiles:
 
 ```bash
-cd peppercheck_flutter && flutter build apk --debug -t lib/main_debug.dart 2>&1 | tail -10
+cd peppercheck_flutter && flutter build apk --debug -t lib/main_dev.dart 2>&1 | tail -10
 ```
 
-The project uses flavored entry points (`main_debug.dart`, `main_staging.dart`, `main_production.dart`), not `lib/main.dart`.
+The project uses flavored entry points (`main_dev.dart`, `main_staging.dart`, `main_production.dart`), not `lib/main.dart`.
 
 ## Riverpod Controller Naming
 

--- a/.github/workflows/ci-flutter.yml
+++ b/.github/workflows/ci-flutter.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Create placeholder env files
         run: |
           mkdir -p assets/env
-          touch assets/env/.env.debug
+          touch assets/env/.env.dev
           touch assets/env/.env.staging
           touch assets/env/.env.production
 

--- a/.github/workflows/deploy-beta.yml
+++ b/.github/workflows/deploy-beta.yml
@@ -144,7 +144,7 @@ jobs:
       - name: Create placeholder env files
         run: |
           mkdir -p assets/env
-          touch assets/env/.env.debug
+          touch assets/env/.env.dev
           touch assets/env/.env.staging
           touch assets/env/.env.production
 

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -144,7 +144,7 @@ jobs:
       - name: Create placeholder env files
         run: |
           mkdir -p assets/env
-          touch assets/env/.env.debug
+          touch assets/env/.env.dev
           touch assets/env/.env.staging
           touch assets/env/.env.production
 

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -2,10 +2,10 @@
     "version": "0.2.0",
     "configurations": [
         {
-            "name": "Flutter: Debug (Local)",
+            "name": "Flutter: Dev (Local)",
             "request": "launch",
             "type": "dart",
-            "program": "lib/main_debug.dart",
+            "program": "lib/main_dev.dart",
             "cwd": "${workspaceFolder}/peppercheck_flutter",
             "preLaunchTask": "ADB Reverse All"
         },

--- a/developer-docs/modules/ROOT/pages/flutter/firebase-setup.adoc
+++ b/developer-docs/modules/ROOT/pages/flutter/firebase-setup.adoc
@@ -47,7 +47,7 @@ After placing the file(s), build and run the app:
 [source,bash]
 ----
 cd peppercheck_flutter
-flutter run -t lib/main_debug.dart
+flutter run -t lib/main_dev.dart
 ----
 
 If `Firebase has not been correctly initialized` appears at startup,

--- a/developer-docs/modules/ROOT/pages/flutter/initial-local-setup.adoc
+++ b/developer-docs/modules/ROOT/pages/flutter/initial-local-setup.adoc
@@ -4,9 +4,9 @@
 
 Per-environment configuration is managed via `.env` files in `assets/env/`.
 
-=== Debug Environment (`.env.debug`)
+=== Dev Environment (`.env.dev`)
 
-For local development, configure `assets/env/.env.debug`.
+For local development, configure `assets/env/.env.dev`.
 
 Important: For Android Emulator, use `localhost` combined with `adb reverse`.
 This ensures the app behaves exactly like the host environment, avoiding redirect mismatch issues with Supabase Auth.
@@ -18,9 +18,9 @@ adb reverse tcp:3000 tcp:3000
 adb reverse tcp:54321 tcp:54321
 ----
 
-NOTE: You can skip this step if you are running the app via VS Code's "Flutter: Debug (Local)" launch configuration, as it automatically runs these commands for you.
+NOTE: You can skip this step if you are running the app via VS Code's "Flutter: Dev (Local)" launch configuration, as it automatically runs these commands for you.
 
-.assets/env/.env.debug
+.assets/env/.env.dev
 [source,properties]
 ----
 # Supabase Configuration
@@ -44,4 +44,4 @@ WEB_DASHBOARD_URL=http://localhost:3000/dashboard
 flutter run
 ----
 
-By default, this runs in `debug` mode using `main_debug.dart` and loads `.env.debug`.
+By default, this runs in `dev` mode using `main_dev.dart` and loads `.env.dev`.

--- a/docs/superpowers/specs/2026-05-11-multi-environment-setup-roadmap-design.md
+++ b/docs/superpowers/specs/2026-05-11-multi-environment-setup-roadmap-design.md
@@ -6,7 +6,7 @@
 
 ## Goal
 
-Make PepperCheck's three environments — **production**, **staging**, and **debug** — independently usable for end-to-end validation. Each environment must:
+Make PepperCheck's three environments — **production**, **staging**, and **dev** — independently usable for end-to-end validation. Each environment must:
 
 1. Operate without side effects leaking to other environments.
 2. Be installable side-by-side on the same device with a uniform operator workflow.
@@ -26,21 +26,21 @@ It does not scale through the upcoming subscription-related changes (further ite
 
 ### Already isolated
 
-- **R2 buckets**: `peppercheck` (prod), `peppercheck-staging`, `peppercheck-debug`. Selected by Edge Functions via `R2_BUCKET_NAME`.
+- **R2 buckets**: `peppercheck` (prod), `peppercheck-staging`, `peppercheck-dev`. Selected by Edge Functions via `R2_BUCKET_NAME`.
 - **Webapp deployment**: Cloudflare Workers with `wrangler.jsonc` `[env.staging]` (`staging.peppercheck.dev`) and `[env.production]` (`peppercheck.dev`).
 - **Build-time env injection (Flutter / webapp)**: CI workflows (`deploy-beta.yml`, `deploy-production.yml`) generate `assets/env/.env.{staging,production}` and webapp `.env.local` from env-scoped GitHub Secrets (`BETA_*`, `PROD_*`).
 - **Supabase projects**: Distinct `BETA_SUPABASE_*` and `PROD_SUPABASE_*` projects.
-- **Stripe**: Live mode for production payouts; one sandbox shared between staging and debug.
+- **Stripe**: Live mode for production payouts; one sandbox shared between staging and dev.
 
 ### Not isolated or shared (this roadmap's scope)
 
 - **Bundle ID / package name**: A single `dev.cloveclove.peppercheck` is reused across all flavors.
-- **Firebase project**: One Firebase project (`peppercheck`) is shared across debug, staging, and production.
+- **Firebase project**: One Firebase project (`peppercheck`) is shared across dev, staging, and production.
 - **Apple Connect / Play Console apps**: One per platform, shared across all flavors.
 - **Google Play RTDN topic**: One topic; staging internal-testing purchases reach the production Supabase webhook.
-- **Stripe sandbox**: Staging and debug share one sandbox, so a local-debug event reaches the staging Supabase function.
+- **Stripe sandbox**: Staging and dev share one sandbox, so a local-dev event reaches the staging Supabase function.
 - **Edge Function runtime secrets**: Set manually per project via `supabase secrets set`; no CI automation or runbook.
-- **Stripe webhook routing**: live → PROD Supabase is wired; sandbox → BETA Supabase exists, but the staging/debug share creates noise.
+- **Stripe webhook routing**: live → PROD Supabase is wired; sandbox → BETA Supabase exists, but the staging/dev share creates noise.
 - **In-app environment indicator**: No on-screen banner identifies which environment a running build is connected to.
 - **Mobile observability**: Firebase Crashlytics, Performance Monitoring, and Analytics are not enabled.
 
@@ -48,20 +48,20 @@ It does not scale through the upcoming subscription-related changes (further ite
 
 Legend: ✅ isolated per environment, ⚠️ shared or not isolated, 🆕 not introduced.
 
-| Subsystem | production | staging | debug | Notes |
+| Subsystem | production | staging | dev | Notes |
 |---|---|---|---|---|
 | Supabase project | ✅ PROD | ✅ BETA | ✅ local | Per-env secrets in CI |
 | Supabase migration deploy | ✅ tag → push | ✅ beta branch → push | ✅ `supabase db reset` | |
 | Edge Function deploy | ✅ tag | ✅ beta branch | ✅ `functions serve` | 11 functions |
 | Edge Function runtime secret | ⚠️ manual | ⚠️ manual | ⚠️ manual `supabase/.env` | |
-| R2 bucket | ✅ `peppercheck` | ✅ `peppercheck-staging` | ✅ `peppercheck-debug` | |
+| R2 bucket | ✅ `peppercheck` | ✅ `peppercheck-staging` | ✅ `peppercheck-dev` | |
 | Webapp deploy | ✅ `peppercheck.dev` | ✅ `staging.peppercheck.dev` | ✅ `npm run dev` | |
 | Build-time env injection | ✅ `PROD_*` | ✅ `BETA_*` | ✅ local file | |
 | Bundle ID / package | ⚠️ shared | ⚠️ shared | ⚠️ shared | |
 | Firebase project | ⚠️ shared | ⚠️ shared | ⚠️ shared | One project across all |
 | `google-services.json` / `GoogleService-Info.plist` | ⚠️ single secret | ⚠️ same | ⚠️ per-developer copy | |
 | APNs Auth Key | ⚠️ one project | ⚠️ same | ⚠️ same | |
-| Google Sign-In OAuth client | ⚠️ shared Web + Android client | ⚠️ shared (no staging app) | ⚠️ separate Android client (debug fingerprint) | Web client configured in Supabase Dashboard |
+| Google Sign-In OAuth client | ⚠️ shared Web + Android client | ⚠️ shared (no staging app) | ⚠️ separate Android client (dev fingerprint) | Web client configured in Supabase Dashboard |
 | iOS `GIDClientID` | ⚠️ hard-coded | ⚠️ same | ⚠️ same | Should move to xcconfig |
 | Android signing keystore | ✅ release upload key + Play App Signing | ✅ same (internal testing) | ✅ debug.keystore | Play App Signing fingerprint is the one registered with Firebase / OAuth |
 | Apple Connect app | ⚠️ one | ⚠️ same | ⚠️ same | |
@@ -69,7 +69,7 @@ Legend: ✅ isolated per environment, ⚠️ shared or not isolated, 🆕 not in
 | IAP product registration | ⚠️ single app | ⚠️ same | ⚠️ same | |
 | Apple ASSN V2 webhook URL | ✅ Production URL → PROD | ✅ Sandbox URL → BETA | n/a (sandbox URL shared) | Single-app dual-URL split |
 | Google Play RTDN Pub/Sub | ⚠️ one topic → PROD | ⚠️ internal-testing purchases → same topic | n/a | |
-| Stripe live/sandbox | ✅ live → PROD | ✅ sandbox A → BETA | ⚠️ shared sandbox A with staging | Debug sandbox to be created |
+| Stripe live/sandbox | ✅ live → PROD | ✅ sandbox A → BETA | ⚠️ shared sandbox A with staging | Dev sandbox to be created |
 | Stripe webhook endpoint | ✅ live URL → PROD | ✅ sandbox URL → BETA | n/a (stripe-cli forwarding) | |
 | Mobile crash / performance / analytics | 🆕 none | 🆕 none | 🆕 none | Firebase suite not enabled |
 | In-app environment badge | ⚠️ none | ⚠️ none | ⚠️ none | |
@@ -91,9 +91,9 @@ Legend: ✅ isolated per environment, ⚠️ shared or not isolated, 🆕 not in
 |---|---|
 | production | `dev.cloveclove.peppercheck` (existing) |
 | staging | `dev.cloveclove.peppercheck.staging` |
-| debug | `dev.cloveclove.peppercheck.debug` |
+| dev | `dev.cloveclove.peppercheck.dev` |
 
-- Android: `productFlavors` with `applicationIdSuffix = ".staging"` / `".debug"`.
+- Android: `productFlavors` with `applicationIdSuffix = ".staging"` / `".dev"`.
 - iOS: per-scheme xcconfig overriding `PRODUCT_BUNDLE_IDENTIFIER`; three schemes (`Runner-Debug`, `Runner-Staging`, `Runner-Production`).
 - Suffix-at-end form is the industry standard (matches `applicationIdSuffix` semantics, sorts adjacently in Apple/Google consoles, reads as `org → app → variant`).
 
@@ -101,7 +101,7 @@ Legend: ✅ isolated per environment, ⚠️ shared or not isolated, 🆕 not in
 
 - `peppercheck` (existing, reused for production)
 - `peppercheck-staging` (new)
-- `peppercheck-debug` (new, operator-managed)
+- `peppercheck-dev` (new, operator-managed)
 - Each project hosts one iOS app and one Android app for its flavor (6 apps total).
 - A single APNs Auth Key (`.p8`) is generated once on the Apple Developer Team and registered in all three projects.
 - `FIREBASE_SERVICE_ACCOUNT` is set per Supabase project (PROD project gets the production project's service account, BETA project gets the staging project's). Edge Function code does not branch on environment — it simply reads its single env var.
@@ -109,16 +109,16 @@ Legend: ✅ isolated per environment, ⚠️ shared or not isolated, 🆕 not in
 #### Google Sign-In OAuth clients
 
 - **Web OAuth client**: one per Supabase project (3 total), used as `serverClientId` in the native Google Sign-In flow and registered as the auth provider in Supabase Dashboard.
-- **Android OAuth client**: one per (env × signing fingerprint). Production and staging use their respective Play App Signing fingerprints; debug uses `debug.keystore` fingerprints (one per developer).
+- **Android OAuth client**: one per (env × signing fingerprint). Production and staging use their respective Play App Signing fingerprints; dev uses `debug.keystore` fingerprints (one per developer).
 - **iOS OAuth client**: per env (3 total). `Info.plist` `GIDClientID` is parameterized through xcconfig.
 
 #### Apple Connect / Play Console apps
 
-- Three Apple Connect apps and three Play Console apps (production / staging / debug). IAP products are duplicated across the three.
+- Three Apple Connect apps and three Play Console apps (production / staging / dev). IAP products are duplicated across the three.
 - Distribution:
   - production app: App Store + TestFlight + Play Store
   - staging app: TestFlight internal testing + Play internal testing track
-  - debug app: not distributed via store, IAP product registration only (so local builds can fetch products)
+  - dev app: not distributed via store, IAP product registration only (so local builds can fetch products)
 
 #### Webhook routing
 
@@ -128,12 +128,12 @@ Legend: ✅ isolated per environment, ⚠️ shared or not isolated, 🆕 not in
 |---|---|---|
 | production | → PROD Supabase | (empty) |
 | staging | → BETA Supabase | (empty) |
-| debug | (empty) | (empty) |
+| dev | (empty) | (empty) |
 
 Rationale for empty Sandbox URLs:
 
 - TestFlight purchases (free) run in the production environment and hit Production URL.
-- Sandbox environment fires only when Xcode debug builds are run with a Sandbox tester Apple ID. Those builds use the `.debug` bundle ID; their notifications would route to the debug app's Sandbox URL. Local end-to-end ASSN testing is intentionally out of scope — server-side ASSN flows are validated through TestFlight on the staging app (which makes all purchases free, so no real money is required).
+- Sandbox environment fires only when Xcode debug builds are run with a Sandbox tester Apple ID. Those builds use the `.dev` bundle ID; their notifications would route to the dev app's Sandbox URL. Local end-to-end ASSN testing is intentionally out of scope — server-side ASSN flows are validated through TestFlight on the staging app (which makes all purchases free, so no real money is required).
 
 **Google Play RTDN:**
 
@@ -141,7 +141,7 @@ Rationale for empty Sandbox URLs:
 |---|---|---|
 | production | existing topic | PROD Supabase `handle-google-play-rtdn` |
 | staging | new `peppercheck-rtdn-staging` | BETA Supabase `handle-google-play-rtdn` |
-| debug | none | n/a |
+| dev | none | n/a |
 
 **Stripe webhooks:**
 
@@ -149,7 +149,7 @@ Rationale for empty Sandbox URLs:
 |---|---|---|
 | production | live mode | PROD Supabase `handle-stripe-webhook` |
 | staging | sandbox A | BETA Supabase `handle-stripe-webhook` |
-| debug | sandbox B (new) | none (use `stripe listen --forward-to` for local) |
+| dev | sandbox B (new) | none (use `stripe listen --forward-to` for local) |
 
 #### Edge Function runtime secrets
 
@@ -166,7 +166,7 @@ Rationale for empty Sandbox URLs:
 
 - A banner widget reads `AppConfig.environment` and, for non-production builds, displays a fixed colored bar at the top of the app:
   - staging: yellow, label "STAGING"
-  - debug: green, label "DEBUG"
+  - dev: green, label "DEV"
 - App icon variants reinforce the same distinction on the home screen.
 
 ### Topology
@@ -194,16 +194,16 @@ staging
   RTDN       : staging Play app → peppercheck-rtdn-staging → BETA Supabase
   OAuth      : staging Web client (Supabase BETA), staging Android client
 
-debug
-  App        : dev.cloveclove.peppercheck.debug (local only)
-  Firebase   : peppercheck-debug
+dev
+  App        : dev.cloveclove.peppercheck.dev (local only)
+  Firebase   : peppercheck-dev
   Supabase   : local (`supabase start`)
   Webapp     : localhost:3000 (`npm run dev`)
-  R2         : peppercheck-debug
+  R2         : peppercheck-dev
   Stripe     : sandbox B → stripe-cli forward → localhost
   ASSN       : no URLs (server-side ASSN validated via staging TestFlight)
   RTDN       : none
-  OAuth      : dev Web client (local Supabase), debug Android client (debug.keystore)
+  OAuth      : dev Web client (local Supabase), dev Android client (debug.keystore)
 ```
 
 ## Phases
@@ -222,18 +222,18 @@ Scriptable steps land under `scripts/setup/`. Scripts read credentials from envi
 
 | # | Task | Label |
 |---|---|---|
-| 0.1 | Read `AppConfig.environment` and render a non-production banner widget at the top of the app (yellow "STAGING" / green "DEBUG"). | 🤖 PR |
+| 0.1 | Read `AppConfig.environment` and render a non-production banner widget at the top of the app (yellow "STAGING" / green "DEV"). | 🤖 PR |
 | 0.2 | Add `supabase secrets set` step to `deploy-beta.yml` and `deploy-production.yml` so all Edge Function runtime secrets are reconciled on every deploy. | 🤖 PR |
 | 0.3 | Add `developer-docs/modules/ROOT/pages/operations/secret-management.adoc` listing required secrets per environment and documenting the "CI reconciles on every deploy; one-off updates via dashboard are fine" policy. | 🤖 PR |
-| 0.4 | Create a dedicated Stripe sandbox for debug and issue `DEBUG_STRIPE_PUBLISHABLE_KEY` / `DEBUG_STRIPE_SECRET_KEY`. | ✋ Stripe Dashboard |
-| 0.5 | Add `developer-docs/modules/ROOT/pages/operations/stripe-cli-setup.adoc` documenting `stripe login` against the debug sandbox and `stripe listen --forward-to http://localhost:54321/functions/v1/handle-stripe-webhook`. | 🤖 PR |
+| 0.4 | Create a dedicated Stripe sandbox for dev and issue `DEV_STRIPE_PUBLISHABLE_KEY` / `DEV_STRIPE_SECRET_KEY`. | ✋ Stripe Dashboard |
+| 0.5 | Add `developer-docs/modules/ROOT/pages/operations/stripe-cli-setup.adoc` documenting `stripe login` against the dev sandbox and `stripe listen --forward-to http://localhost:54321/functions/v1/handle-stripe-webhook`. | 🤖 PR |
 | 0.6 | Add `.claude/rules/multi-environment-setup.md` capturing the per-environment operational assumptions for AI tooling. | 🤖 PR |
 
 **Dependencies:** none.
 
-**Verification:** After staging deploy, the staging build shows the "STAGING" banner; `supabase secrets list --project-ref <BETA>` reflects all expected secrets; the debug sandbox boots and `stripe listen` forwards an event to local Supabase.
+**Verification:** After staging deploy, the staging build shows the "STAGING" banner; `supabase secrets list --project-ref <BETA>` reflects all expected secrets; the dev sandbox boots and `stripe listen` forwards an event to local Supabase.
 
-**Issue layout:** 4 task-cluster issues filed directly under the umbrella — `env banner`, `CI secret automation`, `operations runbook`, `debug Stripe sandbox`. Phase 0 itself is not a GitHub issue. Each cluster is sized to roughly one PR (the debug Stripe sandbox issue tracks an operator-side manual task with no PR).
+**Issue layout:** 4 task-cluster issues filed directly under the umbrella — `env banner`, `CI secret automation`, `operations runbook`, `dev Stripe sandbox`. Phase 0 itself is not a GitHub issue. Each cluster is sized to roughly one PR (the dev Stripe sandbox issue tracks an operator-side manual task with no PR).
 
 ### Phase 1: Bundle ID + Firebase 3-project + Auth split
 
@@ -241,18 +241,18 @@ Scriptable steps land under `scripts/setup/`. Scripts read credentials from envi
 
 | # | Task | Label |
 |---|---|---|
-| 1.1 | Android: declare `productFlavors` in `android/app/build.gradle.kts` (`debug` / `staging` / `production`) with `applicationIdSuffix`; add per-flavor source sets. | 🤖 PR |
+| 1.1 | Android: declare `productFlavors` in `android/app/build.gradle.kts` (`dev` / `staging` / `production`) with `applicationIdSuffix`; add per-flavor source sets. | 🤖 PR |
 | 1.2 | iOS: create three schemes (`Runner-Debug`, `Runner-Staging`, `Runner-Production`) with three xcconfig files overriding `PRODUCT_BUNDLE_IDENTIFIER`. | 🔧 Xcode + pbxproj diff |
 | 1.3 | iOS: replace the hard-coded `GIDClientID` in `Info.plist` with an xcconfig variable. | 🤖 PR |
-| 1.4 | `scripts/setup/bootstrap-firebase-projects.sh`: create `peppercheck-staging` and `peppercheck-debug` via `firebase projects:create`; confirm Blaze plan as needed. | 🤖 |
+| 1.4 | `scripts/setup/bootstrap-firebase-projects.sh`: create `peppercheck-staging` and `peppercheck-dev` via `firebase projects:create`; confirm Blaze plan as needed. | 🤖 |
 | 1.5 | `scripts/setup/register-firebase-apps.sh <env>`: create iOS + Android apps in the target project via `firebase apps:create` and download configs via `firebase apps:sdkconfig`. | 🤖 |
-| 1.6 | Place per-flavor config files: `android/app/src/{debug,staging,production}/google-services.json` and `ios/Runner/Firebase/GoogleService-Info-{Debug,Staging,Production}.plist` (all gitignored, injected by CI). | 🤖 |
+| 1.6 | Place per-flavor config files: `android/app/src/{dev,staging,production}/google-services.json` and `ios/Runner/Firebase/GoogleService-Info-{Dev,Staging,Production}.plist` (all gitignored, injected by CI). | 🤖 |
 | 1.7 | CI workflow updates: split `GOOGLE_SERVICES_JSON` into `GOOGLE_SERVICES_JSON_{STAGING,PRODUCTION}` and write each to the matching source set path. | 🤖 PR |
 | 1.8 | Upload the APNs Auth Key (one `.p8`) to all three Firebase projects with the same Team ID and Key ID. | ✋ Firebase Console |
 | 1.9 | `scripts/setup/create-oauth-clients.sh <env>`: create the Web OAuth client and Android OAuth clients via Google Cloud REST API (with a setup service account); record client IDs. | 🔧 |
 | 1.10 | Register each environment's Web OAuth client in the corresponding Supabase project's Google auth provider. | ✋ Supabase Dashboard (or 🔧 via Supabase Management API) |
 | 1.11 | Set `FIREBASE_SERVICE_ACCOUNT` per Supabase project (each pointing to its matching Firebase project's service account). | 🤖 (Phase 0 mechanism) |
-| 1.12 | Add per-flavor app icons (debug green, staging yellow, production normal). | 🤖 PR |
+| 1.12 | Add per-flavor app icons (dev green, staging yellow, production normal). | 🤖 PR |
 | 1.13 | Verification: build and run all three flavors on real devices, sign in, and confirm test push notifications arrive in each environment via its own Edge Function `send-notification`. | 🔧 |
 
 **Dependencies:** Phase 0 complete.
@@ -263,14 +263,14 @@ Scriptable steps land under `scripts/setup/`. Scripts read credentials from envi
 
 ### Phase 2: Store registration + IAP staging + iOS publishing
 
-**Goal:** Register staging and debug apps with Apple Connect and Play Console, route their store webhooks to BETA Supabase, and stand up iOS publishing automation alongside the existing Android pipeline.
+**Goal:** Register staging and dev apps with Apple Connect and Play Console, route their store webhooks to BETA Supabase, and stand up iOS publishing automation alongside the existing Android pipeline.
 
 | # | Task | Label |
 |---|---|---|
-| 2.1 | Register `.staging` and `.debug` bundle IDs on Apple Developer Portal via App Store Connect API `bundleIds` endpoint. | 🤖 (`register-apple-bundle-ids.sh`) |
+| 2.1 | Register `.staging` and `.dev` bundle IDs on Apple Developer Portal via App Store Connect API `bundleIds` endpoint. | 🤖 (`register-apple-bundle-ids.sh`) |
 | 2.2 | Create the Apple Connect staging app via App Store Connect API `apps`. | 🤖 |
-| 2.3 | Create the Apple Connect debug app (IAP only, no store distribution). | 🤖 |
-| 2.4 | Clone IAP products from the production app into the staging and debug apps. | 🤖 (`clone-iap-products.sh`) |
+| 2.3 | Create the Apple Connect dev app (IAP only, no store distribution). | 🤖 |
+| 2.4 | Clone IAP products from the production app into the staging and dev apps. | 🤖 (`clone-iap-products.sh`) |
 | 2.5 | Configure ASSN V2 URLs on the staging app: Production URL → BETA Supabase, Sandbox URL empty. | 🤖 |
 | 2.6 | Create the TestFlight internal testing group on the staging app and invite testers. | 🔧 (API + Connect UI) |
 | 2.7 | Create the Play Console staging app for `dev.cloveclove.peppercheck.staging`. | ✋ Play Console (no API) |
@@ -289,7 +289,7 @@ Scriptable steps land under `scripts/setup/`. Scripts read credentials from envi
 
 **Verification:** subscribe / cancel / renew lifecycle observable end-to-end in BETA Supabase for both platforms; production tag triggers a TestFlight build for iOS and a Play Store internal upload for Android.
 
-**Issue layout:** 5 task-cluster issues filed directly under the umbrella — `Apple Connect staging+debug apps + IAP + ASSN`, `Play Console staging app + IAP`, `staging RTDN Pub/Sub`, `Play Store upload automation`, `iOS TestFlight upload automation`. Each cluster is roughly one PR.
+**Issue layout:** 5 task-cluster issues filed directly under the umbrella — `Apple Connect staging+dev apps + IAP + ASSN`, `Play Console staging app + IAP`, `staging RTDN Pub/Sub`, `Play Store upload automation`, `iOS TestFlight upload automation`. Each cluster is roughly one PR.
 
 ### Phase 3a: Mobile observability (Firebase suite)
 
@@ -321,7 +321,7 @@ Scriptable steps land under `scripts/setup/`. Scripts read credentials from envi
 
 GUI-only steps that cannot be scripted:
 
-- Create Stripe debug sandbox (Stripe Dashboard, Phase 0)
+- Create Stripe dev sandbox (Stripe Dashboard, Phase 0)
 - Upload APNs Auth Key (Firebase Console, Phase 1)
 - Create Play Console staging app and configure RTDN target topic (Play Console, Phase 2)
 - Register Supabase Google auth provider (Supabase Dashboard; Management API may substitute, Phase 1)
@@ -338,10 +338,10 @@ GUI-only steps that cannot be scripted:
 ### Future work
 
 - **Sentry or equivalent server-side error tracking**: Edge Functions and Cloudflare Workers fall back on Supabase logs and Cloudflare Observability for now.
-- **OSS contributor mock services + operator debug ergonomics**: a debug-only layer that bypasses real external services. Two motivations:
-  - OSS contributor onboarding: run a debug build without provisioning Firebase, Stripe, R2, Apple Developer, or Play Console accounts.
-  - Operator debug ergonomics: validate subscription / point grant / payout flows without going through a TestFlight review cycle.
-  - Implementation ideas (separate spec): a debug-only "simulated purchase" button that calls the Edge Function to grant a subscription tier directly; a "simulated payout" button that updates the ledger without invoking Stripe Connect; a "simulated push trigger" that fires a local notification. Mock layer enabled only when `AppConfig.environment == debug`, dead-code-eliminated otherwise.
+- **OSS contributor mock services + operator dev ergonomics**: a dev-only layer that bypasses real external services. Two motivations:
+  - OSS contributor onboarding: run a dev build without provisioning Firebase, Stripe, R2, Apple Developer, or Play Console accounts.
+  - Operator dev ergonomics: validate subscription / point grant / payout flows without going through a TestFlight review cycle.
+  - Implementation ideas (separate spec): a dev-only "simulated purchase" button that calls the Edge Function to grant a subscription tier directly; a "simulated payout" button that updates the ledger without invoking Stripe Connect; a "simulated push trigger" that fires a local notification. Mock layer enabled only when `AppConfig.environment == dev`, dead-code-eliminated otherwise.
 - **Developer-docs restructure**: tracked separately ([#400](https://github.com/cloveclovedev/peppercheck/issues/400)).
 - **Apple App Store submission automation**: TestFlight upload is in Phase 2; full App Store submission (screenshots, release notes, phased rollout) is deferred to a separate spec.
 - **Play Store submission automation beyond internal track**: Phase 2 covers internal-track upload; production-track promotion automation is deferred.
@@ -366,7 +366,7 @@ GUI-only steps that cannot be scripted:
 #### iOS `CFBundleDisplayName` per flavor
 
 - (a) Same display name ("PepperCheck") across flavors; rely on icon variants only.
-- (b) Distinct display names ("PepperCheck", "PepperCheck Staging", "PepperCheck Debug").
+- (b) Distinct display names ("PepperCheck", "PepperCheck Staging", "PepperCheck Dev").
 
 **Recommendation:** (b). Distinct bundle IDs mean store review is unaffected; the operator gains immediate visual distinction on the home screen.
 
@@ -388,19 +388,19 @@ Firebase Crashlytics collects device identifiers in crash reports. Revisit the p
 
 For the staging app, decide who is invited to the internal testing group. Initial assumption: operator only.
 
-#### IAP product visibility in staging and debug builds
+#### IAP product visibility in staging and dev builds
 
 - (a) Same UI as production — subscribe button visible, real IAP flow triggered.
 - (b) Hide subscribe UI, expose a dedicated "test subscription" UI.
 
-**Recommendation:** (a) for staging (matches production validation). Debug build can either reuse (a) and let the back end reject, or wait for the future debug ergonomics layer (simulated purchase button).
+**Recommendation:** (a) for staging (matches production validation). Dev build can either reuse (a) and let the back end reject, or wait for the future dev ergonomics layer (simulated purchase button).
 
 ### Deferred (revisit later)
 
 - **Per-flavor app version numbering**: future work; not addressed in Phases 0–3a.
 - **Crashlytics alert thresholds**: tune after Phase 3a goes live with real data.
 - **Cron job env gating**: revisit only if assumptions change.
-- **Debug ergonomics features (simulated purchase, etc.)**: independent future spec; can be authored once Phase 1 lands.
+- **Dev ergonomics features (simulated purchase, etc.)**: independent future spec; can be authored once Phase 1 lands.
 
 ## References
 
@@ -446,3 +446,4 @@ Cross-referenced:
 |---|---|
 | 2026-05-11 | Initial draft. |
 | 2026-05-11 | Clarify issue layout: umbrella decomposes into a flat list of task-cluster issues sized to roughly one PR each; Phases are doc-only structural groupings, not GitHub issues. |
+| 2026-06-06 | Renamed environment identifier `debug` → `dev` throughout. Rationale: see [`2026-06-05-android-flavor-split-design.md`](2026-06-05-android-flavor-split-design.md) §"Flavor names: `dev` / `staging` / `production`". Implemented in #445. |

--- a/docs/superpowers/specs/2026-05-11-multi-environment-setup-roadmap-design.md
+++ b/docs/superpowers/specs/2026-05-11-multi-environment-setup-roadmap-design.md
@@ -61,7 +61,7 @@ Legend: ✅ isolated per environment, ⚠️ shared or not isolated, 🆕 not in
 | Firebase project | ⚠️ shared | ⚠️ shared | ⚠️ shared | One project across all |
 | `google-services.json` / `GoogleService-Info.plist` | ⚠️ single secret | ⚠️ same | ⚠️ per-developer copy | |
 | APNs Auth Key | ⚠️ one project | ⚠️ same | ⚠️ same | |
-| Google Sign-In OAuth client | ⚠️ shared Web + Android client | ⚠️ shared (no staging app) | ⚠️ separate Android client (dev fingerprint) | Web client configured in Supabase Dashboard |
+| Google Sign-In OAuth client | ⚠️ shared Web + Android client | ⚠️ shared (no staging app) | ⚠️ separate Android client (debug.keystore fingerprint) | Web client configured in Supabase Dashboard |
 | iOS `GIDClientID` | ⚠️ hard-coded | ⚠️ same | ⚠️ same | Should move to xcconfig |
 | Android signing keystore | ✅ release upload key + Play App Signing | ✅ same (internal testing) | ✅ debug.keystore | Play App Signing fingerprint is the one registered with Firebase / OAuth |
 | Apple Connect app | ⚠️ one | ⚠️ same | ⚠️ same | |

--- a/docs/superpowers/specs/2026-05-31-stripe-debug-sandbox-design.md
+++ b/docs/superpowers/specs/2026-05-31-stripe-debug-sandbox-design.md
@@ -1,4 +1,4 @@
-# Stripe Debug Sandbox
+# Stripe Dev Sandbox
 
 **Date:** 2026-05-31
 **Status:** Draft
@@ -40,7 +40,7 @@ Existing wiring for production and staging is unchanged. No secret rotation on t
 Sandboxes are named without a product prefix:
 
 - `Staging` (existing — currently labeled `テスト環境`; rename is a separate Dashboard action, not gated by this PR)
-- `Debug` (new — created by the operator before running the setup script)
+- `Dev` (new — created by the operator before running the setup script)
 
 Rationale: live mode is necessarily shared across all products in the CloveClove account (one Stripe account = one live mode). If a second CloveClove product appears in the future, the sandboxes can be either kept shared (with code-level `metadata.product` routing) or split out per product. Product-less names avoid forcing a rename when that decision is made.
 

--- a/docs/superpowers/specs/2026-05-31-stripe-debug-sandbox-design.md
+++ b/docs/superpowers/specs/2026-05-31-stripe-debug-sandbox-design.md
@@ -7,15 +7,15 @@
 
 ## Goal
 
-Create a dedicated Stripe sandbox for local debug development so that operator-local Stripe Connect / payout work no longer shares state with the staging sandbox wired to BETA Supabase. Standardize secret placement and Stripe CLI profile usage so the setup is reproducible.
+Create a dedicated Stripe sandbox for local dev development so that operator-local Stripe Connect / payout work no longer shares state with the staging sandbox wired to BETA Supabase. Standardize secret placement and Stripe CLI profile usage so the setup is reproducible.
 
 ## Why
 
-The existing Stripe sandbox is wired to BETA Supabase as the staging webhook destination and is simultaneously used by the operator for local `stripe listen` forwarding. Events triggered from the operator's machine reach the BETA Supabase Edge Function, mixing local-debug noise with staging signal. This blocks confident staging-side validation of Stripe Connect / payout flows.
+The existing Stripe sandbox is wired to BETA Supabase as the staging webhook destination and is simultaneously used by the operator for local `stripe listen` forwarding. Events triggered from the operator's machine reach the BETA Supabase Edge Function, mixing local-dev noise with staging signal. This blocks confident staging-side validation of Stripe Connect / payout flows.
 
-This change isolates local debug into its own sandbox without touching staging-side secrets, deploy workflows, or the existing sandbox's webhook endpoint registration.
+This change isolates local dev into its own sandbox without touching staging-side secrets, deploy workflows, or the existing sandbox's webhook endpoint registration.
 
-## Use case for the debug sandbox
+## Use case for the dev sandbox
 
 Stripe Connect / payout local development:
 
@@ -31,7 +31,7 @@ Stripe Checkout / subscription is out of scope — PepperCheck's subscription is
 |---|---|---|---|
 | production | live | PROD Supabase `handle-stripe-webhook` (URL registered on live) | `cloveclove-live` (optional, read-only inspection) |
 | staging | existing sandbox | BETA Supabase `handle-stripe-webhook` (URL registered on the sandbox) | `cloveclove-staging` (optional, inspection only) |
-| debug | new sandbox | none registered; `stripe listen --forward-to localhost:54321/...` only | `cloveclove-debug` (**required**) |
+| dev | new sandbox | none registered; `stripe listen --forward-to localhost:54321/...` only | `cloveclove-dev` (**required**) |
 
 Existing wiring for production and staging is unchanged. No secret rotation on the deploy side.
 
@@ -48,25 +48,25 @@ Rationale: live mode is necessarily shared across all products in the CloveClove
 
 CLI profile names are **account-scoped**, not product-scoped, to match the sandbox-naming logic above. The "live" vocabulary follows Stripe's own term (the CLI itself names the concept "live mode"):
 
-- `cloveclove-debug` — **required** for `stripe listen` against the new debug sandbox
+- `cloveclove-dev` — **required** for `stripe listen` against the new dev sandbox
 - `cloveclove-staging` — optional, only when inspecting the staging sandbox via CLI
 - `cloveclove-live` — optional, read-only inspection of live data
 
-This PR only sets up `cloveclove-debug`. Setup commands for the other two profiles are documented for future operator reference but not executed as part of this PR.
+This PR only sets up `cloveclove-dev`. Setup commands for the other two profiles are documented for future operator reference but not executed as part of this PR.
 
 ## Secret placement
 
 | File | Key | Consumer |
 |---|---|---|
-| `supabase/functions/.env` | `STRIPE_SECRET_KEY=sk_test_<debug>` | local Edge Function calls to Stripe API |
+| `supabase/functions/.env` | `STRIPE_SECRET_KEY=sk_test_<dev>` | local Edge Function calls to Stripe API |
 | `supabase/functions/.env` | `STRIPE_WEBHOOK_SECRET=whsec_<stripe-listen>` | `handle-stripe-webhook` signature verification |
-| `~/.config/stripe/config.toml` | `[cloveclove-debug]` profile | `stripe` CLI commands |
+| `~/.config/stripe/config.toml` | `[cloveclove-dev]` profile | `stripe` CLI commands |
 
 All target files are gitignored. The script writes the CLI profile via `stripe login`; the `.env` lines are pasted by the operator (see "Script" below for the rationale).
 
 Notably **not** updated by this PR:
 
-- `peppercheck_flutter/assets/env/.env.debug` — `STRIPE_PUBLISHABLE_KEY` is left empty. The Flutter `flutter_stripe` integration is dead under the IAP-only policy and is scheduled for removal in #443.
+- `peppercheck_flutter/assets/env/.env.dev` — `STRIPE_PUBLISHABLE_KEY` is left empty. The Flutter `flutter_stripe` integration is dead under the IAP-only policy and is scheduled for removal in #443.
 - `stripe/.env` — `sync-prices.ts` is dead under the IAP-only policy and is scheduled for removal in #443.
 - `supabase/.env` — does not contain Stripe keys; Stripe lives at `supabase/functions/.env`.
 
@@ -74,17 +74,17 @@ Notably **not** updated by this PR:
 
 `stripe listen` generates a webhook signing secret that **is stable across command restarts** for a given CLI profile (per Stripe CLI documentation: "This process generates a webhook signing secret that remains consistent across command restarts"). Therefore:
 
-- No webhook endpoint registration is needed in the debug sandbox's Dashboard.
-- `stripe listen --project-name=cloveclove-debug --print-secret` is run once during setup, and the resulting `whsec_*` is written to `supabase/functions/.env` as `STRIPE_WEBHOOK_SECRET`.
+- No webhook endpoint registration is needed in the dev sandbox's Dashboard.
+- `stripe listen --project-name=cloveclove-dev --print-secret` is run once during setup, and the resulting `whsec_*` is written to `supabase/functions/.env` as `STRIPE_WEBHOOK_SECRET`.
 - Subsequent `stripe listen --forward-to ...` runs reuse the same secret.
 
-If the operator ever runs `stripe login` again under the `cloveclove-debug` profile, the secret may rotate; the script supports re-running to reconcile.
+If the operator ever runs `stripe login` again under the `cloveclove-dev` profile, the secret may rotate; the script supports re-running to reconcile.
 
 ## Stripe Connect enablement
 
 The new sandbox must have Stripe Connect enabled (Dashboard, one-time toggle) so that `payout-setup` can create Express accounts. Test Connect accounts are created on demand via the existing `payout-setup` Edge Function — no separate bootstrap script is needed.
 
-## Script: `scripts/setup/configure-stripe-debug-sandbox.sh`
+## Script: `scripts/setup/configure-stripe-dev-sandbox.sh`
 
 A small bash script that walks the operator through the setup and runs the steps that are tedious to type by hand. It does **not** edit any `.env` file — the operator copies the printed values into `supabase/functions/.env` themselves so they remain in direct control of the secrets that land on disk. It also does **not** create the sandbox itself (no public Stripe API exists for that).
 
@@ -92,8 +92,8 @@ A small bash script that walks the operator through the setup and runs the steps
 
 1. **Preconditions check**: `stripe` CLI installed.
 2. **Prompt**: confirm the operator has created the sandbox in the Dashboard. If not, print the Dashboard URL and exit.
-3. **CLI profile setup**: run `stripe login --project-name=cloveclove-debug` (interactive browser-based flow that the operator approves on the Dashboard, scoped to the new sandbox).
-4. **Webhook secret retrieval**: run `stripe listen --project-name=cloveclove-debug --print-secret` and print the resulting `whsec_*` to the operator's terminal.
+3. **CLI profile setup**: run `stripe login --project-name=cloveclove-dev` (interactive browser-based flow that the operator approves on the Dashboard, scoped to the new sandbox).
+4. **Webhook secret retrieval**: run `stripe listen --project-name=cloveclove-dev --print-secret` and print the resulting `whsec_*` to the operator's terminal.
 5. **Instructions**: print the two lines the operator should add to or update in `supabase/functions/.env`:
 
    ```
@@ -101,7 +101,7 @@ A small bash script that walks the operator through the setup and runs the steps
    STRIPE_WEBHOOK_SECRET=<paste the whsec_... printed above>
    ```
 
-   Followed by copy-pasteable verification commands (`supabase functions serve handle-stripe-webhook`, `stripe listen --project-name=cloveclove-debug --forward-to ...`, `stripe trigger account.updated --project-name=cloveclove-debug`).
+   Followed by copy-pasteable verification commands (`supabase functions serve handle-stripe-webhook`, `stripe listen --project-name=cloveclove-dev --forward-to ...`, `stripe trigger account.updated --project-name=cloveclove-dev`).
 
 ### Properties
 
@@ -128,14 +128,14 @@ Currently lists `STRIPE_PUBLISHABLE_KEY=pk_test_...`. Leave unchanged in this PR
 
 Acceptance for this PR:
 
-- The script runs to completion: `cloveclove-debug` profile exists in `~/.config/stripe/config.toml`; the `whsec_*` is printed; the operator-facing `.env` instructions and verification commands are displayed.
-- After the operator pastes the two lines into `supabase/functions/.env`, running `stripe trigger account.updated --project-name=cloveclove-debug` with `stripe listen --project-name=cloveclove-debug --forward-to http://localhost:54321/functions/v1/handle-stripe-webhook` reaches the local Edge Function with a 200 response and signature verification passing (verify in `supabase functions serve` logs).
+- The script runs to completion: `cloveclove-dev` profile exists in `~/.config/stripe/config.toml`; the `whsec_*` is printed; the operator-facing `.env` instructions and verification commands are displayed.
+- After the operator pastes the two lines into `supabase/functions/.env`, running `stripe trigger account.updated --project-name=cloveclove-dev` with `stripe listen --project-name=cloveclove-dev --forward-to http://localhost:54321/functions/v1/handle-stripe-webhook` reaches the local Edge Function with a 200 response and signature verification passing (verify in `supabase functions serve` logs).
 - No edit to `BETA_STRIPE_*` GitHub Secrets, no edit to the existing sandbox's registered webhook endpoint.
 - The existing sandbox (now serving as staging) continues to deliver events to BETA Supabase after this change (regression check against a recent BETA event log).
 
 ## Out of scope
 
-- **Stripe billing / Checkout / subscription rebuild** — IAP-only policy is in effect; Stripe-based subscription purchase is stopped. No `products` / `prices` seeding to the debug sandbox.
+- **Stripe billing / Checkout / subscription rebuild** — IAP-only policy is in effect; Stripe-based subscription purchase is stopped. No `products` / `prices` seeding to the dev sandbox.
 - **`developer-docs` runbook prose** — `developer-docs/.../stripe-cli-setup.adoc` is owned by #421. This spec defines the operator workflow that #421 will document; the prose itself lives there.
 - **Sandbox creation automation** — no public Stripe API exists for creating sandboxes. The Dashboard step stays manual.
 - **Test Connect account bootstrap script** — `payout-setup` is idempotent and works as the on-demand bootstrap path.
@@ -171,3 +171,4 @@ Acceptance for this PR:
 | Date | Change |
 |---|---|
 | 2026-05-31 | Initial draft. |
+| 2026-06-06 | Renamed environment identifier `debug` → `dev` throughout. Filename preserved as a date-anchored snapshot. Rationale: see [`2026-06-05-android-flavor-split-design.md`](2026-06-05-android-flavor-split-design.md) §"Flavor names: `dev` / `staging` / `production`". Implemented in #445. |

--- a/docs/superpowers/specs/2026-06-06-debug-to-dev-rename-design.md
+++ b/docs/superpowers/specs/2026-06-06-debug-to-dev-rename-design.md
@@ -1,0 +1,141 @@
+# Rename `debug` environment to `dev` (Flutter, CI, DX, operator scripts)
+
+**Author:** Makoto Kurihara
+**Date:** 2026-06-06
+**Status:** Design
+**Parent:** [#418](https://github.com/cloveclovedev/peppercheck/issues/418) (multi-environment setup roadmap)
+**Implements:** [#445](https://github.com/cloveclovedev/peppercheck/issues/445)
+**Blocks:** [#423](https://github.com/cloveclovedev/peppercheck/issues/423), [#424](https://github.com/cloveclovedev/peppercheck/issues/424), [#425](https://github.com/cloveclovedev/peppercheck/issues/425), [#426](https://github.com/cloveclovedev/peppercheck/issues/426), [#427](https://github.com/cloveclovedev/peppercheck/issues/427)
+
+## Summary
+
+Rename the lowest-environment identifier from `debug` to `dev` across the Flutter app, CI workflows, developer-experience surfaces (VSCode launcher, Claude rules), the operator-facing Stripe sandbox setup script, and active reference documentation. Pure rename — no behavior change. The rationale for choosing `dev` (Android Gradle Plugin `debug` `buildType` source-set collision) is recorded in [`2026-06-05-android-flavor-split-design.md`](2026-06-05-android-flavor-split-design.md) §"Flavor names: `dev` / `staging` / `production`".
+
+## Why this is a precursor
+
+Phase 1 of the multi-environment roadmap ([`2026-05-11-multi-environment-setup-roadmap-design.md`](2026-05-11-multi-environment-setup-roadmap-design.md)) fans out per-flavor source-set files (manifests, app icons, Firebase config) into `android/app/src/<flavor>/`. If the lowest flavor is named `debug`, those paths collide with the built-in `debug` `buildType` source set and silently bleed into the `*Debug` variants of every other flavor. The collision is described in detail in the android-flavor-split spec; this rename removes the entire class of footgun before #423 / #424 / #425 / #426 / #427 lock per-flavor file layouts into the repo.
+
+## Scope
+
+### 1. Flutter code
+
+| File | Change |
+| --- | --- |
+| `peppercheck_flutter/lib/main_debug.dart` | `git mv` → `main_dev.dart`; body `AppConfig.debug` → `AppConfig.dev` |
+| `peppercheck_flutter/lib/app/config/app_environment.dart` | enum value `debug` → `dev`; `static const debug` → `static const dev`; `envFile: 'assets/env/.env.debug'` → `'.env.dev'` |
+| `peppercheck_flutter/lib/app/config/app_environment.g.dart` | Regenerate via `dart run build_runner build --delete-conflicting-outputs` |
+| `peppercheck_flutter/lib/app/app_startup.dart` | Comment at line 45 mentioning `.env.debug` → `.env.dev` |
+| `peppercheck_flutter/lib/common_widgets/environment_banner.dart` | `case AppEnvironment.debug:` → `case AppEnvironment.dev:`; banner label `"DEBUG"` → `"DEV"` |
+| `peppercheck_flutter/test/common_widgets/environment_banner_test.dart` | `AppEnvironment.debug` → `AppEnvironment.dev`; expected label `"DEBUG"` → `"DEV"` |
+
+### 2. Asset list & env file
+
+| File | Change |
+| --- | --- |
+| `peppercheck_flutter/pubspec.yaml` (line 104) | Asset path `assets/env/.env.debug` → `.env.dev` |
+| `peppercheck_flutter/assets/env/.env.debug` (gitignored) | Operator-side: `mv .env.debug .env.dev` |
+
+### 3. CI workflows
+
+| File | Change |
+| --- | --- |
+| `.github/workflows/ci-flutter.yml` (line 35) | `touch assets/env/.env.debug` → `.env.dev` |
+| `.github/workflows/deploy-beta.yml` (line 147) | Same |
+| `.github/workflows/deploy-production.yml` (line 147) | Same |
+
+### 4. Developer-experience surfaces
+
+| File | Change |
+| --- | --- |
+| `.vscode/launch.json` | Configuration name `"Flutter: Debug (Local)"` → `"Flutter: Dev (Local)"`; `"program": "lib/main_debug.dart"` → `"lib/main_dev.dart"` |
+| `.claude/rules/flutter.md` | Build verification example using `main_debug.dart` → `main_dev.dart`; flavored entry-point list mentions |
+
+### 5. Operator-facing script
+
+| File | Change |
+| --- | --- |
+| `scripts/setup/configure-stripe-debug-sandbox.sh` | `git mv` → `configure-stripe-dev-sandbox.sh`; internal Stripe CLI profile name `cloveclove-debug` → `cloveclove-dev`; all user-facing prompt text "debug sandbox" → "dev sandbox" |
+
+The Stripe CLI profile name change requires the operator to re-run `stripe login --project-name=cloveclove-dev` after pulling the merged PR (the existing `cloveclove-debug` profile in `~/.config/stripe/config.toml` is local and unaffected by the rename — operators may delete it manually if desired).
+
+### 6. Active reference documentation
+
+| File | Change |
+| --- | --- |
+| `docs/superpowers/specs/2026-05-11-multi-environment-setup-roadmap-design.md` | Rewrite environment-name `debug` references to `dev` (does not touch Android `debug` `buildType` / Xcode `Debug` configuration / Flutter build-mode `--debug` mentions). Add Revision log entry |
+| `docs/superpowers/specs/2026-05-31-stripe-debug-sandbox-design.md` | Same content rewrite + Revision log entry. **Filename is preserved** as a date-anchored snapshot — see §"Doc handling philosophy" below |
+| `developer-docs/modules/ROOT/pages/flutter/initial-local-setup.adoc` | 4 environment-name `debug` references → `dev` |
+| `developer-docs/modules/ROOT/pages/flutter/firebase-setup.adoc` | `flutter run -t lib/main_debug.dart` example → `main_dev.dart` |
+
+### 7. PR description — operator checklist
+
+The PR body lists actions the operator performs out-of-band (cannot be tested in CI):
+
+- [ ] R2 bucket `peppercheck-debug` — drop and recreate as `peppercheck-dev` (local-only test data, nothing worth preserving)
+- [ ] Local `peppercheck_flutter/assets/env/.env.debug` — `mv` to `.env.dev`
+- [ ] Stripe Dashboard — rename sandbox display name `"Debug"` → `"Dev"` (API keys unchanged)
+- [ ] Stripe CLI — re-run `stripe login --project-name=cloveclove-dev`
+- [ ] GitHub Secrets `DEBUG_*` — none exist (verified via `gh secret list`); record this finding inline
+- [ ] Rewrite environment-name `debug` references in issue bodies #418 / #423 / #424 / #425 / #426 / #427 (operator action)
+
+## Doc handling philosophy
+
+A design document's **filename embeds the date it was written** — that is the snapshot anchor. Even when terminology changes later, the filename stays so the document's place in the project's timeline remains stable.
+
+The document's **content** is the current source of truth for what to do or look at. Letting old terminology persist in active reference docs (roadmap, runbooks) causes future operators and contributors to read instructions in a vocabulary that no longer matches the code. So content is kept current, and a Revision log entry records when and why the terminology changed.
+
+- `2026-05-11-multi-environment-setup-roadmap-design.md` and `2026-05-31-stripe-debug-sandbox-design.md` are **active references** consumed by ongoing Phase 1 work and operator runbooks → rewrite content, add Revision log entry, preserve filename
+- Closed-feature historical specs and plans (e.g., `2026-05-16-non-prod-environment-banner-design.md`, `2026-04-27-draft-task-deletion-design.md`, legacy `docs/plans/*`) are **snapshots of decisions made at a point in time** → leave untouched
+
+Future readers of the snapshots can read `debug` as the historical name of the environment now called `dev`; the rationale lives in the android-flavor-split spec and is linked from each rewritten doc's Revision log.
+
+## Explicitly out of scope (per #445 §6)
+
+- Android Gradle Plugin's built-in `debug` `buildType` — standard Gradle name, unrelated
+- Xcode's standard `Debug` build configuration — standard Xcode name
+- Flutter / Dart `--debug` / `--release` / `Debug` / `Release` build-mode flags and macros
+- C/C++ `_DEBUG` preprocessor macro (Windows runner)
+- Comments and identifiers where "debug" means "build with debug symbols" or "attach a debugger"
+- Supabase migration string literals containing `'debug'` (template IDs and unrelated row data)
+- Cloudflare Workers `console.debug` / log-level types (`peppercheck-webapp/cloudflare-env.d.ts`)
+- `README.md` mentions of `SUPABASE_URL_DEBUG` / `GATEWAY_URL_DEBUG` — these are legacy from the pre-Flutter native Android implementation, not consumed by the current Flutter Gradle build (verified via grep). The README at large is stale and warrants a separate "refresh for Flutter" PR
+- `docs/development/android/README.md` — Japanese legacy Native Android documentation, separate cleanup
+
+## Verification
+
+Run locally before pushing:
+
+1. `dart run build_runner build --delete-conflicting-outputs` (regenerate `app_environment.g.dart`)
+2. `cd peppercheck_flutter && flutter test`
+3. `cd peppercheck_flutter && flutter build apk --debug -t lib/main_dev.dart` — primary entry point builds
+4. `cd peppercheck_flutter && flutter build apk --debug -t lib/main_staging.dart` — staging not regressed
+5. `cd peppercheck_flutter && flutter build apk --debug -t lib/main_production.dart` — production not regressed
+6. `git ls-files | xargs rg "main_debug|\\.env\\.debug|AppEnvironment\\.debug|AppConfig\\.debug" 2>/dev/null` — returns only intentionally out-of-scope historical doc hits
+
+CI green on the PR confirms `.env.dev` `touch` works in all three workflows.
+
+## PR strategy
+
+Single PR, branch `chore/rename-debug-to-dev-flutter` cut from `main`. Rename is mechanical and atomic — splitting code from docs would land a state where one half references the old name while the other half references the new name, breaking `flutter build` for any reviewer who checks out the intermediate commit.
+
+The PR title follows the project's Conventional Commits convention: `chore(flutter): rename "debug" environment to "dev"`.
+
+In-place work on the feature branch (no `git worktree`): Flutter builds need gitignored secrets / config (`local.properties`, `.env.*`, `google-services.json`) that worktrees don't carry over.
+
+## Risks
+
+- **`.g.dart` regeneration order** — must run `build_runner` after the enum rename or stale generated code will reference `debug`. Mitigation: include the regeneration in step 1 of the verification sequence; `--delete-conflicting-outputs` handles the conflict.
+- **Operator local-env break at merge time** — once `main` carries `.env.dev`, any operator pull without renaming their gitignored `.env.debug` will hit `flutter build` failures ("asset not found"). Mitigation: PR description's operator checklist makes the `mv` step explicit; the change is mechanical (one `mv` command).
+- **Stripe CLI re-login friction** — operators using the existing `cloveclove-debug` profile must re-login as `cloveclove-dev`. Mitigation: this is one command (`stripe login --project-name=cloveclove-dev`), called out in the operator checklist. The renamed setup script's prompt walks the operator through it.
+
+## Acceptance
+
+- [ ] All §1–§6 file edits applied
+- [ ] Verification steps 1–6 pass locally
+- [ ] CI green on the PR
+- [ ] PR description carries the §7 operator checklist
+- [ ] Revision log entries added to roadmap-design.md and stripe-debug-sandbox-design.md
+
+## Revision log
+
+- 2026-06-06: Initial spec for #445.

--- a/peppercheck_flutter/lib/app/app_startup.dart
+++ b/peppercheck_flutter/lib/app/app_startup.dart
@@ -42,7 +42,7 @@ Future<void> _initSdk(AppConfig config) async {
   await Firebase.initializeApp();
 
   // On iOS Simulator, localhost is 127.0.0.1, but on Android Emulator it is 10.0.2.2.
-  // .env.debug usually contains 10.0.2.2. We replace it globally at runtime for iOS.
+  // .env.dev usually contains 10.0.2.2. We replace it globally at runtime for iOS.
   if (Platform.isIOS) {
     dotenv.env.forEach((key, value) {
       if (value.contains('10.0.2.2')) {

--- a/peppercheck_flutter/lib/app/config/app_environment.dart
+++ b/peppercheck_flutter/lib/app/config/app_environment.dart
@@ -2,7 +2,7 @@ import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'app_environment.g.dart';
 
-enum AppEnvironment { debug, staging, production }
+enum AppEnvironment { dev, staging, production }
 
 /// Build-time descriptor used by [appStartup] during bootstrap only.
 /// Widget-facing runtime state lives in `appEnvironmentProvider`.
@@ -12,9 +12,9 @@ class AppConfig {
 
   const AppConfig({required this.environment, required this.envFile});
 
-  static const debug = AppConfig(
-    environment: AppEnvironment.debug,
-    envFile: 'assets/env/.env.debug',
+  static const dev = AppConfig(
+    environment: AppEnvironment.dev,
+    envFile: 'assets/env/.env.dev',
   );
 
   static const staging = AppConfig(

--- a/peppercheck_flutter/lib/common_widgets/environment_banner.dart
+++ b/peppercheck_flutter/lib/common_widgets/environment_banner.dart
@@ -21,9 +21,9 @@ class EnvironmentBanner extends ConsumerWidget {
           color: AppColors.accentYellowLight,
           child: child,
         );
-      case AppEnvironment.debug:
+      case AppEnvironment.dev:
         return Banner(
-          message: 'DEBUG',
+          message: 'DEV',
           location: BannerLocation.topEnd,
           color: AppColors.accentGreenLight,
           child: child,

--- a/peppercheck_flutter/lib/main_dev.dart
+++ b/peppercheck_flutter/lib/main_dev.dart
@@ -2,5 +2,5 @@ import 'package:peppercheck_flutter/app/app_startup.dart';
 import 'package:peppercheck_flutter/app/config/app_environment.dart';
 
 void main() {
-  appStartup(AppConfig.debug);
+  appStartup(AppConfig.dev);
 }

--- a/peppercheck_flutter/pubspec.yaml
+++ b/peppercheck_flutter/pubspec.yaml
@@ -101,7 +101,7 @@ flutter:
 
   assets:
     - assets/images/
-    - assets/env/.env.debug
+    - assets/env/.env.dev
     - assets/env/.env.staging
     - assets/env/.env.production
 

--- a/peppercheck_flutter/test/common_widgets/environment_banner_test.dart
+++ b/peppercheck_flutter/test/common_widgets/environment_banner_test.dart
@@ -39,13 +39,13 @@ void main() {
     expect(find.text('child'), findsOneWidget);
   });
 
-  testWidgets('debug: green DEBUG Banner at topEnd', (tester) async {
+  testWidgets('dev: green DEV Banner at topEnd', (tester) async {
     await tester.pumpWidget(
-      _harness(env: AppEnvironment.debug, child: const Text('child')),
+      _harness(env: AppEnvironment.dev, child: const Text('child')),
     );
 
     final banner = tester.widget<Banner>(find.byType(Banner));
-    expect(banner.message, 'DEBUG');
+    expect(banner.message, 'DEV');
     expect(banner.color, AppColors.accentGreenLight);
     expect(banner.location, BannerLocation.topEnd);
     expect(find.text('child'), findsOneWidget);

--- a/scripts/setup/configure-stripe-dev-sandbox.sh
+++ b/scripts/setup/configure-stripe-dev-sandbox.sh
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
 #
-# Guided setup for the PepperCheck debug Stripe sandbox.
+# Guided setup for the PepperCheck dev Stripe sandbox.
 #
 # What this does:
-#   1. Confirms the debug sandbox has been created in the Stripe Dashboard.
-#   2. Runs `stripe login --project-name=cloveclove-debug` (browser-based).
-#   3. Runs `stripe listen --project-name=cloveclove-debug --print-secret`
+#   1. Confirms the dev sandbox has been created in the Stripe Dashboard.
+#   2. Runs `stripe login --project-name=cloveclove-dev` (browser-based).
+#   3. Runs `stripe listen --project-name=cloveclove-dev --print-secret`
 #      and prints the resulting webhook signing secret.
 #   4. Prints the two .env lines the operator should paste into
 #      supabase/functions/.env, plus verification commands.
@@ -28,7 +28,7 @@ cat <<'EOF'
 
 Before continuing, in the Stripe Dashboard:
 
-  1. Create a new sandbox dedicated to local debug.
+  1. Create a new sandbox dedicated to local dev.
      URL: https://dashboard.stripe.com/test/sandboxes
   2. Enable Stripe Connect for that sandbox
      (Settings > Connect > Get started, in the new sandbox).
@@ -37,7 +37,7 @@ Before continuing, in the Stripe Dashboard:
 
 EOF
 
-read -r -p "Have you created the debug sandbox and enabled Connect? [y/N]: " answer
+read -r -p "Have you created the dev sandbox and enabled Connect? [y/N]: " answer
 case "${answer:-N}" in
   y|Y|yes|YES) ;;
   *)
@@ -47,19 +47,19 @@ case "${answer:-N}" in
 esac
 
 echo
-echo "Setting up the 'cloveclove-debug' Stripe CLI profile."
-echo "A browser window will open — approve the pairing and SELECT THE DEBUG SANDBOX"
+echo "Setting up the 'cloveclove-dev' Stripe CLI profile."
+echo "A browser window will open — approve the pairing and SELECT THE DEV SANDBOX"
 echo "(not the staging sandbox or live mode)."
 echo
-stripe login --project-name=cloveclove-debug
+stripe login --project-name=cloveclove-dev
 
 echo
 echo "Fetching the local webhook signing secret..."
-webhook_secret=$(stripe listen --project-name=cloveclove-debug --print-secret)
+webhook_secret=$(stripe listen --project-name=cloveclove-dev --print-secret)
 
 if [[ -z "${webhook_secret}" ]]; then
   echo "Error: stripe listen --print-secret returned empty output." >&2
-  echo "Check that the cloveclove-debug profile was set up correctly." >&2
+  echo "Check that the cloveclove-dev profile was set up correctly." >&2
   exit 1
 fi
 
@@ -70,7 +70,7 @@ Setup complete. Next steps for the operator:
 ------------------------------------------------------------
 
 1. Open supabase/functions/.env (create it from supabase/functions/.env.example
-   if it does not exist) and add or update these two lines with the debug
+   if it does not exist) and add or update these two lines with the dev
    sandbox values:
 
    STRIPE_SECRET_KEY=<paste your sk_test_... from the Dashboard>
@@ -83,12 +83,12 @@ Setup complete. Next steps for the operator:
 
 3. Start the webhook forwarder (in a second terminal):
 
-   stripe listen --project-name=cloveclove-debug \\
+   stripe listen --project-name=cloveclove-dev \\
      --forward-to http://localhost:54321/functions/v1/handle-stripe-webhook
 
 4. Trigger a test event (in a third terminal):
 
-   stripe trigger account.updated --project-name=cloveclove-debug
+   stripe trigger account.updated --project-name=cloveclove-dev
 
 5. Verify in the 'supabase functions serve' logs that the event arrived
    with a 200 response and signature verification passed.


### PR DESCRIPTION
## Summary

Precursor for #423 / Phase 1 of the multi-environment roadmap. Renames the lowest-environment identifier from `debug` to `dev` across:

- Flutter Dart code (`AppEnvironment`, `AppConfig`, `main_dev.dart`, banner label)
- `pubspec.yaml` asset list (`.env.dev`)
- CI workflows (`ci-flutter.yml`, `deploy-beta.yml`, `deploy-production.yml`)
- DX surfaces (`.vscode/launch.json`, `.claude/rules/flutter.md`)
- Operator script (`scripts/setup/configure-stripe-dev-sandbox.sh`)
- Active reference docs (multi-env roadmap, stripe sandbox spec, initial-local-setup runbook, firebase-setup runbook)

Pure rename — no behavior change. Rationale for picking **dev** (Android Gradle Plugin **debug** buildType source-set collision) lives in [2026-06-05-android-flavor-split-design.md](docs/superpowers/specs/2026-06-05-android-flavor-split-design.md) section *Flavor names*.

Spec: [docs/superpowers/specs/2026-06-06-debug-to-dev-rename-design.md](docs/superpowers/specs/2026-06-06-debug-to-dev-rename-design.md).

## Out of scope (per spec section 6)

- `README.md` mentions of `SUPABASE_URL_DEBUG` / `GATEWAY_URL_DEBUG` — legacy native-Android docs not consumed by the current Flutter Gradle build. Tracked for a separate README refresh PR.
- `docs/development/android/README.md` — Japanese legacy native-Android doc, separate cleanup.
- Closed-feature historical specs / plans — preserved as snapshots per the doc-handling philosophy in the spec.

## Test plan

- [x] `flutter analyze` clean (5 pre-existing info-level issues unrelated to this rename)
- [x] `flutter test` passes (109 tests, including updated `dev: green DEV Banner` widget test)
- [x] `flutter build apk --debug -t lib/main_dev.dart` succeeds
- [x] `flutter build apk --debug -t lib/main_staging.dart` regression-checked
- [x] `flutter build apk --debug -t lib/main_production.dart` regression-checked
- [x] CI green on this PR (verifies all three workflows tolerate the renamed `.env.dev` `touch`)

## Operator checklist (post-merge)

- [x] R2 bucket `peppercheck-debug` — drop and recreate as `peppercheck-dev` (local-only test data, nothing worth preserving)
- [x] Local `peppercheck_flutter/assets/env/.env.debug` — `mv` to `.env.dev` on each developer machine (gitignored; not part of this diff)
- [x] Stripe Dashboard — rename sandbox display name **Debug** → **Dev** (API keys unchanged)
- [x] Stripe CLI — re-run `stripe login --project-name=cloveclove-dev` (the old `cloveclove-debug` profile in `~/.config/stripe/config.toml` is local and may be deleted manually)
- [ ] GitHub Secrets `DEBUG_*` — verified via `gh secret list`: none exist (no-op)
- [x] Rewrite environment-name `debug` references in issue bodies of #418 / #423 / #424 / #425 / #426 / #427

Closes #445.

🤖 Generated with [Claude Code](https://claude.com/claude-code)