### PR TITLE
chore(scripts): add sync-github-secrets.sh + relocate operator secrets to ~/.config/peppercheck/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,9 +14,6 @@
 # slang i18n generated analysis files
 peppercheck_flutter/assets/i18n/_*.json
 
-# GitHub Secrets config (contains real values)
-scripts/github-secrets
-
 # Git worktrees
 .worktrees/
 

--- a/developer-docs/modules/ROOT/pages/operations/multi-environment-bootstrap.adoc
+++ b/developer-docs/modules/ROOT/pages/operations/multi-environment-bootstrap.adoc
@@ -40,6 +40,10 @@ Day-to-day Flutter development does NOT need these. Once the `dev` flavor config
 | `scripts/setup/setup-deploy-secrets.sh <sa-json-path>`
 | Sets four GitHub Secrets at once via STDIN redirect (values never appear on stdout, in the process list, or in shell history): `BETA_FIREBASE_SERVICE_ACCOUNT_JSON`, `BETA_FIREBASE_APP_ID` (auto-resolved from `firebase apps:list`), `BETA_GOOGLE_SERVICES_JSON`, `PROD_GOOGLE_SERVICES_JSON`.
 | Once per credential refresh. Re-run to update any of the four secrets after a service-account key rotation or staging app re-registration.
+
+| `scripts/sync-github-secrets.sh`
+| Merges new keys from `scripts/github-secrets.example` into `~/.config/peppercheck/github-secrets` (the operator-owned config consumed by `scripts/setup-github-secrets.sh`). Preserves existing values, drops keys removed from the template, leaves new keys empty for manual fill-in. Writes a timestamped `.bak` and keeps the 3 most recent. Never echoes secret values; orphan / new key reports use names only.
+| Whenever `scripts/github-secrets.example` is updated upstream.
 |===
 
 == Order of operations
@@ -98,6 +102,14 @@ After step 4, also visit the Firebase Console once to enable App Distribution on
 | `~/.config/peppercheck/peppercheck-staging-sa.json`
 | `bootstrap-peppercheck-staging-sa.sh`
 | Service account JSON key for the staging FAD upload + Edge Function FCM. Mode 0600 inside a mode 0700 directory. Source of truth for `BETA_FIREBASE_SERVICE_ACCOUNT_JSON`.
+
+| `~/.config/peppercheck/github-secrets`
+| Operator-owned, populated from `scripts/github-secrets.example` then maintained via `scripts/sync-github-secrets.sh`
+| Source of values for `scripts/setup-github-secrets.sh`. Holds env-scoped text secrets (Supabase / Stripe / R2 / Pub-Sub / Operator auth / Web base URLs). Mode 0600.
+
+| `~/.config/peppercheck/github-secrets.bak.<ISO-timestamp>`
+| `sync-github-secrets.sh`
+| Timestamped snapshot of the previous `github-secrets` taken before each sync. The 3 most recent generations are retained; older ones are auto-pruned.
 |===
 
 == Secrets set by step 4

--- a/scripts/github-secrets.example
+++ b/scripts/github-secrets.example
@@ -1,8 +1,21 @@
 # GitHub Secrets for peppercheck CI/CD
-# Copy this file to scripts/github-secrets and fill in the values.
 #
-# Text secrets are set from this file via scripts/setup-github-secrets.sh
-# Binary/file secrets are set separately (see instructions below).
+# First-time setup:
+#   mkdir -p ~/.config/peppercheck && chmod 700 ~/.config/peppercheck
+#   cp scripts/github-secrets.example ~/.config/peppercheck/github-secrets
+#   chmod 600 ~/.config/peppercheck/github-secrets
+#   # Edit ~/.config/peppercheck/github-secrets to fill in values.
+#
+# Push text secrets to GitHub:
+#   scripts/setup-github-secrets.sh
+#
+# When this template is updated upstream, merge new keys into your local
+# secrets file without losing existing values:
+#   scripts/sync-github-secrets.sh
+#   # Preserves values for surviving keys, drops removed keys (saved to a
+#   # timestamped .bak), leaves new keys empty for you to fill in.
+#
+# Binary/file secrets are set separately (see instructions at the bottom).
 
 # --- Supabase ---
 # Access token: https://supabase.com/dashboard/account/tokens

--- a/scripts/setup-github-secrets.sh
+++ b/scripts/setup-github-secrets.sh
@@ -2,21 +2,25 @@
 # Set GitHub Secrets for peppercheck CI/CD from a config file.
 #
 # Usage:
-#   ./scripts/setup-github-secrets.sh                    # uses scripts/github-secrets
+#   ./scripts/setup-github-secrets.sh                    # uses ~/.config/peppercheck/github-secrets
 #   ./scripts/setup-github-secrets.sh path/to/file       # uses custom file
 #
 # Binary/file secrets must be set separately. The full list of file-style
 # secrets and their gh-secret-set invocations is documented at the bottom
 # of scripts/github-secrets.example. This script also prints a summary
 # after the text-secret pass.
+#
+# To keep ~/.config/peppercheck/github-secrets in sync with template
+# updates, run scripts/sync-github-secrets.sh.
 
 set -euo pipefail
 
-SECRETS_FILE="${1:-scripts/github-secrets}"
+SECRETS_FILE="${1:-${HOME}/.config/peppercheck/github-secrets}"
 
 if [[ ! -f "$SECRETS_FILE" ]]; then
   echo "Error: $SECRETS_FILE not found."
-  echo "Copy scripts/github-secrets.example to scripts/github-secrets and fill in the values."
+  echo "Copy scripts/github-secrets.example to ~/.config/peppercheck/github-secrets and fill in the values."
+  echo "(Legacy scripts/github-secrets path was moved out of the repo; mkdir -p ~/.config/peppercheck && chmod 700 ~/.config/peppercheck && mv scripts/github-secrets ~/.config/peppercheck/github-secrets && chmod 600 ~/.config/peppercheck/github-secrets if migrating.)"
   exit 1
 fi
 

--- a/scripts/sync-github-secrets.sh
+++ b/scripts/sync-github-secrets.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+# Sync ~/.config/peppercheck/github-secrets with scripts/github-secrets.example.
+#
+# Preserves the value of every key still present in the template, drops keys
+# the template no longer defines (saved to a timestamped .bak first), and
+# leaves newly-added keys empty for the operator to fill in. The template
+# is the source of truth for which keys belong; this script never echoes
+# secret values to stdout / stderr.
+#
+# Usage: scripts/sync-github-secrets.sh
+#
+# Pre-req: ~/.config/peppercheck/github-secrets exists. If you have a legacy
+# scripts/github-secrets file from before the Phase 1 relocation, move it
+# manually:
+#   mkdir -p ~/.config/peppercheck && chmod 700 ~/.config/peppercheck
+#   mv scripts/github-secrets ~/.config/peppercheck/github-secrets
+#   chmod 600 ~/.config/peppercheck/github-secrets
+#
+# Output:
+#   ~/.config/peppercheck/github-secrets             (rewritten, mode 0600)
+#   ~/.config/peppercheck/github-secrets.bak.<ISO>   (timestamped backup,
+#                                                     keeps the 3 most
+#                                                     recent generations;
+#                                                     older ones are pruned)
+
+set -euo pipefail
+umask 077
+
+repo_root="$(git rev-parse --show-toplevel)"
+template="${repo_root}/scripts/github-secrets.example"
+secrets_dir="${HOME}/.config/peppercheck"
+current="${secrets_dir}/github-secrets"
+
+if [[ ! -f "$template" ]]; then
+  echo "ERROR: template not found at ${template}" >&2
+  exit 1
+fi
+if [[ ! -f "$current" ]]; then
+  echo "ERROR: current secrets file not found at ${current}" >&2
+  echo "       If you have a legacy scripts/github-secrets, move it first:" >&2
+  echo "         mkdir -p ${secrets_dir} && chmod 700 ${secrets_dir}" >&2
+  echo "         mv ${repo_root}/scripts/github-secrets ${current}" >&2
+  echo "         chmod 600 ${current}" >&2
+  exit 1
+fi
+
+mkdir -p "$secrets_dir"
+chmod 700 "$secrets_dir"
+
+output_tmp="$(mktemp "${secrets_dir}/.github-secrets.sync.XXXXXX")"
+report_tmp="$(mktemp "${secrets_dir}/.github-secrets.sync-report.XXXXXX")"
+chmod 600 "$output_tmp" "$report_tmp"
+trap 'rm -f "$output_tmp" "$report_tmp"' EXIT
+
+# All key/value handling happens inside awk so the values never become bash
+# variables in the controller process. The awk script writes the merged
+# file content to stdout and writes "ORPHAN <key>" / "NEW <key>" lines —
+# names only, never values — to stderr.
+awk -v current="$current" -v template="$template" '
+BEGIN {
+    while ((getline line < current) > 0) {
+        if (line ~ /^[[:space:]]*#/) continue
+        if (line ~ /^[[:space:]]*$/) continue
+        eq = index(line, "=")
+        if (eq == 0) continue
+        key = substr(line, 1, eq - 1)
+        val = substr(line, eq + 1)
+        cur_value[key] = val
+        cur_seen[key] = 1
+        cur_order[++ncur] = key
+    }
+    close(current)
+
+    while ((getline line < template) > 0) {
+        if (line ~ /^[[:space:]]*#/ || line ~ /^[[:space:]]*$/) {
+            print line
+            continue
+        }
+        eq = index(line, "=")
+        if (eq == 0) {
+            print line
+            continue
+        }
+        key = substr(line, 1, eq - 1)
+        tpl_seen[key] = 1
+        if (key in cur_seen) {
+            print key "=" cur_value[key]
+        } else {
+            print key "="
+            new_order[++nnew] = key
+        }
+    }
+    close(template)
+
+    for (i = 1; i <= ncur; i++) {
+        k = cur_order[i]
+        if (!(k in tpl_seen)) {
+            print "ORPHAN " k > "/dev/stderr"
+        }
+    }
+    for (i = 1; i <= nnew; i++) {
+        print "NEW " new_order[i] > "/dev/stderr"
+    }
+}
+' > "$output_tmp" 2> "$report_tmp"
+
+orphans=()
+new_keys=()
+while IFS=' ' read -r tag key || [[ -n "${tag:-}" ]]; do
+  [[ -z "${tag:-}" ]] && continue
+  case "$tag" in
+    ORPHAN) orphans+=("$key") ;;
+    NEW)    new_keys+=("$key") ;;
+  esac
+done < "$report_tmp"
+
+timestamp="$(date -u +'%Y-%m-%dT%H-%M-%SZ')"
+backup="${secrets_dir}/github-secrets.bak.${timestamp}"
+cp "$current" "$backup"
+chmod 600 "$backup"
+
+# Keep the 3 most recent .bak files (including the one we just wrote);
+# prune anything older. `ls -1 -t` sorts by modification time, newest first.
+sorted_backups=()
+while IFS= read -r f; do
+  sorted_backups+=("$f")
+done < <(ls -1 -t "${secrets_dir}"/github-secrets.bak.* 2>/dev/null || true)
+if [[ ${#sorted_backups[@]} -gt 3 ]]; then
+  i=3
+  while [[ $i -lt ${#sorted_backups[@]} ]]; do
+    rm -f "${sorted_backups[$i]}"
+    echo "[prune] $(basename "${sorted_backups[$i]}")"
+    i=$((i + 1))
+  done
+fi
+
+mv "$output_tmp" "$current"
+# Drop output_tmp from the trap now that it has been consumed.
+trap 'rm -f "$report_tmp"' EXIT
+
+echo "[ok] ${current} synced from $(basename "$template")"
+echo "     backup: $(basename "$backup")"
+
+if [[ ${#orphans[@]} -gt 0 ]]; then
+  echo ""
+  echo "Orphan keys (no longer defined by the template — removed from new file,"
+  echo "preserved in backup for recovery if a key was renamed):"
+  printf '  %s\n' "${orphans[@]}" | sort
+fi
+
+if [[ ${#new_keys[@]} -gt 0 ]]; then
+  echo ""
+  echo "New keys (defined by the template, empty in your new file — please fill"
+  echo "in by editing ${current} directly, then run scripts/setup-github-secrets.sh):"
+  printf '  %s\n' "${new_keys[@]}" | sort
+fi


### PR DESCRIPTION
## Summary

Adds a maintenance helper that keeps the operator-owned `github-secrets` file in sync with the canonical `scripts/github-secrets.example` template, and relocates the operator-owned file out of the repo into `~/.config/peppercheck/`.

## Motivation

While wrapping up #448, we noticed the operator's local `scripts/github-secrets` had drifted from `scripts/github-secrets.example`: several BETA_/PROD_ keys added by recent PRs were never copied into the local file, and the legacy `FIREBASE_APP_ID` key (removed from the template) was still sitting around. The previous workflow ("manually re-diff the template every time it changes") doesn't scale.

A small `sync-github-secrets.sh` formalizes the merge: walk the template, copy values from the local file for surviving keys, drop removed keys (preserved in a timestamped `.bak`), and leave new keys empty for the operator to fill in. The script is careful to never echo secret values — orphan / new key names only — and writes the merged file atomically via tempfile + mv.

The operator's local secrets file also moves to `~/.config/peppercheck/github-secrets`, alongside the SA JSON key added in #448. This aligns the operator-private files under a single XDG-style directory and eliminates the chance of accidentally committing the file by relying on `.gitignore`.

## Changes

- **NEW** `scripts/sync-github-secrets.sh` — bash 3.2-compatible (macOS system bash) + awk for the merge logic. Backup rotation keeps the 3 most recent `.bak` files.
- `scripts/setup-github-secrets.sh` — default path updated to `~/.config/peppercheck/github-secrets`, with a migration hint in the "file not found" error message.
- `scripts/github-secrets.example` — header comment rewritten to document the new copy path and point at the sync script.
- `.gitignore` — `scripts/github-secrets` line removed (the file no longer lives in the repo).
- `developer-docs/.../operations/multi-environment-bootstrap.adoc` — adds the new script to the Scripts overview table and adds two new entries to the Generated files table (`github-secrets` + `.bak.<timestamp>` files).

## Operator migration (one-time)

Performed by hand during this PR's preparation:

```bash
mkdir -p ~/.config/peppercheck && chmod 700 ~/.config/peppercheck
mv scripts/github-secrets ~/.config/peppercheck/github-secrets
chmod 600 ~/.config/peppercheck/github-secrets
```

No file contents were read during the move.

## Test plan

- [x] `bash -n` + `shellcheck` clean on both `sync-github-secrets.sh` and the updated `setup-github-secrets.sh`.
- [x] Live run of `scripts/sync-github-secrets.sh` against the operator's actual file detected the expected drift:
  - 1 orphan key (`FIREBASE_APP_ID`, removed from template in #448) — dropped from new file, preserved in `.bak`.
  - 20 new keys (BETA_/PROD_ Stripe / R2 / Pub-Sub / Operator auth / Web base URL) — left empty for fill-in.
  - Backup file written with mode 0600 inside a mode 0700 directory.
  - **No secret values appeared in script output.**
- [x] CI: `ci-flutter.yml` / `ci-supabase.yml` / `ci-webapp.yml` not triggered (no touched paths) — N/A.
- [x] Future: run `sync-github-secrets.sh` after the next `scripts/github-secrets.example` update to confirm the maintenance path keeps working.

## Related

- Wrap-up follow-up from #448 (Phase 1 Android flavor split).
- Aligns with `~/.config/peppercheck/peppercheck-staging-sa.json` introduced by #448.

🤖 Generated with [Claude Code](https://claude.com/claude-code)