### PR TITLE
chore(vscode): pin flutterFlavor on each launch config

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -6,6 +6,7 @@
             "request": "launch",
             "type": "dart",
             "program": "lib/main_dev.dart",
+            "flutterFlavor": "dev",
             "cwd": "${workspaceFolder}/peppercheck_flutter",
             "preLaunchTask": "ADB Reverse All"
         },
@@ -14,6 +15,7 @@
             "request": "launch",
             "type": "dart",
             "program": "lib/main_staging.dart",
+            "flutterFlavor": "staging",
             "cwd": "${workspaceFolder}/peppercheck_flutter",
             "flutterMode": "debug"
         },
@@ -22,6 +24,7 @@
             "request": "launch",
             "type": "dart",
             "program": "lib/main_staging.dart",
+            "flutterFlavor": "staging",
             "cwd": "${workspaceFolder}/peppercheck_flutter",
             "flutterMode": "release"
         },
@@ -30,6 +33,7 @@
             "request": "launch",
             "type": "dart",
             "program": "lib/main_production.dart",
+            "flutterFlavor": "production",
             "cwd": "${workspaceFolder}/peppercheck_flutter",
             "flutterMode": "release"
         }


### PR DESCRIPTION
## Summary

- Adds \`flutterFlavor\` to each entry in \`.vscode/launch.json\` so the Dart entry point (\`main_dev.dart\` / \`main_staging.dart\` / \`main_production.dart\`) and the Gradle product flavor stay in sync. Without this, VSCode would silently build the default Gradle flavor and install under a package ID that doesn't match the Dart entry point.
- During the wallet payout row redesign PR (#455), this caused 30+ minutes of misdiagnosis: VSCode was building production-flavor APKs while running \`main_dev.dart\`, so the installed package was \`dev.cloveclove.peppercheck\` (production ID), not \`dev.cloveclove.peppercheck.dev\` (dev ID).

## ⚠️ Do not merge until Firebase is set up

Merging this PR by itself will **break Google Sign-In** in VSCode debug for \"Dev (Local)\" and the two \"Staging\" configs, because the new package IDs (\`dev.cloveclove.peppercheck.dev\` / \`dev.cloveclove.peppercheck.staging\`) are not yet registered as Android apps in the Firebase project.

The Firebase OAuth registration is tracked in #453. Merge order:

1. Register \`dev.cloveclove.peppercheck.dev\` and \`dev.cloveclove.peppercheck.staging\` as Android apps in Firebase + add their SHA-1s (per #453).
2. Then merge this PR.

## Test plan

- [ ] Once Firebase entries are added, \`flutter run -t lib/main_dev.dart --flavor dev\` (or VSCode debug \"Flutter: Dev (Local)\") signs in successfully.
- [ ] Same check for staging configs.
- [ ] Production config still works (no change in package ID for \`production\`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)