### PR TITLE
fix(backend): Phase 1 review follow-ups (Atlas revisions schema, WAL archiving, clean-clone bootstrap)

### DIFF
--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -69,7 +69,7 @@ jobs:
         run: atlas migrate validate --dir file://migrations
 
       - name: Apply migrations as the migrator role
-        run: atlas migrate apply --env local --url "$DATABASE_URL" --revisions-schema public
+        run: atlas migrate apply --env local --url "$DATABASE_URL" --revisions-schema atlas
 
       - name: Check for schema/migration drift
         run: |

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -96,7 +96,10 @@ jobs:
           echo "app role: DML ok, DDL denied"
 
       - name: Tests (race, serialized packages)
-        run: go test -race -p 1 ./...
+        # -count=1 disables the Go test cache so the DB integration tests always
+        # run against the fresh service Postgres (a cached PASS would otherwise
+        # skip re-execution when DATABASE_URL is unchanged).
+        run: go test -race -p 1 -count=1 ./...
 
   image:
     runs-on: ubuntu-latest

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -44,7 +44,7 @@ test: ## Run Go tests incl. DB integration on a throwaway Postgres (needs host a
 	[ "$$ready" = 1 ] || { echo "test DB not ready after 60s"; exit 1; }; \
 	dsn="postgres://peppercheck_migrator:m@127.0.0.1:$$port/peppercheck?sslmode=disable"; \
 	atlas migrate apply --env local --url "$$dsn" --revisions-schema atlas >/dev/null; \
-	DATABASE_URL="$$dsn" go test -race -p 1 ./...
+	DATABASE_URL="$$dsn" go test -race -p 1 -count=1 ./...
 
 fmt: ## Format Go code
 	gofmt -w .

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -35,9 +35,14 @@ test: ## Run Go tests incl. DB integration on a throwaway Postgres (needs host a
 	@set -e; name=pc-maketest; port=55432; \
 	docker rm -f $$name >/dev/null 2>&1 || true; \
 	trap 'docker rm -f $$name >/dev/null 2>&1 || true' EXIT; \
-	docker run --rm -d --name $$name -e POSTGRES_PASSWORD=postgres -e POSTGRES_DB=peppercheck -e POSTGRES_MIGRATOR_PASSWORD=m -e POSTGRES_APP_PASSWORD=a -e POSTGRES_BACKUP_PASSWORD=b -v "$$PWD/deploy/postgres/init:/docker-entrypoint-initdb.d:ro" -p $$port:5432 postgres:17 >/dev/null; \
-	until docker exec $$name pg_isready -U postgres -d peppercheck >/dev/null 2>&1; do sleep 1; done; sleep 1; \
-	dsn="postgres://peppercheck_migrator:m@localhost:$$port/peppercheck?sslmode=disable"; \
+	docker run --rm -d --name $$name -e POSTGRES_PASSWORD=postgres -e POSTGRES_DB=peppercheck -e POSTGRES_MIGRATOR_PASSWORD=m -e POSTGRES_APP_PASSWORD=a -e POSTGRES_BACKUP_PASSWORD=b -v "$$PWD/deploy/postgres/init:/docker-entrypoint-initdb.d:ro" -p 127.0.0.1:$$port:5432 postgres:17 >/dev/null; \
+	ready=; i=0; while [ $$i -lt 60 ]; do \
+	  if docker exec $$name pg_isready -h 127.0.0.1 -U postgres -d peppercheck >/dev/null 2>&1; then ready=1; break; fi; \
+	  docker ps -q -f name=$$name | grep -q . || { echo "test DB container exited during init:"; docker logs $$name 2>&1 | tail -20; exit 1; }; \
+	  i=$$((i+1)); sleep 1; \
+	done; \
+	[ "$$ready" = 1 ] || { echo "test DB not ready after 60s"; exit 1; }; \
+	dsn="postgres://peppercheck_migrator:m@127.0.0.1:$$port/peppercheck?sslmode=disable"; \
 	atlas migrate apply --env local --url "$$dsn" --revisions-schema atlas >/dev/null; \
 	DATABASE_URL="$$dsn" go test -race -p 1 ./...
 

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -1,7 +1,11 @@
 # Local development helpers for the peppercheck Go backend.
-# Requires docker + go. Atlas is pinned to v1.2.0 (see README).
+# Requires docker + go + atlas (pinned v1.2.0 — see README).
+#
+# NOTE: after pulling a change to the DB role/schema bootstrap
+# (deploy/postgres/init/*), run `make reset` — Postgres init scripts only run on
+# an EMPTY data dir, so an existing volume won't pick up new roles/schemas.
 
-.PHONY: help up down down-v logs ps backup test fmt vet
+.PHONY: help up down down-v reset logs ps backup test fmt vet
 
 help: ## Show available targets
 	grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN{FS=":.*?## "}{printf "  %-9s %s\n", $$1, $$2}'
@@ -16,6 +20,8 @@ down: ## Stop the stack (keep volumes)
 down-v: ## Stop and remove volumes (clears Postgres data + the local WAL archive)
 	docker compose --profile backup down -v
 
+reset: down-v up ## Recreate from scratch (run after DB role/schema init changes)
+
 logs: ## Follow stack logs
 	docker compose logs -f
 
@@ -25,8 +31,15 @@ ps: ## Show stack status
 backup: ## Start the opt-in backup profile (needs AGE_RECIPIENT in .env)
 	docker compose --profile backup up -d --build backup
 
-test: ## Run Go tests (needs DATABASE_URL, or run `make up` first)
-	go test -race -p 1 ./...
+test: ## Run Go tests incl. DB integration on a throwaway Postgres (needs host atlas v1.2.0)
+	@set -e; name=pc-maketest; port=55432; \
+	docker rm -f $$name >/dev/null 2>&1 || true; \
+	trap 'docker rm -f $$name >/dev/null 2>&1 || true' EXIT; \
+	docker run --rm -d --name $$name -e POSTGRES_PASSWORD=postgres -e POSTGRES_DB=peppercheck -e POSTGRES_MIGRATOR_PASSWORD=m -e POSTGRES_APP_PASSWORD=a -e POSTGRES_BACKUP_PASSWORD=b -v "$$PWD/deploy/postgres/init:/docker-entrypoint-initdb.d:ro" -p $$port:5432 postgres:17 >/dev/null; \
+	until docker exec $$name pg_isready -U postgres -d peppercheck >/dev/null 2>&1; do sleep 1; done; sleep 1; \
+	dsn="postgres://peppercheck_migrator:m@localhost:$$port/peppercheck?sslmode=disable"; \
+	atlas migrate apply --env local --url "$$dsn" --revisions-schema atlas >/dev/null; \
+	DATABASE_URL="$$dsn" go test -race -p 1 ./...
 
 fmt: ## Format Go code
 	gofmt -w .

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -1,0 +1,35 @@
+# Local development helpers for the peppercheck Go backend.
+# Requires docker + go. Atlas is pinned to v1.2.0 (see README).
+
+.PHONY: help up down down-v logs ps backup test fmt vet
+
+help: ## Show available targets
+	grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN{FS=":.*?## "}{printf "  %-9s %s\n", $$1, $$2}'
+
+up: ## Start the core stack (creates .env from the template if missing)
+	[ -f .env ] || cp .env.example .env
+	docker compose up -d --build
+
+down: ## Stop the stack (keep volumes)
+	docker compose down
+
+down-v: ## Stop and remove volumes (clears Postgres data + the local WAL archive)
+	docker compose --profile backup down -v
+
+logs: ## Follow stack logs
+	docker compose logs -f
+
+ps: ## Show stack status
+	docker compose ps
+
+backup: ## Start the opt-in backup profile (needs AGE_RECIPIENT in .env)
+	docker compose --profile backup up -d --build backup
+
+test: ## Run Go tests (needs DATABASE_URL, or run `make up` first)
+	go test -race -p 1 ./...
+
+fmt: ## Format Go code
+	gofmt -w .
+
+vet: ## Run go vet
+	go vet ./...

--- a/backend/README.md
+++ b/backend/README.md
@@ -46,7 +46,14 @@ Feature packages (`internal/identity`, `internal/task`, …) with the
   (`down-v` then `up`) — the migrator can't create the `atlas` schema on its own
   (no database-level `CREATE`), so a stale volume would fail migration. Local
   data is disposable (fresh-start policy). For a persistent DB you would instead
-  apply the delta once by hand, e.g. `CREATE SCHEMA atlas AUTHORIZATION peppercheck_migrator;`.
+  apply the delta once by hand — create the schema **and move the existing
+  history table into it**, otherwise Atlas reads an empty `atlas.atlas_schema_revisions`
+  and thinks no migrations are applied:
+
+  ```sql
+  CREATE SCHEMA atlas AUTHORIZATION peppercheck_migrator;
+  ALTER TABLE public.atlas_schema_revisions SET SCHEMA atlas;
+  ```
 - **Atlas is pinned to `v1.2.0`** (Standard distribution, used unauthenticated =
   free). Match it on your machine — Homebrew can't pin a specific version, so
   use the install script:

--- a/backend/README.md
+++ b/backend/README.md
@@ -39,6 +39,14 @@ Feature packages (`internal/identity`, `internal/task`, …) with the
 
 ## Notes & caveats
 
+- **Changing the DB bootstrap needs a fresh volume.** The role/schema bootstrap
+  in `deploy/postgres/init/*` (including the migrator-owned `atlas` schema) runs
+  **only on an empty Postgres data dir** (`docker-entrypoint-initdb.d`). After
+  pulling a change there onto an existing local volume, run **`make reset`**
+  (`down-v` then `up`) — the migrator can't create the `atlas` schema on its own
+  (no database-level `CREATE`), so a stale volume would fail migration. Local
+  data is disposable (fresh-start policy). For a persistent DB you would instead
+  apply the delta once by hand, e.g. `CREATE SCHEMA atlas AUTHORIZATION peppercheck_migrator;`.
 - **Atlas is pinned to `v1.2.0`** (Standard distribution, used unauthenticated =
   free). Match it on your machine — Homebrew can't pin a specific version, so
   use the install script:
@@ -55,11 +63,18 @@ Feature packages (`internal/identity`, `internal/task`, …) with the
   retention/pruning and no off-site upload**. Real WAL retention, off-site (B2)
   shipping, physical base backups, and restore drills are **Phase 7 and required
   before any VPS deploy**. Locally, `make down-v` clears the archive.
-- **DB passwords in connection strings must be URI-safe.** DSNs embed the
-  password in a `postgres://user:pass@host/db` URL, and Atlas requires this URL
-  form, so a real password containing `/ # % @ :` etc. must be **percent-encoded**
-  when injected (or constrain the generated password to a URI-safe charset). The
-  local dev defaults are URI-safe.
+- **DB passwords must be URI-safe (single-variable design).** Each password
+  variable (e.g. `POSTGRES_APP_PASSWORD`) is used BOTH to create the DB role
+  (raw literal, in `00-roles.sh`) AND embedded in a `postgres://user:pass@host/db`
+  DSN (which URI-**decodes** it), and Atlas requires the URL form. The two only
+  agree when the value contains no URI-reserved characters. So **constrain real
+  (Bitwarden) passwords to a URI-safe charset** (alphanumeric + `-_.~`). Do NOT
+  try to fix a special-char password by percent-encoding this single shared
+  variable — the role would be created with the encoded literal (e.g. `p%40ss`)
+  while the DSN connects with the decoded value (`p@ss`), so they mismatch and
+  the connection fails. If arbitrary special characters are truly unavoidable,
+  split into two variables: a raw value for role creation and a separately
+  percent-encoded value for every DSN. The local dev defaults are URI-safe.
 - **Production deploys must use `-f compose.yaml` explicitly** (no
   `compose.override.yaml`), since the committed dev override publishes Postgres
   to host loopback for local tooling.

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,65 @@
+# peppercheck backend
+
+Go backend for PepperCheck (Phase 1 foundation). One binary (`peppercheck`) run
+as `api`, `worker`, or `healthcheck`; PostgreSQL managed with Atlas; Docker
+Compose for local development. **No feature endpoints yet** — this is the
+foundation the rest of the Supabase → Go + VPS refactor builds on.
+
+## Quick start
+
+```sh
+make up                 # creates .env from .env.example, builds + starts the core stack
+curl localhost/livez    # -> ok
+curl localhost/readyz   # -> ready
+make down-v             # stop and clear volumes (incl. the local WAL archive)
+```
+
+`make up` creates `.env` from `.env.example` if it's missing, then runs
+`docker compose up -d --build`. A bare `docker compose up` on a clean clone
+**fails on purpose** — secrets are fail-closed (`${VAR:?}`), so `.env` must exist
+first. Run `make help` for all targets.
+
+`.env` holds **non-sensitive local defaults only** (throwaway dev passwords, an
+age public key). Never put a real provider secret or real DB password in it —
+real secrets are injected at runtime via Bitwarden Secrets Manager / Docker
+secrets (Phase 7).
+
+## Structure
+
+- `cmd/peppercheck/` — the single binary's entry point (command dispatch).
+- `internal/api`, `internal/worker` — the `api` and `worker` command assemblies.
+- `internal/platform/*` — shared infrastructure: `config`, `logging`,
+  `httpserver`, `database`, `jobs` (durable queue), `inbox` (webhook dedup).
+- `schema/<feature>/NN_*.sql` — Atlas **table-only** declarative schema;
+  `migrations/` — generated versioned migrations; `atlas.hcl` — Atlas env.
+- `deploy/` — Caddy, Postgres init + WAL archiver, backup container.
+
+Feature packages (`internal/identity`, `internal/task`, …) with the
+`handler → service → store` layering arrive from Phase 2 onward.
+
+## Notes & caveats
+
+- **Atlas is pinned to `v1.2.0`** (Standard distribution, used unauthenticated =
+  free). Match it on your machine — Homebrew can't pin a specific version, so
+  use the install script:
+  ```sh
+  curl -sSf https://atlasgo.sh | sh -s -- --version v1.2.0
+  ```
+  The schema is table-only (no DB functions/triggers), so no `atlas login` /
+  Atlas Pro feature is ever needed. Atlas's migration-history table lives in a
+  dedicated `atlas` schema, isolated from the least-privilege app role.
+- **Backup is an opt-in Compose profile** (`make backup`), not started by the
+  core stack. It needs `AGE_RECIPIENT` (an age public key) in `.env`.
+- **WAL archiving is a local skeleton.** It archives to the `wal-archive` volume
+  with `archive_timeout=900` (matches the 15-minute RPO), but has **no
+  retention/pruning and no off-site upload**. Real WAL retention, off-site (B2)
+  shipping, physical base backups, and restore drills are **Phase 7 and required
+  before any VPS deploy**. Locally, `make down-v` clears the archive.
+- **DB passwords in connection strings must be URI-safe.** DSNs embed the
+  password in a `postgres://user:pass@host/db` URL, and Atlas requires this URL
+  form, so a real password containing `/ # % @ :` etc. must be **percent-encoded**
+  when injected (or constrain the generated password to a URI-safe charset). The
+  local dev defaults are URI-safe.
+- **Production deploys must use `-f compose.yaml` explicitly** (no
+  `compose.override.yaml`), since the committed dev override publishes Postgres
+  to host loopback for local tooling.

--- a/backend/compose.yaml
+++ b/backend/compose.yaml
@@ -55,13 +55,13 @@ services:
       - apply
       - --dir
       - file:///migrations
-      # peppercheck_migrator (deploy/postgres/init/00-roles.sh) only has
-      # CREATE on the `public` schema, not database-level CREATE. Without this
-      # flag Atlas tries to create its own `atlas_schema_revisions` schema to
-      # track applied migrations, which that role cannot do, so the
-      # revisions table lives in `public` instead.
+      # peppercheck_migrator (deploy/postgres/init/00-roles.sh) owns a
+      # dedicated `atlas` schema (created in 00-roles.sh), so Atlas tracks
+      # its applied-migrations history there instead of in `public` — kept
+      # isolated from the least-privilege app role, which is never granted
+      # USAGE on `atlas`.
       - --revisions-schema
-      - public
+      - atlas
       - --url
       - postgres://peppercheck_migrator:${POSTGRES_MIGRATOR_PASSWORD:?POSTGRES_MIGRATOR_PASSWORD is required}@postgres:5432/peppercheck?sslmode=disable
     volumes:

--- a/backend/compose.yaml
+++ b/backend/compose.yaml
@@ -28,15 +28,20 @@ services:
       - -c
       - archive_mode=on
       - -c
-      - archive_command=test ! -f /wal-archive/%f && cp %p /wal-archive/%f
+      - archive_command=/usr/local/bin/archive-wal.sh %p %f
       - -c
-      - archive_timeout=60
+      # 900s (15min) matches the accepted RPO (docs/superpowers/specs/2026-07-22-phase0-baseline.md).
+      # 60s forced a 16MiB segment every minute (~22.5 GiB/day of WAL); nothing
+      # yet prunes /wal-archive or ships it off-site (B2) — retention/pruning +
+      # off-site upload is Phase 7 and a pre-VPS-deploy requirement.
+      - archive_timeout=900
       - -c
       - max_wal_senders=3
     volumes:
       - pgdata:/var/lib/postgresql/data
       - wal-archive:/wal-archive
       - ./deploy/postgres/init:/docker-entrypoint-initdb.d:ro
+      - ./deploy/postgres/archive-wal.sh:/usr/local/bin/archive-wal.sh:ro
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U postgres -d peppercheck"]
       interval: 5s

--- a/backend/deploy/postgres/archive-wal.sh
+++ b/backend/deploy/postgres/archive-wal.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+# Idempotent, atomic WAL archiver. Args: $1 = %p (source WAL path), $2 = %f (WAL
+# file name). Postgres may re-archive the same segment (e.g. after a crash), so
+# this returns success if the destination already holds an identical file, fails
+# (never overwrites) if it holds a DIFFERENT file, and otherwise copies atomically.
+set -eu
+src="$1"
+dest="/wal-archive/$2"
+if [ -f "$dest" ]; then
+  if cmp -s "$src" "$dest"; then
+    exit 0
+  fi
+  echo "archive-wal: $2 already exists with different content; refusing to overwrite" >&2
+  exit 1
+fi
+tmp="$dest.tmp.$$"
+cp "$src" "$tmp"
+mv "$tmp" "$dest"

--- a/backend/deploy/postgres/init/00-roles.sh
+++ b/backend/deploy/postgres/init/00-roles.sh
@@ -13,6 +13,12 @@ psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" \
   CREATE ROLE peppercheck_migrator LOGIN PASSWORD :'migrator_pw';
   GRANT CREATE, USAGE ON SCHEMA public TO peppercheck_migrator;
 
+  -- Atlas migration-history table lives in its own schema, owned by the
+  -- migrator, so the least-privilege app role (granted no USAGE here) can never
+  -- read or tamper with migration state. The app's blanket default-privilege
+  -- grant below is scoped to `public`, so it never reaches this schema.
+  CREATE SCHEMA atlas AUTHORIZATION peppercheck_migrator;
+
   -- Runtime role: least-privilege DML only, never DDL.
   CREATE ROLE peppercheck_app LOGIN PASSWORD :'app_pw';
   GRANT USAGE ON SCHEMA public TO peppercheck_app;


### PR DESCRIPTION
## Phase 1 review follow-ups

Addresses findings from several review rounds on the merged Phase 1 backend (PR #463). Base: `refactor/go-api-vps`.

### Security / correctness
- **Atlas migration history isolated from the app role.** `atlas_schema_revisions` now lives in a dedicated migrator-owned `atlas` schema (`--revisions-schema atlas` + `CREATE SCHEMA atlas AUTHORIZATION peppercheck_migrator` in `00-roles.sh`), so the least-privilege `peppercheck_app` role can no longer read or tamper with migration state — it has no `USAGE` on `atlas`, and its blanket default-privilege grant is scoped to `public`. compose **and** CI both use `--revisions-schema atlas`. Verified: app `SELECT` on `atlas.atlas_schema_revisions` → permission denied; app DML on `public` still works.
- **Idempotent, atomic WAL archiver.** Replaced `archive_command=test ! -f … && cp …` (which returned exit 1 when re-archiving the same segment — e.g. after a crash — causing infinite retry and `pg_wal` exhaustion) with `deploy/postgres/archive-wal.sh`: identical re-archive → success, different file → refuse (exit 1, no overwrite), otherwise copy-to-temp + atomic `mv`.
- **`archive_timeout` 60 → 900** — matches the accepted 15-minute RPO (60s forced ~22.5 GiB/day of WAL). Retention/pruning + off-site (B2) shipping remains a **Phase-7 pre-VPS-deploy requirement** (documented).

### Developer experience / docs
- **`backend/Makefile` + `backend/README.md`.** `make up` bootstraps `.env` so a clean clone starts (a bare `docker compose up` is fail-closed on secrets by design). `make reset` recreates from scratch after a DB role/schema `init` change (init scripts only run on an empty data dir). README documents:
  - **`make test` runs the DB integration tests on a throwaway Postgres** — waits for real in-container TCP readiness (excludes the init-time socket-only server) with a bounded timeout + early-exit detection, binds the test DB to `127.0.0.1` only, and uses **`-count=1`** (also added to CI) so the tests always run against the fresh DB instead of returning a cached PASS.
  - **DB passwords must be URI-safe.** Each password variable is used BOTH to create the DB role (raw literal) AND embedded in a `postgres://…` DSN that URI-**decodes** it (and Atlas requires the URL form), so they only agree when the value has no URI-reserved characters. **Constrain real passwords to a URI-safe charset** — percent-encoding a single shared variable does **not** work (role gets the encoded literal, DSN connects with the decoded value → mismatch); if special chars are unavoidable, split into a raw variable and a separately-encoded DSN variable.
  - The **persistent-DB one-time migration** to adopt the `atlas` schema moves the existing history table (`CREATE SCHEMA atlas …; ALTER TABLE public.atlas_schema_revisions SET SCHEMA atlas;`), not just creates the schema.
  - Atlas `v1.2.0` pin + install; WAL-retention caveat; production must use `-f compose.yaml` (no dev override).

### Verification
`make test` runs all DB integration tests (verified non-cached across repeated runs) and tears the throwaway DB down cleanly; app is denied access to the `atlas` schema; the WAL archiver is idempotent/atomic; `cmp` confirmed present in `postgres:17`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FRDpWxfgE5Y9JQm2GzMDaU
