### PR TITLE
fix(backend): Phase 2 codex review follow-ups — FK index, runtime-role CI test, token-revocation note

### DIFF
--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -32,10 +32,11 @@ jobs:
           --health-timeout 5s
           --health-retries 10
     env:
-      # go tests + atlas apply run AS THE MIGRATOR: it owns the tables (so tests
-      # can TRUNCATE) and, via ALTER DEFAULT PRIVILEGES, the app role gets DML on
-      # them — which the role-separation step below verifies.
+      # Most integration tests run as the migrator because their fixture cleanup
+      # uses TRUNCATE. The identity store also runs once through APP_DATABASE_URL
+      # so CI exercises the same least-privilege role used in production.
       DATABASE_URL: postgres://peppercheck_migrator:migrator_ci_pw@localhost:5432/peppercheck?sslmode=disable
+      APP_DATABASE_URL: postgres://peppercheck_app:app_ci_pw@localhost:5432/peppercheck?sslmode=disable
       # Consumed by the real 00-roles.sh:
       PGHOST: localhost
       PGPASSWORD: postgres

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -43,8 +43,9 @@ test: ## Run Go tests incl. DB integration on a throwaway Postgres (needs host a
 	done; \
 	[ "$$ready" = 1 ] || { echo "test DB not ready after 60s"; exit 1; }; \
 	dsn="postgres://peppercheck_migrator:m@127.0.0.1:$$port/peppercheck?sslmode=disable"; \
+	app_dsn="postgres://peppercheck_app:a@127.0.0.1:$$port/peppercheck?sslmode=disable"; \
 	atlas migrate apply --env local --url "$$dsn" --revisions-schema atlas >/dev/null; \
-	DATABASE_URL="$$dsn" go test -race -p 1 -count=1 ./...
+	DATABASE_URL="$$dsn" APP_DATABASE_URL="$$app_dsn" go test -race -p 1 -count=1 ./...
 
 fmt: ## Format Go code
 	gofmt -w .

--- a/backend/internal/identity/store_test.go
+++ b/backend/internal/identity/store_test.go
@@ -45,6 +45,45 @@ func TestCreateWithIdentityThenFind(t *testing.T) {
 	}
 }
 
+func TestStoreWorksWithRuntimeRole(t *testing.T) {
+	db := testsupport.DBFromEnv(t, "APP_DATABASE_URL")
+	const issuer = "runtime-role-test"
+	const subject = "subject"
+	clean := func() error {
+		_, err := db.Exec(`
+			DELETE FROM public.users u
+			USING public.user_identities i
+			WHERE u.id = i.user_id
+			  AND i.issuer = $1
+			  AND i.subject = $2`,
+			issuer, subject,
+		)
+		return err
+	}
+	if err := clean(); err != nil {
+		t.Fatalf("clean runtime-role fixtures: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := clean(); err != nil {
+			t.Errorf("clean runtime-role fixtures: %v", err)
+		}
+	})
+
+	s := NewStore(db)
+	ctx := context.Background()
+	created, err := s.CreateWithIdentity(ctx, issuer, subject)
+	if err != nil {
+		t.Fatalf("create with runtime role: %v", err)
+	}
+	found, err := s.FindByIdentity(ctx, issuer, subject)
+	if err != nil {
+		t.Fatalf("find with runtime role: %v", err)
+	}
+	if found.ID != created.ID {
+		t.Fatalf("find returned %s, want %s", found.ID, created.ID)
+	}
+}
+
 func TestCreateWithIdentityDuplicateSignalsNotFound(t *testing.T) {
 	s := newStore(t)
 	ctx := context.Background()

--- a/backend/internal/platform/auth/firebase.go
+++ b/backend/internal/platform/auth/firebase.go
@@ -52,7 +52,9 @@ func NewFirebaseVerifier(ctx context.Context, projectID string) (*FirebaseVerifi
 // public-key fetch) with its own timeout. An invalid/expired token returns
 // ErrInvalidToken (the caller maps it to 401); any other failure — a public-key
 // fetch, network error, or timeout — is wrapped and returned as-is so the caller
-// can treat it as 503 and log the cause. It is NOT the user's fault.
+// can treat it as 503 and log the cause. It is NOT the user's fault. This method
+// intentionally does not check token revocation or whether the Firebase user was
+// disabled; the immediate-lockout policy is tracked in the operations follow-up.
 func (v *FirebaseVerifier) Verify(ctx context.Context, rawToken string) (Identity, error) {
 	ctx, cancel := context.WithTimeout(ctx, v.timeout)
 	defer cancel()

--- a/backend/internal/testsupport/db.go
+++ b/backend/internal/testsupport/db.go
@@ -9,17 +9,24 @@ import (
 	"github.com/cloveclovedev/peppercheck/backend/internal/core/database"
 )
 
-// DB returns a connected *sql.DB for integration tests, or skips the test when
-// DATABASE_URL is not set. The pool is closed automatically at test cleanup.
+// DB returns a connected *sql.DB for integration tests using DATABASE_URL.
 func DB(t *testing.T) *database.Handle {
 	t.Helper()
-	dsn := os.Getenv("DATABASE_URL")
+	return DBFromEnv(t, "DATABASE_URL")
+}
+
+// DBFromEnv returns a connected *sql.DB using the named environment variable,
+// or skips the test when it is not set. The pool is closed automatically at
+// test cleanup.
+func DBFromEnv(t *testing.T, envName string) *database.Handle {
+	t.Helper()
+	dsn := os.Getenv(envName)
 	if dsn == "" {
-		t.Skip("DATABASE_URL not set; skipping integration test")
+		t.Skipf("%s not set; skipping integration test", envName)
 	}
 	db, err := database.Connect(context.Background(), dsn)
 	if err != nil {
-		t.Fatalf("connect: %v", err)
+		t.Fatalf("connect using %s: %v", envName, err)
 	}
 	t.Cleanup(func() { _ = db.Close() })
 	return db

--- a/backend/migrations/20260725114029_add_user_identities_user_id_index.sql
+++ b/backend/migrations/20260725114029_add_user_identities_user_id_index.sql
@@ -1,0 +1,2 @@
+-- Create index "user_identities_user_id_idx" to table: "user_identities"
+CREATE INDEX "user_identities_user_id_idx" ON "public"."user_identities" ("user_id");

--- a/backend/migrations/atlas.sum
+++ b/backend/migrations/atlas.sum
@@ -1,4 +1,5 @@
-h1:k06WU8RTWw6i/U+v1gl3FK3SzTEh9jLRGAJ6S5MwASw=
+h1:ZN4eZMmGqUMiysY8LF4950pSG1u4WZvU1PmyEADYNc4=
 20260723132843_phase1_baseline.sql h1:6ruU5+0h61Vu2x1TdLLKgdyKkqVcOHj5k5mTSyy/LJQ=
 20260723142427_add_jobs.sql h1:gtIwPrilHLjMbx/7vsVSI8R2USaKfauzUbU8PH3cLjc=
 20260723143726_add_webhook_inbox.sql h1:IXSVNx+WE9EJ+f1msmGlM2dD0sHPKMbPHGzqHhv+rxQ=
+20260725114029_add_user_identities_user_id_index.sql h1:sY0AMmd9WUIcQTunkVVCpNrQfiMy/Jpy0NmoTpoJees=

--- a/backend/schema/identity/02_user_identities.sql
+++ b/backend/schema/identity/02_user_identities.sql
@@ -13,3 +13,6 @@ CREATE TABLE public.user_identities (
     updated_at timestamptz NOT NULL DEFAULT now(),
     CONSTRAINT user_identities_issuer_subject_key UNIQUE (issuer, subject)
 );
+
+CREATE INDEX user_identities_user_id_idx
+    ON public.user_identities (user_id);

--- a/docs/operations/go-vps-refactor-followups.md
+++ b/docs/operations/go-vps-refactor-followups.md
@@ -52,6 +52,13 @@ Reference: `docs/operations/phase2-auth-operator-checklist.md`,
       `signInWithGoogle()` (it was extracted for the removed Apple-link flow).
 - [ ] `api_client.dart` stale "interceptor" comment (~line 44; design uses inline
       retry, no interceptor).
+- [ ] **Firebase session invalidation policy**: the Go API currently uses
+      `VerifyIDToken`, which validates signature and expiry but does not check
+      whether a token was revoked or its Firebase user was disabled. Before the
+      first privileged Go endpoint ships, decide whether accepting tokens until
+      their natural expiry is sufficient. If immediate lockout is required, use
+      a credentialed Admin client with `VerifyIDTokenAndCheckRevoked`, or enforce
+      `users.status` centrally for every authenticated request.
 - [ ] Pre-existing uncommitted `evidence_controller.g.dart` + untracked files
       (`.agents/`, other-phase plan/spec docs, `supabase/snippets/*.sql`) — decide
       what to keep / clean up.


### PR DESCRIPTION
## Summary

Follow-ups from the codex review of the Phase 2 identity spine (#466). All backend-scoped; no feature behavior change.

- **FK index** — add `user_identities_user_id_idx` on `user_identities(user_id)`. A foreign key with no supporting index makes every parent-row `DELETE` do a sequential scan of the child and blocks concurrent child writes during the referential check. Schema (`02_user_identities.sql`), Atlas migration (`20260725114029_...`), and `atlas.sum` updated together.
- **Runtime-role integration test** — the identity store is now exercised once through the least-privilege `peppercheck_app` role via `APP_DATABASE_URL`, so role separation is verified end to end (INSERT/SELECT/DELETE under the runtime role) instead of only asserted at the DDL level. `ci-backend.yml` and `make test` supply `APP_DATABASE_URL`; `testsupport` gains `DBFromEnv` (existing `DB` unchanged).
- **Token-revocation note** — document that `Verify()` intentionally does not check token revocation or a disabled Firebase user (`VerifyIDToken` validates signature + expiry only), and track the immediate-lockout decision in the operations follow-up before the first privileged endpoint ships.

## Verification

- `make test` — all packages green, including `internal/identity` running the new `TestStoreWorksWithRuntimeRole` under `APP_DATABASE_URL`.
- Atlas migration applies cleanly (`atlas migrate apply` runs as part of `make test`); schema / migration / `atlas.sum` consistent.

## Notes

- Pre-existing uncommitted `evidence_controller.g.dart` and untracked working-tree files (`.agents/`, other-phase plan/spec docs, `supabase/snippets/*.sql`) are intentionally **not** included in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UL9BwCujaqw61pYFCv2AiD