### PR TITLE
fix(flutter): scope cleartext ATS to dev flavor and normalize token-provider errors

### DIFF
--- a/docs/operations/phase2-auth-operator-checklist.md
+++ b/docs/operations/phase2-auth-operator-checklist.md
@@ -1,11 +1,12 @@
 # Phase 2 Auth Operator/Infra Checklist
 
 This is a per-environment operator runbook for the Phase 2 identity work
-(Firebase-authenticated `/api/v1/me`, Flutter Google/Apple sign-in). Complete
-the steps for an environment (dev / staging / production) **before** that
-environment's release ships the corresponding client or backend code. Steps
-are grouped by environment where the action is per-Firebase-project, and
-called out once where the action is shared or per-platform.
+(Firebase-authenticated `/api/v1/me`, Flutter Google sign-in on iOS/Android,
+and Apple sign-in on iOS). Complete the steps for an environment (dev /
+staging / production) **before** that environment's release ships the
+corresponding client or backend code. Steps are grouped by environment where
+the action is per-Firebase-project, and called out once where the action is
+shared or per-platform.
 
 This app uses only Google and Apple sign-in (no phone/SMS), which is free at
 PepperCheck's scale; there is no billing change required for Phase 2.
@@ -58,23 +59,26 @@ registered against the matching Firebase project. Each flavor (`dev`,
 
 *Ties to: Apple e2e (P2-6)*
 
-- [ ] Dev: enable Apple provider — Firebase Console → Authentication →
-      Sign-in method; register the Services ID and Sign in with Apple key
-      from step 5
-- [ ] Staging: enable Apple provider; register Services ID + key
-- [ ] Production: enable Apple provider; register Services ID + key
+Phase 2 uses Firebase's native iOS provider flow:
+`FirebaseAuth.signInWithProvider(AppleAuthProvider())`. A Services ID and
+OAuth code-flow key are not required for this native flow. They are needed
+only if Apple sign-in later expands to web/Android, or for Apple token
+revocation in Phase 6.
 
-## 5. Apple Developer — capability, Services ID, and key
+- [ ] Dev: enable Apple provider — Firebase Console → Authentication →
+      Sign-in method; verify the native iOS flow
+- [ ] Staging: enable Apple provider and verify the native iOS flow
+- [ ] Production: enable Apple provider and verify the native iOS flow
+
+## 5. Apple Developer — iOS capability
 
 *Ties to: Apple e2e (P2-6)*
 
-- [ ] Dev: add the "Sign in with Apple" capability to the dev App ID; create
-      (or reuse) the Services ID and the Sign in with Apple key used as input
-      to step 4
-- [ ] Staging: add the capability to the staging App ID; create the Services
-      ID and key
-- [ ] Production: add the capability to the production App ID; create the
-      Services ID and key
+- [ ] Dev: add the "Sign in with Apple" capability to the dev App ID
+- [ ] Staging: add the capability to the staging App ID
+- [ ] Production: add the capability to the production App ID
+- [ ] Create a Services ID and Sign in with Apple key only when implementing
+      web/Android Apple sign-in or Phase 6 token revocation
 
 ## 6. Xcode — Sign in with Apple capability per flavor scheme
 
@@ -100,21 +104,21 @@ Deployed environments must inject the real per-project ID.
 (Dev/local may keep the default unless testing against a real Firebase
 project locally.)
 
-## 8. End-to-end smoke test (per platform, real device)
+## 8. End-to-end smoke test (real devices)
 
 *Ties to: Flutter Google + Apple e2e (P2-5, P2-6); run once all prior steps
 for the environment are complete*
 
 - [ ] Android, real device: sign in with Google using a verified email;
       confirm a single internal user via `GET /api/v1/me`
-- [ ] Android, real device: sign in with Apple using the **same** verified
-      email; confirm `/api/v1/me` returns the **same** internal `user.id` as
-      the Google sign-in (one Firebase UID → one internal user)
-- [ ] iOS, real device: repeat the same Google → Apple, same-email
-      convergence check
-- [ ] Either platform: sign in with Apple using "Hide My Email" (a relay
+- [ ] iOS, real device: sign in with Google, then Apple using the **same**
+      verified email; confirm `/api/v1/me` returns the **same** internal
+      `user.id` (one Firebase UID → one internal user)
+- [ ] iOS, real device: sign in with Apple using "Hide My Email" (a relay
       address) and confirm it resolves to a **separate** internal user, not
       merged with the verified-email account above
+- [ ] Confirm the Apple button is not offered on Android; Android Apple
+      sign-in is outside the Phase 2 scope
 - [ ] Repeat this smoke test once per environment before that environment's
       release (dev now; staging and production before their respective
       releases)

--- a/docs/superpowers/specs/2026-07-24-phase2-identity-client-boundary-design.md
+++ b/docs/superpowers/specs/2026-07-24-phase2-identity-client-boundary-design.md
@@ -11,6 +11,12 @@
 > Each phase is its own `spec → plan → implementation` cycle; this document
 > covers **Phase 2 only**. The implementation plan is produced separately by the
 > writing-plans workflow and is not committed.
+>
+> **Implementation outcome (2026-07-25):** Google shipped on iOS and Android.
+> Apple shipped on iOS only, using Firebase's native
+> `signInWithProvider(AppleAuthProvider())` flow. The originally designed
+> manual nonce/credential/link flow was removed after real-device verification.
+> See `docs/operations/firebase-apple-signin-method.md`.
 
 ---
 
@@ -58,7 +64,7 @@ data features rely on (Supabase RLS `auth.uid()`):
 
 **After Phase 2 the integration-branch app:**
 - ✅ builds and launches (clean clone),
-- ✅ signs in with **Google and Apple** via Firebase,
+- ✅ signs in with **Google on iOS/Android** and **Apple on iOS** via Firebase,
 - ✅ resolves the internal user through `GET /api/v1/me`,
 - ✅ signs out,
 - ⏸ data-heavy features (task/profile/evidence/judgement/point/…) are **not**
@@ -376,22 +382,16 @@ safe.
 
 ## 7. Apple Sign-In & operator/infra checklist (PR P2-6)
 
-**Flutter code:**
-- Add `sign_in_with_apple`. Generate a secure nonce (random + SHA-256) →
-  `OAuthProvider('apple').credential(idToken:, rawNonce:)` →
-  `signInWithCredential`.
-- Handle `account-exists-with-different-credential` (Workspace/custom domains
-  that Firebase does not auto-link): catch → **show an explicit consent prompt**
-  ("An account with this email already exists — link Apple to it?") → **only on
-  confirmation** re-authenticate with the existing provider and
-  `linkWithCredential`. **Cancel path:** if the user declines, abort the link,
-  leave the accounts separate (no silent merge), surface a clear message, and
-  return to sign-in. Never merge users on an email-string match alone. Firebase's
-  Apple guidance requires explicit user consent before linking. Both the confirm
-  and cancel paths are covered by tests.
-- **Apple Hide My Email:** relay addresses differ from the real email; such
-  accounts stay separate unless explicitly linked, and revealing the real email
-  later does not retroactively merge.
+**Implemented Flutter code (supersedes the original manual credential/link
+design):**
+- Offer Apple sign-in on iOS only. Android uses Google; adding Apple there would
+  require a Services ID and web OAuth callback flow.
+- Call `FirebaseAuth.signInWithProvider(AppleAuthProvider())`; Firebase drives
+  the native Apple UI and nonce handling.
+- Same verified-email convergence relies on Firebase's one-account-per-email
+  setting. There is no manual email-string merge or consent/link flow.
+- **Apple Hide My Email:** relay addresses differ from the real email, so those
+  accounts remain separate.
 
 **Operator / infrastructure runbook** (per environment — dev / staging /
 production Firebase projects). Add the release-checklist Pending entries **when
@@ -410,17 +410,18 @@ environment's release: the `FIREBASE_PROJECT_ID` injection (step 7) with
 3. **Android SHA keys:** register the SHA-1 **and** SHA-256 of the signing key
    for **each flavor** (dev debug keystore, staging, production) in the matching
    Firebase project — Google sign-in fails without them.
-4. **Firebase — Apple provider:** enable Apple in each project and register the
-   Services ID + Sign in with Apple key.
+4. **Firebase — Apple provider:** enable Apple in each project. The Phase 2
+   native iOS flow does not require a Services ID or OAuth code-flow key.
 5. **Apple Developer:** add the "Sign in with Apple" capability to each App ID;
-   create the Services ID and the Sign in with Apple key used in step 4.
+   create a Services ID/key only for a future web/Android flow or Phase 6 token
+   revocation.
 6. **Xcode:** add the Sign in with Apple capability to the Runner target per
    flavor scheme.
 7. **`FIREBASE_PROJECT_ID` injection:** set the real per-env project ID for the
    deployed api (staging/production), replacing the dummy local default (§5.5).
-8. **E2E smoke (per platform, real device):** verify Google sign-in and Apple
-   sign-in for the **same verified email** resolve to the **same internal user**
-   (one Firebase UID → one `/api/v1/me` `user.id`), and that an Apple
+8. **E2E smoke (real devices):** verify Google on Android; verify Google and
+   Apple on iOS for the **same verified email** resolve to the **same internal
+   user** (one Firebase UID → one `/api/v1/me` `user.id`); verify an Apple
    Hide-My-Email relay stays a **separate** account.
 
 ---
@@ -463,11 +464,10 @@ Phase 1 CI.)
 
 **CI gates:** Go — gofmt, `go vet`, unit, Postgres integration, race, Atlas
 fmt/lint, apply-to-empty-DB, schema-drift, image build. Flutter — dart format,
-`flutter analyze`, tests, **architecture import checks** (`firebase_auth` only
-in `features/auth`; Dio construction only in `core/network`), flavored debug
-build (`lib/main_dev.dart`). Per project convention, each Flutter PR runs
-`flutter build` only; a single emulator pass runs at the end of Phase 2 on the
-integration branch.
+`flutter analyze`, tests, and **architecture import checks** (`firebase_auth`
+only in `features/auth`; Dio construction only in `core/network`). To keep PR
+feedback time bounded, the flavored debug build (`lib/main_dev.dart`) and
+real-device pass run once before the phase merge rather than in every PR CI run.
 
 ---
 
@@ -475,8 +475,9 @@ integration branch.
 
 Derived from the Phase 0 baseline §6(a) auth characterization:
 
-- **`account-exists-with-different-credential`** → re-auth + `linkWithCredential`
-  (§7), never a silent second account.
+- **Provider convergence** → Firebase's one-account-per-email setting links
+  trusted verified providers. A non-auto-link error is surfaced; the client
+  never merges accounts from an email string.
 - **Partial sign-out failure** → each leg independent and idempotent; do not
   inherit the current `Future.wait` ambiguity.
 - **Apple Hide My Email churn** → no retroactive merge.
@@ -506,7 +507,7 @@ each (§3). Go first (verifiable via curl + token), then Flutter, then Apple.
 | P2-3 | Go | `identity` feature (`domain`/`service`/`store`/`handler`); `GET /api/v1/me`; authz-isolation + API integration + db/tests assert-SQL constraint tests. |
 | P2-4 | Flutter | `core/network` `ApiClient` (base URL, token/request-id interceptors, timeouts, error mapping); add `firebase_auth`; base-URL config. |
 | P2-5 | Flutter | `features/auth` Firebase adapter (**Google**); app-level current-user contract exposing the internal UUID; remove Supabase from the auth path → **Google end-to-end**. |
-| P2-6 | Flutter + infra | Apple Sign-In (`sign_in_with_apple`, nonce, `linkWithCredential`); operator/infra checklist (§7) → **Apple end-to-end**. Single emulator verification pass. |
+| P2-6 | Flutter + infra | iOS Apple Sign-In via `signInWithProvider(AppleAuthProvider())`; operator/infra checklist (§7) → **Apple end-to-end on iOS**. Real-device verification pass. |
 
 ---
 
@@ -524,11 +525,11 @@ each (§3). Go first (verifiable via curl + token), then Flutter, then Apple.
 
 ## 12. Done criteria (Phase 2)
 
-- [ ] A clean clone builds and runs; sign-in (Google **and** Apple), `/api/v1/me`,
-      and sign-out work on the integration branch.
-- [ ] Both providers create/restore the **same internal user** (same verified
-      email → one account via Firebase linking; Apple Hide-My-Email stays
-      separate unless explicitly linked); no duplicate users.
+- [ ] A clean clone builds and runs; Google sign-in on iOS/Android, Apple
+      sign-in on iOS, `/api/v1/me`, and sign-out work on the integration branch.
+- [ ] Google and Apple create/restore the **same internal user** on iOS when
+      they use the same verified email and Firebase auto-links them; Apple
+      Hide-My-Email stays separate; no duplicate users.
 - [ ] The Go API verifies the Firebase ID token and resolves it to the internal
       UUID; domain/service packages import no Firebase types.
 - [ ] User-isolation authz test passes (a token for one user cannot read

--- a/peppercheck_flutter/android/app/src/dev/AndroidManifest.xml
+++ b/peppercheck_flutter/android/app/src/dev/AndroidManifest.xml
@@ -1,0 +1,4 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <application
+        android:networkSecurityConfig="@xml/network_security_config" />
+</manifest>

--- a/peppercheck_flutter/android/app/src/dev/res/xml/network_security_config.xml
+++ b/peppercheck_flutter/android/app/src/dev/res/xml/network_security_config.xml
@@ -1,11 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!--
-  Dev-only cleartext allowlist: the dev flavor talks to the Go API through
-  Caddy on the loopback host (10.0.2.2 for the Android emulator). All other
-  traffic remains HTTPS-only (cleartextTrafficPermitted defaults to false on
-  API 28+). Staging/production build against HTTPS endpoints and never hit
-  this allowlist.
--->
+<!-- Dev-only cleartext allowlist for the local Go API through Caddy. -->
 <network-security-config>
     <domain-config cleartextTrafficPermitted="true">
         <domain includeSubdomains="false">10.0.2.2</domain>

--- a/peppercheck_flutter/android/app/src/main/AndroidManifest.xml
+++ b/peppercheck_flutter/android/app/src/main/AndroidManifest.xml
@@ -2,8 +2,7 @@
     <application
         android:label="PepperCheck"
         android:name="${applicationName}"
-        android:icon="@mipmap/ic_launcher"
-        android:networkSecurityConfig="@xml/network_security_config">
+        android:icon="@mipmap/ic_launcher">
         <activity
             android:name=".MainActivity"
             android:exported="true"

--- a/peppercheck_flutter/ios/Flutter/Dev.xcconfig
+++ b/peppercheck_flutter/ios/Flutter/Dev.xcconfig
@@ -8,6 +8,10 @@ APP_DISPLAY_NAME = PepperCheck Dev
 // Firebase plist selector (consumed by the Run Script Phase)
 FIREBASE_PLIST_FLAVOR = Dev
 
+// Allow the shared Info.plist to include local-networking ATS only for dev.
+INFOPLIST_PREPROCESS = YES
+INFOPLIST_PREPROCESSOR_DEFINITIONS = $(inherited) PEPPERCHECK_DEV_BUILD=1
+
 // Google Sign-In OAuth client (sourced from gitignored secrets file)
 #include? "Secrets/Dev.secrets.xcconfig"
 

--- a/peppercheck_flutter/ios/Flutter/Production.xcconfig
+++ b/peppercheck_flutter/ios/Flutter/Production.xcconfig
@@ -6,6 +6,10 @@ APP_DISPLAY_NAME = PepperCheck
 
 FIREBASE_PLIST_FLAVOR = Production
 
+// Preprocess the shared Info.plist without the dev-only local-networking ATS.
+INFOPLIST_PREPROCESS = YES
+INFOPLIST_PREPROCESSOR_DEFINITIONS = $(inherited) PEPPERCHECK_DEV_BUILD=0
+
 #include? "Secrets/Production.secrets.xcconfig"
 
 // Sign in with Apple capability (shared entitlements, all build configs)

--- a/peppercheck_flutter/ios/Flutter/Staging.xcconfig
+++ b/peppercheck_flutter/ios/Flutter/Staging.xcconfig
@@ -5,6 +5,10 @@ APP_DISPLAY_NAME = PepperCheck Staging
 
 FIREBASE_PLIST_FLAVOR = Staging
 
+// Preprocess the shared Info.plist without the dev-only local-networking ATS.
+INFOPLIST_PREPROCESS = YES
+INFOPLIST_PREPROCESSOR_DEFINITIONS = $(inherited) PEPPERCHECK_DEV_BUILD=0
+
 #include? "Secrets/Staging.secrets.xcconfig"
 
 // Sign in with Apple capability (shared entitlements, all build configs)

--- a/peppercheck_flutter/ios/Runner/Info.plist
+++ b/peppercheck_flutter/ios/Runner/Info.plist
@@ -45,14 +45,14 @@
 	<true/>
 	<key>UIApplicationSupportsIndirectInputEvents</key>
 	<true/>
+#if PEPPERCHECK_DEV_BUILD
 	<key>NSAppTransportSecurity</key>
 	<dict>
-		<!-- Dev-only: the iOS simulator reaches the Go API via Caddy on
-		     127.0.0.1. NSAllowsLocalNetworking permits cleartext to
-		     loopback/.local hosts without opening arbitrary loads. -->
+		<!-- The iOS simulator reaches the dev Go API through local Caddy. -->
 		<key>NSAllowsLocalNetworking</key>
 		<true/>
 	</dict>
+#endif
 	<key>GIDClientID</key>
 	<string>$(GID_CLIENT_ID)</string>
 	<key>CFBundleURLTypes</key>

--- a/peppercheck_flutter/lib/core/network/api_client.dart
+++ b/peppercheck_flutter/lib/core/network/api_client.dart
@@ -91,7 +91,15 @@ class ApiClient {
   }) async {
     final headers = <String, dynamic>{_requestIdHeader: _newRequestId()};
     if (authenticated) {
-      final token = await _idTokenProvider(forceRefresh: forceRefresh);
+      final String? token;
+      try {
+        token = await _idTokenProvider(forceRefresh: forceRefresh);
+      } catch (_, stackTrace) {
+        Error.throwWithStackTrace(
+          const ApiException.tokenUnavailable(),
+          stackTrace,
+        );
+      }
       if (token != null) headers['Authorization'] = 'Bearer $token';
     }
     return _dio.get<dynamic>(path, options: Options(headers: headers));

--- a/peppercheck_flutter/lib/core/network/api_exception.dart
+++ b/peppercheck_flutter/lib/core/network/api_exception.dart
@@ -23,8 +23,16 @@ class ApiException implements Exception {
       requestId = null,
       statusCode = null;
 
+  /// The authentication provider could not supply an ID token.
+  const ApiException.tokenUnavailable()
+    : code = 'token_unavailable',
+      message = 'authentication token unavailable',
+      requestId = null,
+      statusCode = null;
+
   /// Stable machine-readable code (server envelope `error.code`, or
-  /// `network`/`timeout`/`unknown` for client-side failures).
+  /// `network`/`timeout`/`token_unavailable`/`unknown` for client-side
+  /// failures).
   final String code;
 
   /// Human-readable detail. Not for control flow — branch on [code].

--- a/peppercheck_flutter/test/core/network/api_client_test.dart
+++ b/peppercheck_flutter/test/core/network/api_client_test.dart
@@ -162,4 +162,24 @@ void main() {
       throwsA(isA<ApiException>().having((e) => e.code, 'code', 'timeout')),
     );
   });
+
+  test('maps ID-token provider failures to ApiException', () async {
+    final adapter = _FakeAdapter((o, _) => _json(200, {'ok': true}));
+    final client = _client(
+      adapter,
+      tokens: ({required bool forceRefresh}) async {
+        throw Exception('provider-specific failure');
+      },
+    );
+
+    await expectLater(
+      () => client.getJson('/api/v1/me'),
+      throwsA(
+        isA<ApiException>()
+            .having((e) => e.code, 'code', 'token_unavailable')
+            .having((e) => e.statusCode, 'statusCode', isNull),
+      ),
+    );
+    expect(adapter.requests, isEmpty);
+  });
 }

--- a/peppercheck_flutter/test/core/network/api_exception_test.dart
+++ b/peppercheck_flutter/test/core/network/api_exception_test.dart
@@ -18,5 +18,6 @@ void main() {
   test('network and timeout named constructors set their codes', () {
     expect(const ApiException.network().code, 'network');
     expect(const ApiException.timeout().code, 'timeout');
+    expect(const ApiException.tokenUnavailable().code, 'token_unavailable');
   });
 }


### PR DESCRIPTION
Phase 2 client-boundary follow-ups from a codex review. Three independent, low-risk fixes plus doc alignment.

## Changes

### 1. Scope the cleartext/local-networking exception to the `dev` flavor
Staging and production now ship HTTPS-only; only the local dev build can reach the Go API via Caddy on loopback.
- **Android:** moved `network_security_config.xml` from `src/main/res/xml` to `src/dev/res/xml` and reference it from a `dev`-only `AndroidManifest.xml` overlay. The main manifest no longer declares `networkSecurityConfig`.
- **iOS:** gated the `NSAllowsLocalNetworking` ATS dict behind `#if PEPPERCHECK_DEV_BUILD`, enabling `INFOPLIST_PREPROCESS` per flavor xcconfig (`Dev=1`, `Staging`/`Production=0`).

### 2. Normalize ID-token provider failures at the `ApiClient` boundary
Exceptions thrown by the ID-token provider are now converted to a stable `ApiException.tokenUnavailable` (code `token_unavailable`) instead of leaking provider-specific exceptions to callers. Added unit tests (provider throw → `token_unavailable`, no request sent).

### 3. Align Phase 2 spec + operator checklist with shipped scope
- Google on iOS/Android, Apple on **iOS only** via `signInWithProvider(AppleAuthProvider())` (native flow — no manual nonce/credential/link).
- A Services ID / OAuth code-flow key is only needed for a future web/Android Apple flow or Phase 6 token revocation.
- Noted that the flavored build + real-device pass run once before the phase merge, not in every PR CI run.

## Verification
- `flutter analyze lib/core/network test/core/network` — clean
- `flutter test test/core/network/api_client_test.dart test/core/network/api_exception_test.dart` — 9/9 pass
- Android XML / iOS plist preprocessing reviewed; `git diff --check` clean

## Notes
- Excluded from this PR: an unrelated `evidence_controller.g.dart` codegen-hash change already present in the working tree, and the gitignored `dev/google-services.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)