### PR TITLE
chore(dev): add Git worktree helpers

### DIFF
--- a/backend/Makefile
+++ b/backend/Makefile
@@ -7,6 +7,11 @@
 
 .PHONY: help up down down-v reset logs ps backup test fmt vet
 
+# Override these when running backend tests from more than one worktree.
+# scripts/worktree/dev.sh supplies isolated values automatically.
+TEST_CONTAINER_NAME ?= pc-maketest
+TEST_POSTGRES_PORT ?= 55432
+
 help: ## Show available targets
 	grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN{FS=":.*?## "}{printf "  %-9s %s\n", $$1, $$2}'
 
@@ -32,7 +37,7 @@ backup: ## Start the opt-in backup profile (needs AGE_RECIPIENT in .env)
 	docker compose --profile backup up -d --build backup
 
 test: ## Run Go tests incl. DB integration on a throwaway Postgres (needs host atlas v1.2.0)
-	@set -e; name=pc-maketest; port=55432; \
+	@set -e; name="$(TEST_CONTAINER_NAME)"; port="$(TEST_POSTGRES_PORT)"; \
 	docker rm -f $$name >/dev/null 2>&1 || true; \
 	trap 'docker rm -f $$name >/dev/null 2>&1 || true' EXIT; \
 	docker run --rm -d --name $$name -e POSTGRES_PASSWORD=postgres -e POSTGRES_DB=peppercheck -e POSTGRES_MIGRATOR_PASSWORD=m -e POSTGRES_APP_PASSWORD=a -e POSTGRES_BACKUP_PASSWORD=b -v "$$PWD/deploy/postgres/init:/docker-entrypoint-initdb.d:ro" -p 127.0.0.1:$$port:5432 postgres:17 -c archive_mode=off >/dev/null; \

--- a/docs/README.md
+++ b/docs/README.md
@@ -59,3 +59,7 @@ docs/
 - 図表やコード例を積極的に使用
 - 更新日時を明記
 - 関連ドキュメントへのリンクを適切に設置 
+
+# Development tooling
+
+- [Parallel local development with Git worktrees](development/git-worktrees.md)

--- a/docs/development/git-worktrees.md
+++ b/docs/development/git-worktrees.md
@@ -1,0 +1,161 @@
+# Parallel local development with Git worktrees
+
+Use a separate Git worktree for each agent or feature that needs to build or
+run locally. The helper scripts keep local configuration, Docker Compose
+resources, host ports, and Flutter build output isolated per worktree.
+
+## Bootstrap a worktree
+
+Create the worktree using your normal Git or agent workflow, then run this
+command from its repository root:
+
+```sh
+scripts/worktree/bootstrap.sh
+```
+
+The script copies only this reviewed list of machine-local configuration from
+the primary worktree: backend local configuration, all Flutter environment
+assets, Android Firebase configs, iOS Firebase plists, and iOS signing
+xcconfigs. It does not copy build directories, Pods, `.dart_tool`, caches, or
+arbitrary ignored files. It then runs `flutter pub get` in the target worktree.
+
+The primary worktree is the first entry reported by `git worktree list`. To use
+another source explicitly, pass `--source /absolute/path`. Use
+`--skip-pub-get` only when dependency resolution should be deferred.
+
+The copied files can contain provider configuration or signing identifiers.
+The bootstrap script verifies that every destination remains ignored by Git;
+they are copied only on the local machine and must never be committed.
+
+## Run an isolated backend
+
+```sh
+scripts/worktree/dev.sh backend-up
+scripts/worktree/dev.sh settings
+scripts/worktree/dev.sh status
+scripts/worktree/dev.sh backend-down
+```
+
+The script derives a Docker Compose project name from the full worktree path.
+Before starting a backend or test database, it probes ports beginning with a
+stable path-derived candidate and selects the first fully available set. The
+backend selection is stored in the worktree's Git administrative directory, so
+later lifecycle commands use the same stack. Each worktree therefore receives
+its own containers, volumes, network, Caddy HTTP/HTTPS ports, Postgres port,
+and temporary Postgres instance for `backend-test`.
+
+Override the defaults when necessary:
+
+```sh
+scripts/worktree/dev.sh \
+  --instance task-editor \
+  --caddy-port 18081 \
+  --https-port 19081 \
+  --postgres-port 15433 \
+  --test-postgres-port 16433 \
+  backend-up
+```
+
+Use the same flags for later `backend-down`, `status`, and `backend-logs`
+calls. `backend-test` passes an isolated temporary container name and port to
+the backend Makefile:
+
+```sh
+scripts/worktree/dev.sh backend-test
+```
+
+## Run Flutter against that backend
+
+First obtain a distinct simulator or emulator for each concurrently running
+worktree. A dev flavor has one application identifier, so installing two
+builds of that flavor onto the same device replaces the prior build.
+
+```sh
+flutter devices
+scripts/worktree/dev.sh flutter-run --device <device-id>
+```
+
+`flutter-run` passes the worktree's Caddy HTTP port as `DEV_API_PORT`; the
+Flutter app therefore reaches the matching isolated backend. The script runs
+the dev flavor only. Use the ordinary flavor commands for staging or production
+validation.
+
+Flutter build output, `.dart_tool`, iOS Pods, and Gradle intermediate files
+are already worktree-local. Shared SDK caches may serialize initial dependency
+downloads, but do not share the generated application outputs.
+
+## Clean up a worktree
+
+Cleanup has two levels: pausing a worktree you will return to, and fully
+removing one you are done with. The primary worktree's stack is a separate
+Docker Compose project, so none of these commands affect it.
+
+### Stop the Flutter session
+
+How you stop the app depends on how `flutter run` is attached to a terminal.
+
+- **Interactive terminal (normal human use).** When you started the app with
+  `scripts/worktree/dev.sh flutter-run` in your own terminal, press `q` in that
+  terminal to quit: it terminates the app on the device and detaches the
+  tooling. `r` (hot reload), `R` (hot restart), and `d` (detach, leaving the app
+  running) work there too.
+- **Backgrounded or killed run (non-interactive, e.g. an agent).** If the
+  `flutter run` process is killed instead of quit with `q`, the tooling detaches
+  without a clean shutdown, and the two platforms differ:
+  - Android keeps the app running, because it was launched as an ordinary
+    process the tooling only attached to. Stop it explicitly:
+    `adb -s <emulator-id> shell am force-stop dev.cloveclove.peppercheck.dev`.
+  - The iOS simulator app is launched under the debugger, so it exits on detach
+    on its own. Terminate it explicitly only if needed:
+    `xcrun simctl terminate <simulator-udid> dev.cloveclove.peppercheck.dev`.
+
+  (`dev.cloveclove.peppercheck.dev` is the dev flavor's application/bundle id on
+  both platforms.)
+
+### Stop the backend (keep the worktree)
+
+Run from the worktree:
+
+```sh
+scripts/worktree/dev.sh backend-down
+```
+
+This stops and removes the worktree's containers and network but keeps its
+volumes (Postgres data, the local WAL archive, and Caddy state), so the next
+`backend-up` resumes with the same data.
+
+### Fully remove a worktree
+
+When you are finished with a worktree, tear the backend down together with its
+volumes, then remove the worktree itself. Run from the worktree:
+
+```sh
+scripts/worktree/dev.sh backend-down --volumes
+```
+
+`--volumes` (short: `-v`) removes the worktree's containers, network, and
+volumes (Postgres data, the local WAL archive, and Caddy state) in one step —
+Docker resources live outside the worktree, so removing the checkout alone would
+leave them orphaned. Then remove the worktree and, if it was a throwaway branch,
+delete it. Run these from the primary worktree (or any directory outside the
+target):
+
+```sh
+git worktree remove <path-to-worktree> --force
+git branch -D <branch>   # only if the branch is no longer needed
+```
+
+`--force` is required because bootstrap copies machine-local configuration and
+build output into the worktree, so Git treats it as dirty. Removing the worktree
+deletes those local copies; the shared SDK caches are untouched.
+
+If you removed the worktree before running `backend-down --volumes`, the
+containers and volumes are orphaned but still carry the `pc_` name prefix, so
+you can clean them up manually:
+
+```sh
+docker ps -a --filter "name=pc_" --format '{{.Names}}'   # find leftover containers
+docker volume ls --filter "name=pc_"                     # find leftover volumes
+docker rm -f <container>...
+docker volume rm <volume>...
+```

--- a/scripts/worktree/bootstrap.sh
+++ b/scripts/worktree/bootstrap.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# Bootstrap a Git worktree with the local configuration required to build and
+# run PepperCheck. Only the reviewed paths below are copied; build artifacts,
+# caches, and arbitrary ignored files are intentionally excluded.
+#
+# Run from the target worktree:
+#   scripts/worktree/bootstrap.sh
+#   scripts/worktree/bootstrap.sh --source /path/to/canonical/worktree
+#   scripts/worktree/bootstrap.sh --skip-pub-get
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage:
+  scripts/worktree/bootstrap.sh
+  scripts/worktree/bootstrap.sh --source /path/to/canonical/worktree
+  scripts/worktree/bootstrap.sh --skip-pub-get
+EOF
+}
+
+repo_root="$(git rev-parse --show-toplevel)"
+source_root=""
+run_pub_get=1
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --source)
+      source_root="${2:?--source requires a path}"
+      shift
+      ;;
+    --skip-pub-get)
+      run_pub_get=0
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+  shift
+done
+
+if [ -z "$source_root" ]; then
+  source_root="$(git worktree list --porcelain | awk '/^worktree / { print substr($0, 10); exit }')"
+fi
+
+source_root="$(git -C "$source_root" rev-parse --show-toplevel)"
+if [ "$source_root" = "$repo_root" ]; then
+  echo "source and target worktrees must differ; pass --source explicitly if needed" >&2
+  exit 2
+fi
+
+# Keep this list intentionally explicit. These are source-controlled path names
+# but their contents are machine-local provider or signing configuration.
+local_files=(
+  backend/.env
+  peppercheck_flutter/assets/env/.env.dev
+  peppercheck_flutter/assets/env/.env.staging
+  peppercheck_flutter/assets/env/.env.production
+  peppercheck_flutter/android/app/src/dev/google-services.json
+  peppercheck_flutter/android/app/src/staging/google-services.json
+  peppercheck_flutter/android/app/src/production/google-services.json
+  peppercheck_flutter/ios/Runner/Firebase/GoogleService-Info-Dev.plist
+  peppercheck_flutter/ios/Runner/Firebase/GoogleService-Info-Staging.plist
+  peppercheck_flutter/ios/Runner/Firebase/GoogleService-Info-Production.plist
+  peppercheck_flutter/ios/Flutter/Secrets/Dev.secrets.xcconfig
+  peppercheck_flutter/ios/Flutter/Secrets/Staging.secrets.xcconfig
+  peppercheck_flutter/ios/Flutter/Secrets/Production.secrets.xcconfig
+)
+
+missing=0
+for relative_path in "${local_files[@]}"; do
+  if [ ! -f "$source_root/$relative_path" ]; then
+    echo "missing required local configuration in source worktree: $relative_path" >&2
+    missing=1
+  fi
+  if ! git -C "$repo_root" check-ignore -q -- "$relative_path"; then
+    echo "refusing to copy to a path that is not ignored: $relative_path" >&2
+    missing=1
+  fi
+done
+[ "$missing" -eq 0 ] || exit 1
+
+umask 077
+for relative_path in "${local_files[@]}"; do
+  mkdir -p "$(dirname "$repo_root/$relative_path")"
+  cp -p "$source_root/$relative_path" "$repo_root/$relative_path"
+  chmod 600 "$repo_root/$relative_path"
+  echo "copied $relative_path"
+done
+
+if [ "$run_pub_get" -eq 1 ]; then
+  (
+    cd "$repo_root/peppercheck_flutter"
+    flutter pub get
+  )
+fi
+
+echo "worktree bootstrap complete"

--- a/scripts/worktree/dev.sh
+++ b/scripts/worktree/dev.sh
@@ -1,0 +1,317 @@
+#!/usr/bin/env bash
+# Run an isolated local stack for the current Git worktree.
+#
+# Usage:
+#   scripts/worktree/dev.sh backend-up
+#   scripts/worktree/dev.sh flutter-run --device <device-id>
+#   scripts/worktree/dev.sh backend-test
+#   scripts/worktree/dev.sh settings
+#   scripts/worktree/dev.sh status
+#
+# The optional --instance and port flags make the same worktree identity
+# repeatable. Defaults are derived from its absolute path.
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage:
+  scripts/worktree/dev.sh backend-up
+  scripts/worktree/dev.sh backend-down [--volumes]
+  scripts/worktree/dev.sh flutter-run --device <device-id>
+  scripts/worktree/dev.sh backend-test
+  scripts/worktree/dev.sh settings
+  scripts/worktree/dev.sh status
+
+  backend-down stops the stack but keeps its volumes so a later backend-up
+  resumes with the same data. Add --volumes (-v) to also remove the volumes
+  (Postgres data, the local WAL archive, and Caddy state) for a full teardown.
+EOF
+}
+
+repo_root="$(git rev-parse --show-toplevel)"
+instance=""
+caddy_port=""
+https_port=""
+postgres_port=""
+test_postgres_port=""
+device_id=""
+caddy_port_explicit=0
+https_port_explicit=0
+postgres_port_explicit=0
+test_postgres_port_explicit=0
+remove_volumes=0
+command=""
+
+# Options and the command may appear in any order, so the documented
+# `dev.sh flutter-run --device <id>` form works as well as options-first.
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --instance)
+      instance="${2:?--instance requires a value}"
+      shift
+      ;;
+    --caddy-port)
+      caddy_port="${2:?--caddy-port requires a value}"
+      caddy_port_explicit=1
+      shift
+      ;;
+    --https-port)
+      https_port="${2:?--https-port requires a value}"
+      https_port_explicit=1
+      shift
+      ;;
+    --postgres-port)
+      postgres_port="${2:?--postgres-port requires a value}"
+      postgres_port_explicit=1
+      shift
+      ;;
+    --test-postgres-port)
+      test_postgres_port="${2:?--test-postgres-port requires a value}"
+      test_postgres_port_explicit=1
+      shift
+      ;;
+    --device)
+      device_id="${2:?--device requires a device ID}"
+      shift
+      ;;
+    --volumes|-v)
+      remove_volumes=1
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    --*)
+      echo "unknown option: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+    *)
+      if [ -n "$command" ]; then
+        echo "unexpected argument: $1" >&2
+        usage >&2
+        exit 2
+      fi
+      command="$1"
+      ;;
+  esac
+  shift
+done
+
+command="${command:-status}"
+
+if [ "$remove_volumes" -eq 1 ] && [ "$command" != "backend-down" ]; then
+  echo "--volumes is only valid with backend-down" >&2
+  exit 2
+fi
+
+if [ -z "$instance" ]; then
+  instance="$(basename "$repo_root")"
+fi
+instance="$(printf '%s' "$instance" | tr '[:upper:]' '[:lower:]' | tr -cs 'a-z0-9_-' '-')"
+instance="${instance#-}"
+instance="${instance%-}"
+[ -n "$instance" ] || { echo "--instance must contain a letter or digit" >&2; exit 2; }
+
+# Start probing from a stable path-derived slot. The selected backend ports are
+# persisted in this worktree's Git administrative directory, not in the work
+# tree, so later lifecycle commands use the same stack.
+worktree_hash="$(printf '%s' "$repo_root" | cksum | awk '{print $1}')"
+initial_slot="$((worktree_hash % 100))"
+state_file="$(git rev-parse --git-path peppercheck-worktree-dev.env)"
+case "$state_file" in
+  /*) ;;
+  *) state_file="$repo_root/$state_file" ;;
+esac
+compose_project="pc_${instance}_${worktree_hash}"
+test_container="pc-${instance}-${worktree_hash}-test"
+
+state_caddy_port=""
+state_https_port=""
+state_postgres_port=""
+
+load_state() {
+  [ -f "$state_file" ] || return 0
+
+  while IFS='=' read -r key value; do
+    case "$key" in
+      CADDY_HTTP_PORT) state_caddy_port="$value" ;;
+      CADDY_HTTPS_PORT) state_https_port="$value" ;;
+      POSTGRES_HOST_PORT) state_postgres_port="$value" ;;
+    esac
+  done < "$state_file"
+}
+
+is_numeric_port() {
+  case "$1" in
+    ''|*[!0-9]*) return 1 ;;
+    *) return 0 ;;
+  esac
+}
+
+require_lsof() {
+  command -v lsof >/dev/null 2>&1 || {
+    echo "lsof is required to select an available local port" >&2
+    exit 1
+  }
+}
+
+port_is_available() {
+  ! lsof -nP -iTCP:"$1" -sTCP:LISTEN -t >/dev/null 2>&1
+}
+
+backend_ports_are_available() {
+  port_is_available "$caddy_port" \
+    && port_is_available "$https_port" \
+    && port_is_available "$postgres_port"
+}
+
+select_backend_ports() {
+  require_lsof
+
+  for offset in $(seq 0 99); do
+    slot="$(((initial_slot + offset) % 100))"
+    candidate_caddy="${caddy_port:-$((18000 + slot))}"
+    candidate_https="${https_port:-$((19000 + slot))}"
+    candidate_postgres="${postgres_port:-$((15432 + slot))}"
+
+    if port_is_available "$candidate_caddy" \
+      && port_is_available "$candidate_https" \
+      && port_is_available "$candidate_postgres"; then
+      caddy_port="$candidate_caddy"
+      https_port="$candidate_https"
+      postgres_port="$candidate_postgres"
+      return 0
+    fi
+  done
+
+  echo "could not find an available Caddy HTTP/HTTPS and Postgres port set" >&2
+  exit 1
+}
+
+select_test_postgres_port() {
+  require_lsof
+
+  for offset in $(seq 0 99); do
+    slot="$(((initial_slot + offset) % 100))"
+    candidate_test_postgres="${test_postgres_port:-$((16432 + slot))}"
+    if port_is_available "$candidate_test_postgres"; then
+      test_postgres_port="$candidate_test_postgres"
+      return 0
+    fi
+  done
+
+  echo "could not find an available test Postgres port" >&2
+  exit 1
+}
+
+write_state() {
+  umask 077
+  mkdir -p "$(dirname "$state_file")"
+  cat > "$state_file" <<EOF
+CADDY_HTTP_PORT=$caddy_port
+CADDY_HTTPS_PORT=$https_port
+POSTGRES_HOST_PORT=$postgres_port
+EOF
+}
+
+stack_is_running() {
+  docker ps --filter "label=com.docker.compose.project=$compose_project" --quiet \
+    | grep -q .
+}
+
+load_state
+caddy_port="${caddy_port:-${state_caddy_port:-$((18000 + initial_slot))}}"
+https_port="${https_port:-${state_https_port:-$((19000 + initial_slot))}}"
+postgres_port="${postgres_port:-${state_postgres_port:-$((15432 + initial_slot))}}"
+test_postgres_port="${test_postgres_port:-$((16432 + initial_slot))}"
+
+for port in "$caddy_port" "$https_port" "$postgres_port" "$test_postgres_port"; do
+  is_numeric_port "$port" || { echo "port must be numeric: $port" >&2; exit 2; }
+done
+
+backend_make() {
+  COMPOSE_PROJECT_NAME="$compose_project" \
+  CADDY_HTTP_PORT="$caddy_port" \
+  CADDY_HTTPS_PORT="$https_port" \
+  POSTGRES_HOST_PORT="$postgres_port" \
+  make -C "$repo_root/backend" "$@"
+}
+
+print_settings() {
+  cat <<EOF
+worktree:        $repo_root
+compose project: $compose_project
+Caddy HTTP:      http://127.0.0.1:$caddy_port
+Caddy HTTPS:     https://127.0.0.1:$https_port
+Postgres:        127.0.0.1:$postgres_port
+test Postgres:   127.0.0.1:$test_postgres_port
+EOF
+}
+
+case "$command" in
+  backend-up)
+    if ! stack_is_running; then
+      if ! backend_ports_are_available; then
+        if { [ "$caddy_port_explicit" -eq 1 ] && ! port_is_available "$caddy_port"; } \
+          || { [ "$https_port_explicit" -eq 1 ] && ! port_is_available "$https_port"; } \
+          || { [ "$postgres_port_explicit" -eq 1 ] && ! port_is_available "$postgres_port"; }; then
+          echo "an explicitly selected backend port is already in use" >&2
+          exit 1
+        fi
+        [ "$caddy_port_explicit" -eq 1 ] || caddy_port=""
+        [ "$https_port_explicit" -eq 1 ] || https_port=""
+        [ "$postgres_port_explicit" -eq 1 ] || postgres_port=""
+        select_backend_ports
+      fi
+      write_state
+    fi
+    backend_make up
+    print_settings
+    ;;
+  backend-down)
+    if [ "$remove_volumes" -eq 1 ]; then
+      backend_make down-v
+      rm -f "$state_file"
+    else
+      backend_make down
+    fi
+    ;;
+  backend-logs)
+    backend_make logs
+    ;;
+  backend-test)
+    require_lsof
+    if ! port_is_available "$test_postgres_port"; then
+      if [ "$test_postgres_port_explicit" -eq 1 ]; then
+        echo "the explicitly selected test Postgres port is already in use" >&2
+        exit 1
+      fi
+      test_postgres_port=""
+      select_test_postgres_port
+    fi
+    make -C "$repo_root/backend" test \
+      TEST_CONTAINER_NAME="$test_container" \
+      TEST_POSTGRES_PORT="$test_postgres_port"
+    ;;
+  flutter-run)
+    [ -n "$device_id" ] || { echo "flutter-run requires --device <device-id>" >&2; exit 2; }
+    (
+      cd "$repo_root/peppercheck_flutter"
+      exec flutter run --flavor dev -t lib/main_dev.dart \
+        --dart-define="DEV_API_PORT=$caddy_port" -d "$device_id"
+    )
+    ;;
+  settings)
+    print_settings
+    ;;
+  status)
+    print_settings
+    backend_make ps
+    ;;
+  *)
+    echo "unknown command: $command" >&2
+    usage >&2
+    exit 2
+    ;;
+esac


### PR DESCRIPTION
## Summary

- add a reviewed bootstrap script for per-worktree local configuration
- isolate Docker Compose project names, ports, and temporary backend test databases by worktree
- document parallel development and cleanup workflows

## Why

Concurrent local worktrees previously shared local configuration and backend resources, causing port, container, and test-database collisions.

## Validation

- `bash -n scripts/worktree/bootstrap.sh scripts/worktree/dev.sh`
- `scripts/worktree/bootstrap.sh --help`
- `scripts/worktree/dev.sh --help`
- `scripts/worktree/dev.sh --instance worktree-check --caddy-port 18081 --https-port 19081 --postgres-port 15433 --test-postgres-port 16433 settings`
- direct pre-commit hooks for the changed paths (all non-applicable)