### PR TITLE
chore: ignore local development artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,10 @@ peppercheck_flutter/assets/i18n/_*.json
 # Backed up separately (1Password / private repo + symlink). Format and
 # maintenance policy live inside the SKILL.md file itself.
 .claude/skills/release-checklist/
+.agents/skills/release-checklist/
+
+# Python bytecode caches.
+__pycache__/
 
 # Backend local environment file (secrets/local config)
 backend/.env


### PR DESCRIPTION
## Summary

- ignore the operator-private release-checklist skill in its active `.agents` location
- ignore Python bytecode cache directories

## Why

These machine-local artifacts should not appear as untracked repository changes.

## Validation

- `git diff --check -- .gitignore`
- direct pre-commit hooks for `.gitignore` (all non-applicable)