### PR TITLE
docs: add Phase 3 and 4 design records

### DIFF
--- a/docs/superpowers/specs/2026-07-25-phase3a-profile-notification-design.md
+++ b/docs/superpowers/specs/2026-07-25-phase3a-profile-notification-design.md
@@ -1,0 +1,778 @@
+# Phase 3a — Profile & Notification-token (Design)
+
+> Status: **Design (approved in brainstorming 2026-07-25).**
+> Part of the Supabase → Go API + VPS refactor. Program strategy:
+> `docs/superpowers/specs/2026-07-22-supabase-to-go-vps-refactor-design.md`
+> (see §22 Phase 3). Phase 0 baseline:
+> `docs/superpowers/specs/2026-07-22-phase0-baseline.md`. Builds on Phase 1
+> (foundation, merged into the integration branch `refactor/go-api-vps`) and on
+> Phase 2 (identity & client boundary), which is **being implemented in parallel**
+> and not yet merged — this design targets Phase 2's contracts; Phase 3a
+> implementation lands after Phase 2 merges. Phase 2 spec:
+> `docs/superpowers/specs/2026-07-24-phase2-identity-client-boundary-design.md`.
+>
+> Each phase is its own `spec → plan → implementation` cycle; this document
+> covers **Phase 3a only**. The implementation plan is produced separately by the
+> writing-plans workflow and is not committed.
+
+---
+
+## 0. Phase 3 split — 3a vs 3b
+
+Strategy §22 lists Phase 3 ("Low-risk slices + Go web") as one phase covering
+`profile, reference data, notification-token registration, reports,
+support/account; server-rendered public/legal pages; deletion request; Stripe
+Connect return/refresh; remove obsolete web routes`. In brainstorming these were
+found to be **two independent tracks** with different runtimes, deploy targets,
+and test surfaces, so Phase 3 is split into two spec→plan→implementation cycles:
+
+- **Phase 3a (this document)** — app data slices behind the Go JSON API +
+  Flutter client: **profile** and **notification-token registration** (plus the
+  provisioning fan-out that both need).
+- **Phase 3b (separate spec)** — Go `html/template` server-rendered web:
+  public/legal pages, Stripe Connect return/refresh landing pages, the
+  provider-neutral web deletion-request resource, and retiring the obsolete
+  Next.js routes. 3b carries a new surface not present in Phase 2 (browser-side
+  auth for the authenticated web deletion page), which is the main reason to
+  separate it.
+
+### Scope decisions vs the strategy's Phase 3 grouping
+
+These are **intentional narrowings** of the strategy's Phase 3 list, recorded so
+the deviation is explicit:
+
+| Item | Strategy placed in | Phase 3a decision | Why |
+|------|--------------------|-------------------|-----|
+| **reports** | Phase 3 | → **Phase 4** | `reports.task_id` is a `NOT NULL` FK to `tasks`, `content_type` references task/evidence/judgement, and the report UI entry points live **inside** the task/evidence/judgement screens — all of which arrive in Phase 4. A reports API built in 3a would have no caller and no FK target until Phase 4. |
+| **account / deletion** | Phase 3 (request resource) | → **Phase 6** | In-app deletion is `check_account_deletable` + a multi-system saga (Firebase/RC/Stripe/R2/DB). The saga is Phase 6 and the eligibility gate is meaningless without it. "support" is a `mailto:` + external legal links (no backend) and needs no migration. |
+| **reference data** | Phase 3 | → **each consuming phase** | Operator decision: reference tables (`subscription_plans`, `matching_config`, …) are seeded by the phase that consumes them (plans/prices → Phase 5; matching config → Phase 4). Phase 3a's own features (`profile`, `notification`) need **no** reference rows — timezone is a column default, notification defaults are column defaults, and `report_reason`/etc. are Postgres `ENUM` types (DDL, not seed rows). So 3a introduces no seed mechanism. |
+| **Go web / legal / deletion-request web / Stripe Connect landing / remove Next.js** | Phase 3 | → **Phase 3b** | Different runtime & deploy target (Cloudflare → VPS/Caddy); separate spec. |
+
+**Net Phase 3a scope:** `profile` (username / timezone / avatar) + `notification`
+token registration + the **eager provisioning fan-out** both depend on.
+
+---
+
+## 1. Purpose
+
+Phase 3a migrates the first two low-risk data features off Supabase onto the Go
+API + Flutter API client, and extends the identity provisioning established in
+Phase 2 so a first-time user is fully set up on the new backend:
+
+- **`profile`** — the Go API owns the `profiles` table (username, avatar,
+  timezone); Flutter reads/writes it through `ApiClient` instead of direct
+  PostgREST. Avatar uploads go through a Go-issued **R2 presigned upload**
+  (`platform/r2`), replacing the `generate-upload-url` Edge Function's avatar
+  path.
+- **`notification` token registration** — the Go API owns `user_fcm_tokens`;
+  Flutter re-enables FCM token sync (disabled in Phase 2 P2-5) against the Go
+  API.
+- **Provisioning fan-out** — first-sighting provisioning is extended from
+  `users` + `user_identities` (Phase 2) to **also** create `profiles`
+  (auto-generated username) and `notification_settings`, atomically, matching
+  today's `handle_new_user` behavior for the tables this phase owns.
+
+This is the phase Phase 2 §5.4 anticipated: multiple authenticated endpoints now
+need the internal user, so identity resolution is **promoted into middleware**.
+
+---
+
+## 2. Decisions locked in brainstorming (2026-07-25)
+
+| # | Decision | Rationale |
+|---|----------|-----------|
+| P3a-D1 | **Scope = `profile` + `notification`-token registration + provisioning fan-out.** reports → Phase 4; account/deletion → Phase 6; reference data → consuming phases; Go web → Phase 3b (§0). | Dependency-clean, genuinely low-risk slices. reports/account/web each depend on things not present in 3a. |
+| P3a-D2 | **`users` and `profiles` stay separate tables.** `profiles` is keyed `id uuid PK REFERENCES users(id) ON DELETE CASCADE` (1:1, PK = FK, column stays named `id`). | The Supabase-era reason (can't extend `auth.users`) is gone, but the separation is good design independent of it: `identity` owns a thin, stable anchor (`users`) that Phase 4/5/6 tables FK; `profile` owns mutable, public-readable presentation data. It also makes Phase 6 deletion clean — anonymize/clear `profiles` (PII), keep the anonymized `users` anchor for referential integrity. Keeping the DB column named `id` preserves continuity with the old schema; the API/Flutter contract nonetheless drops `id` (D10). |
+| P3a-D3 | **Eager provisioning fan-out in one transaction.** First sighting creates `users` + `user_identities` + `profiles` (generated username) + `notification_settings` atomically. `user_ratings` (Phase 4-domain) and `point_wallets`/trial wallets (Phase 5) are **not** in the 3a fan-out. | Matches today's atomic `handle_new_user`; avoids "profile not yet created" states across an app that assumes `username NOT NULL` always exists. Extends the Phase 2 D4 onboarding seam as anticipated. |
+| P3a-D4 | **Promote identity resolution into auth middleware.** A middleware after Phase 2's token-verify step resolves the verified `Identity` → internal `User` (provisioning on first sight) and exposes `CurrentUser(ctx)`; handlers read the internal UUID from context. | Phase 2 §5.4 deferred this "until multiple endpoints need it." Phase 3a is that phase (profile GET/PATCH, avatar, fcm-token endpoints all need the internal UUID). Replaces RLS `auth.uid()` scoping with server-side authz. |
+| P3a-D5 | **Behavior-preserving port of `notification_settings` and `user_fcm_tokens` with deliberate constraint hardening** — no structural (shape) refactoring in 3a, but deliberate `NOT NULL` constraint hardening on always-present columns (timezone / timestamps / reminder arrays, §4.2). | Migration parity keeps behavior verifiable against the old system; shape change without a concrete need is YAGNI + added migration risk. The tightenings are `NOT NULL` only (§4.2), safe on a fresh DB. Candidates considered and rejected for now: normalizing `*_reminder_minutes int[]`, `device_type text` → enum. |
+| P3a-D6 | **Avatar upload via a new `platform/r2` presigned-upload adapter;** mint endpoint `POST /api/v1/me/avatar/request-upload-url`. Avatar stays public-domain served. | Avatar editing is a self-contained low-risk slice. Phase 4 extends `platform/r2` for private evidence + authorized downloads; 3a keeps the public-avatar path only (YAGNI on the private-download shape). The action-named endpoint says what the caller wants (request an upload URL), not "upload a URL." |
+| P3a-D7 | **`/api/v1/me` stays identity-only (Phase 2, unchanged); profile is a separate resource `/api/v1/me/profile`.** | Clean feature boundary; keeps the Phase 2 `/me` contract stable (also avoids colliding with the in-flight Phase 2 implementation). Leaves `/api/v1/users/{id}` for public other-user profiles in Phase 4 — "self = `/me/*`, others = `/users/{id}`." |
+| P3a-D8 | **Restructure the Flutter `profile` and `notification` features to the Option E layout** (`data/ domain/ application/ ui/`, `*ViewModel`, DTOs in separate files) as opportunistic refactoring while their data layer is rewritten. | Strategy §15 — improve code you're already touching. Today they use `presentation/` + `*Controller`, not Option E. Scoped to the two migrated features, not a repo-wide big-bang. |
+| P3a-D9 | **Two PRs: one Go, one Flutter.** Optionally split the Go PR (foundation vs feature endpoints) only if it grows too large to review. | Operator preference; both PRs keep the integration branch buildable (§3). |
+| P3a-D10 | **Contract & robustness refinements (from review 2026-07-25).** The profile contract is **idless** (own profile identified by `CurrentUser`; other-user reads become a separate `PublicProfile` in Phase 4) and carries **no Stripe fields** (dropped from the new DB too). Avatar: no `filename` in the request (server derives the extension from `contentType`); `fileSizeBytes` 1..5 MiB (0 rejected); the **5 MiB cap is best-effort** — R2 enforces the signed `Content-Type` but a storage-layer size cap cannot be relied on (`Content-Length` enforcement is undocumented, presigned POST unsupported), and object creation is not self-bounding (new key per presign), so abuse is bounded by a **per-user rate limit + inline delete-previous** and size is checked best-effort by a client pre-check + finalize `HEAD` backstop (adapter gains `Head`/`Delete`) + a Phase 4 sweep — not a hard guarantee (a hard cap would need a Go-API proxy, deliberately avoided; §4.6); `avatarUrl` validated by **URL parse** (https, no userinfo, exact host incl. port, segment-wise path), not string prefix; the byte `PUT` uses a dedicated **`PresignedUploadClient`** (no Firebase bearer / no API interceptors / URL never logged). `timezone` is **IANA-validated** (`400 invalid_timezone`). Sign-out runs via an **app-layer coordinator** that deletes the FCM token **before** Firebase sign-out; FCM tokens / presigned URLs are never logged in full. | Correctness + security hardening: keeps dead/foreign concerns out of the contract, blocks avatarUrl spoofing (the size limit is a best-effort PATCH-time backstop, not a hard block — see §4.6 abuse handling), prevents leaking the Firebase token to Cloudflare (the presigned URL's signature is *meant* to go to R2 — the risk is logging that URL, not sending it), and keeps invalid timezones out of Phase 4 scheduling. |
+| P3a-D11 | **`updated_at` via a common `set_updated_at()` trigger — amends the Phase 1 "Go sets `updated_at`, no triggers" convention** for this housekeeping concern only (§4.2). INSERT = `DEFAULT now()`; UPDATE / `ON CONFLICT DO UPDATE` bump via trigger; explicit per-table definition; a DB assertion enforces "`updated_at` column ⇒ trigger"; existing Phase 1/2 tables retrofitted in the 3a Go PR after Phase 2 merges. | More robust than Go-sets — no write path (esp. UPSERT conflict updates) can forget it; `updated_at` is housekeeping, not business logic, so the max-Go/"no business DB functions" stance is preserved. Matches the proven old-schema approach; self-enforced by the assertion. |
+
+---
+
+## 3. Execution model — narrowing continues
+
+Per strategy D5 the integration branch stays buildable and runnable after each
+PR. Phase 3a continues the Phase 2 "transitional narrowing": features not yet
+migrated stay non-functional against real data.
+
+**After Phase 3a the integration-branch app:**
+- ✅ builds and launches (clean clone),
+- ✅ signs in (Google + Apple) and resolves the internal user (Phase 2),
+- ✅ **profile** works end-to-end against the Go API: view own profile, edit
+  username (with taken-name error), change timezone, upload/replace avatar,
+- ✅ **FCM token registration** works against the Go API (re-enabled from the
+  Phase 2 P2-5 disable),
+- ⏸ task / evidence / judgement / point / payout / reports / account-deletion
+  remain non-functional until their phases. Expected and accepted.
+
+`Supabase.initialize(...)` **remains** in startup for the still-un-migrated data
+features. The `profile` and `notification` features stop importing
+`supabase_flutter` (CI import check).
+
+---
+
+## 4. Backend design
+
+### 4.1 Package layout (new / changed)
+
+```
+cmd/peppercheck/main.go              # wires profile + notification provisioners
+                                     #   into identity; mounts new handlers;
+                                     #   adds the ResolveUser middleware
+internal/
+  core/
+    httpserver/                      # (Phase 2) error envelope; small helpers
+  platform/
+    auth/                            # (Phase 2) TokenVerifier + verify middleware
+    r2/                              # NEW — S3-compatible R2 adapter
+                                     #   (platform/r2 vs core/objectstore is an
+                                     #    open non-blocking classification, §4.7)
+      r2.go                          # Uploader: PresignPut + Head + Delete
+  identity/                          # (Phase 2) + resolution middleware
+    domain.go                        # User (anchor) — unchanged
+    service.go                       # ResolveOrProvision extended: runs the fan-out tx
+    store.go                         # users / user_identities — CreateUserInTx
+    middleware.go                    # NEW — ResolveUser; CurrentUser(ctx) accessor
+    handler.go                       # GET /api/v1/me — unchanged (identity only)
+  profile/                           # NEW feature
+    domain.go                        # Profile
+    service.go                       # GetOwn, UpdateOwn, RequestAvatarUploadURL,
+                                     #   ProvisionInTx (username generation)
+    store.go                         # profiles table; CreateInTx, Get, Update
+    handler.go                       # GET/PATCH /api/v1/me/profile;
+                                     #   POST /api/v1/me/avatar/request-upload-url
+  notification/                      # NEW backend feature
+    domain.go                        # NotificationSettings, FCMToken
+    service.go                       # RegisterToken, DeleteToken, ProvisionSettingsInTx
+    store.go                         # user_fcm_tokens / notification_settings
+    handler.go                       # PUT/DELETE /api/v1/me/fcm-tokens
+```
+
+### 4.2 Schema (Atlas) — new tables
+
+Phase 1 created the identity core + jobs + inbox only. Phase 3a adds three
+tables to the Atlas schema (`backend/schema`).
+
+**`updated_at` housekeeping — convention amendment (P3a-D11).** `updated_at` is
+maintained by a **common `set_updated_at()` trigger** (one trigger per table),
+which **amends** the Phase 1 "Go sets `updated_at`, no triggers" rule for this
+housekeeping concern only: `INSERT` uses `DEFAULT now()`, and every `UPDATE` /
+`ON CONFLICT DO UPDATE` bumps `updated_at` via the trigger, so no write path can
+forget it (the `ON CONFLICT` case is exactly where Go easily would). The trigger
+uses **`now()`**, so `updated_at` = **the last *modifying transaction's* time**
+(Postgres `now()` is transaction-start time; two updates in one transaction share
+it, which is the intended semantics — use `statement_timestamp()` only if
+per-statement resolution is ever genuinely needed). This is the
+**sole** DB-side function — there are still **no business DB functions/triggers**
+(the strategy's max-Go stance holds; `updated_at` is not business logic). The
+trigger is defined explicitly per table (not dynamically created); a DB-test
+assertion enforces "any table with an `updated_at` column has the trigger"
+(§8). Existing Phase 1/2 tables carrying `updated_at` are retrofitted with the
+same trigger in the 3a Go PR, after Phase 2 merges (§9). To make the trigger the
+**sole owner** of `updated_at`, that PR also **removes explicit
+`updated_at = now()` from existing Go SQL** (e.g. the Phase 1 jobs store) and
+switches any "Go-maintained `updated_at`" schema comment to "trigger-maintained."
+
+```
+profiles (
+  id                        uuid PRIMARY KEY REFERENCES users(id) ON DELETE CASCADE,
+  username                  text NOT NULL UNIQUE,
+  avatar_url                text,
+  timezone                  text NOT NULL DEFAULT 'UTC',
+  created_at                timestamptz NOT NULL DEFAULT now(),
+  updated_at                timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT profiles_username_length CHECK (char_length(username) BETWEEN 2 AND 20)
+)
+
+notification_settings (
+  user_id                             uuid PRIMARY KEY REFERENCES users(id) ON DELETE CASCADE,
+  evidence_reminder_minutes           int[]  NOT NULL DEFAULT '{10}',
+  judgement_reminder_minutes          int[]  NOT NULL DEFAULT '{10}',
+  auto_confirm_reminder_minutes       int[],
+  evidence_reminder_even_if_submitted boolean NOT NULL DEFAULT false,
+  created_at                          timestamptz NOT NULL DEFAULT now(),
+  updated_at                          timestamptz NOT NULL DEFAULT now()
+)
+
+user_fcm_tokens (
+  id             uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id        uuid NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  token          text NOT NULL UNIQUE,           -- upsert conflict target
+  device_type    text,                            -- 'android' | 'ios' | 'web'
+  created_at     timestamptz NOT NULL DEFAULT now(),
+  updated_at     timestamptz NOT NULL DEFAULT now(),
+  last_active_at timestamptz NOT NULL DEFAULT now()
+)
+-- indexes: user_fcm_tokens(user_id), user_fcm_tokens(last_active_at)
+```
+
+Structures are ported from the Supabase schema (P3a-D5) with these deliberate
+changes: (1) `profiles.id → users(id)` replaces the old `profiles.id →
+auth.users(id)`; (2) **`stripe_connect_account_id` is dropped** — the referee
+payout / Stripe Connect account linkage is designed in Phase 5 (likely a
+payments-owned table), not carried on `profiles`, and nothing in 3a reads it;
+(3) **deliberate `NOT NULL` constraint hardening** on columns that were nullable
+in the old schema but always have a value in practice — `profiles.timezone`
+(default `'UTC'`), the `created_at`/`updated_at` timestamps across all three
+tables, `user_fcm_tokens.last_active_at` (default `now()`), plus
+`notification_settings.*_reminder_minutes` gaining `NOT NULL DEFAULT '{10}'`.
+This is safe because go-live builds a fresh DB (no rows to violate it, §4.3).
+
+### 4.3 Provisioning fan-out (eager, one transaction)
+
+`identity.Service.ResolveOrProvision` is extended. The common path (identity
+already known) is unchanged: `FindByIdentity → return existing user`. The
+first-sighting path now runs a **single transaction** that fans out across
+feature stores:
+
+```
+BEGIN
+  users            := identity.Store.CreateUserInTx(tx)
+  user_identities  := identity.Store.CreateIdentityInTx(tx, users.id, issuer, subject)
+  profile.Provisioner.CreateInTx(tx, users.id)          -- generates username
+  notification.Provisioner.CreateSettingsInTx(tx, users.id)
+COMMIT
+```
+
+- **Dependency inversion.** `identity` depends on two **narrow interfaces** it
+  declares, not on the concrete `profile`/`notification` packages:
+  ```go
+  // package identity
+  type ProfileProvisioner  interface { CreateInTx(ctx, tx, userID uuid.UUID) error }
+  type SettingsProvisioner interface { CreateSettingsInTx(ctx, tx, userID uuid.UUID) error }
+  ```
+  `profile.Service` and `notification.Service` implement them; `main.go` wires
+  the concrete impls in. Each store's `*InTx` method accepts the shared
+  transaction (a `Querier`/`*sql.Tx`), so the whole fan-out is atomic.
+- **Concurrent first sighting** is still resolved by `user_identities
+  UNIQUE(issuer, subject)` (Phase 2): the losing transaction rolls back (no
+  orphan `users`/`profiles`/`settings` rows) and the row is re-selected.
+- **Username generation lives in `profile`** (the feature that owns usernames),
+  not identity — see §4.4.
+- **No data backfill is needed.** Go-live builds a fresh DB and
+  testers re-create accounts via normal login (strategy D9); provisioning creates
+  `profiles`/`notification_settings` for each user at first sighting going
+  forward, so there are no pre-existing rows to migrate. The `set_updated_at()`
+  retrofit on Phase 1/2 tables (§4.2) likewise applies to future writes only and
+  needs no backfill.
+
+### 4.4 Username generation — faithful port with bounded retry
+
+Ported from `handle_new_user`: `user_` + `hex(4 random bytes)` (13 chars, within
+2–20), retried on `profiles_username_key` violation, **max 5 attempts**, then a
+hard error (never an unbounded loop — Phase 2 §9's carried-forward requirement).
+
+The old `plpgsql` loop relied on the implicit savepoint of a `BEGIN … EXCEPTION`
+block. The Go/`database-sql` port makes that explicit **inside the provisioning
+transaction**:
+
+```
+for attempt := 1..5:
+    SAVEPOINT sp_username
+    try INSERT INTO profiles(id, username, ...) VALUES (userID, gen(), ...)
+        -> success: RELEASE SAVEPOINT sp_username; break
+    catch unique_violation on profiles_username_key:
+        ROLLBACK TO SAVEPOINT sp_username; continue
+if still failing after 5: return error (rolls back the whole provisioning tx)
+```
+
+Random bytes come from `crypto/rand`. This is the only place a username is
+minted in Phase 3a (no user-chosen username at signup); username **editing** is
+a separate authenticated `PATCH` (§4.6).
+
+### 4.5 Identity resolution middleware (`identity/middleware.go`)
+
+The new middleware runs **after** Phase 2's token-verify middleware and turns the
+verified external `Identity` into the internal `User`:
+
+```
+RequestID → AccessLog → Recover → VerifyToken (Phase 2, Identity in ctx)
+          → ResolveUser (Phase 3a, User in ctx) → handler
+```
+
+- `ResolveUser` reads the `Identity` from context, calls
+  `identity.Service.ResolveOrProvision` (first sight provisions via the §4.3
+  fan-out), and stores the internal `User` in context. Handlers read it via
+  `identity.CurrentUser(ctx) (User, bool)`.
+- It lives in the `identity` package because it depends on `identity.Service`
+  (a feature) — `platform/auth` must not depend on a feature, so the resolution
+  step cannot live there. Token **verification** stays in `platform/auth`;
+  internal-user **resolution** is an identity concern.
+- Cost: one indexed `FindByIdentity` per authenticated request (acceptable;
+  caching deferred until measured).
+- `GET /api/v1/me` (Phase 2) is refactored to read `CurrentUser(ctx)` instead of
+  calling `ResolveOrProvision` itself, but its response is unchanged (P3a-D7).
+
+### 4.6 `profile` feature
+
+Server-side authorization: every operation is scoped to
+`identity.CurrentUser(ctx).ID` (replaces RLS `id = auth.uid()`).
+
+- **`GET /api/v1/me/profile`** → `200`
+  ```json
+  { "username": "user_1a2b3c4d", "avatarUrl": "https://…/avatar/…jpg",
+    "timezone": "Asia/Tokyo", "createdAt": "…", "updatedAt": "…" }
+  ```
+  The DTO has **no `id`** — `/me/profile` is implicitly the caller's own profile
+  (identified by `CurrentUser`), so an id field is redundant. No Stripe fields.
+  Other-user profiles are a separate future `PublicProfile` resource (§10), not
+  this contract.
+- **`PATCH /api/v1/me/profile`** — partial update, body any subset of
+  `{ username?, timezone?, avatarUrl? }`:
+  - `username`: server validates length 2–20 and charset `^[\p{L}\p{N}_\-]+$`
+    (mirrors the Flutter client-side rule); unchanged value is a no-op; a unique
+    violation → **`409 { code: "username_taken" }`**.
+  - `timezone`: validated as an **IANA timezone** via `time.LoadLocation`; an
+    invalid value → **`400 { code: "invalid_timezone" }`** (keeps bad values out
+    of Phase 4's deadline/notification scheduling). The api container must ship
+    the tz database — import `time/tzdata` (embedded) or install OS tzdata.
+  - `avatarUrl`: the server **parses the URL** (never a raw string-prefix check,
+    which authority/query tricks like `https://evil/?x=https://domain/avatar/uid/`
+    bypass) and requires **all** of: scheme `https`; **no userinfo**; host an
+    **exact match** (including port) of the configured R2 public domain; the path
+    validated **segment-by-segment** as exactly `avatar / {userId} / <file>` with
+    `..`, encoded slashes (`%2F`), and encoded/dot path segments rejected. So a
+    caller cannot set an arbitrary or another user's object. On a successful
+    avatar change the server **deletes the user's previous avatar object** (inline
+    delete-previous, see size/abuse handling below).
+- **`POST /api/v1/me/avatar/request-upload-url`** — **rate-limited per user**
+  (`429 { code: "rate_limited" }` when exceeded); body
+  `{ contentType, fileSizeBytes }` → `200`
+  ```json
+  { "uploadUrl": "https://<r2-presigned-PUT>", "publicUrl": "https://<domain>/avatar/…",
+    "expiresAt": "…" }
+  ```
+  No `filename` is accepted — the server derives the extension from
+  `contentType`. Validates `contentType` against the allow-list
+  (jpeg/png/webp/gif/heic/heif) and `fileSizeBytes` in **1..5 MiB** (0 rejected);
+  the presign **signs `Content-Type`** (R2 **enforces** the signed `Content-Type`
+  — a mismatch fails with `403 SignatureDoesNotMatch`) and best-effort signs
+  `Content-Length`. Presign TTL **600 s**; object key
+  `avatar/{userId}/{uuid}.{ext}`. The client PUTs bytes to `uploadUrl` (via the
+  dedicated `PresignedUploadClient`, §5.1.1), then calls `PATCH /me/profile {
+  avatarUrl: publicUrl }` to persist. (3-step flow, same shape as today's Edge
+  Function path, now Go-issued.)
+
+  **Size/abuse handling is best-effort (not a hard guarantee).** Per the R2 docs,
+  R2 enforces a signed `Content-Type` but does **not** document enforcing a signed
+  `Content-Length`, and R2 does **not support presigned POST** (so S3's
+  `content-length-range` policy is unavailable). A direct-to-R2 PUT therefore
+  cannot be size-capped at the storage layer, and — correcting an earlier claim —
+  object creation is **not** self-bounding either: each `request-upload-url` mints
+  a **new key**, so without a limit an authenticated user could create many
+  objects (the 600 s TTL bounds URL validity, not object count or retention). The
+  only place that could *hard*-cap transferred bytes is a Go-API proxy, which we
+  deliberately avoid here (avatars are small; proxying all future evidence too is
+  undesirable). Phase 3a bounds abuse with a **rate limit + inline
+  delete-previous** (the intent of "bound issuance + bound object count") plus a
+  finalize backstop:
+  - **Per-user rate limit** on `POST /me/avatar/request-upload-url` — a token
+    bucket keyed by internal user id allowing a **burst of 10** (capacity 10) and
+    a **sustained ~10 requests/hour** (refill 10 tokens/hour = 1 per 6 min); idle
+    bucket entries are **evicted after 1 h** of inactivity to
+    bound memory (in-memory is sufficient for the single-instance api topology;
+    revisit if scaled). Over-limit → `429 { code: "rate_limited" }` with a
+    **`Retry-After`** header (seconds until the next token). Values are the initial
+    tunable defaults; they cap object creation at ~10/hour/user.
+  - **Versioned per-upload key** `avatar/{userId}/{uuid}.{ext}` — a new key per
+    upload gives natural CDN cache-busting and never clobbers the current avatar
+    (a fixed key would let a bad upload overwrite the live avatar).
+  - **Inline delete-previous on commit — precise contract** (avoids deleting the
+    live avatar on a PATCH retry, and never turns a committed change into a 503):
+    1. Verify the new object (`HEAD`), then **commit the DB update first**
+       (set `avatar_url` to the new URL).
+    2. **Only after** the DB commit succeeds, delete the **previous** object.
+    3. If `oldKey == newKey` (idempotent retry with the same `avatarUrl`), **do
+       not delete** — otherwise a retry would delete the current avatar.
+    4. If the DB update fails, **do not delete** anything.
+    5. An R2 delete failure is **logged only** — it does **not** fail the
+       already-successful `PATCH` (the stale object is reclaimed by the Phase 4
+       sweep). Bounds *referenced* objects to ~1 per user without a sweep.
+  - **Client pre-check (UX):** the Flutter client refuses a file > 5 MiB before
+    uploading (bypassable by a modified client, so not a guarantee).
+  - **Finalize `HEAD` backstop:** on commit the server calls `Head` (§4.7) and
+    persists `avatar_url` **only if** the object exists, is 1..5 MiB, and is an
+    allowed `Content-Type`. Not a hard cap — the presigned URL is reusable within
+    its TTL and finalize can be skipped (TOCTOU); it checks the object's state at
+    PATCH time only.
+  - **Phase 4 sweep** reclaims **abandoned** objects (uploaded but never
+    committed — bounded by the rate limit) **and** must size/type-check the
+    **referenced** object, clearing `avatar_url` if it is invalid. The existing
+    sweep excludes referenced keys unconditionally; Phase 4 must change that.
+  - **Accepted residual risk (documented):** until the Phase 4 sweep lands,
+    abandoned objects can accumulate up to the rate limit and a user could leave
+    one oversized object at a just-minted key. Bounded and low-severity pre-launch
+    (no real users, disposable data, §4.3) — accepted.
+  - An optional real-R2 smoke test (§8) **records the observed behavior** of R2
+    for an oversized PUT (whether it is accepted or rejected). Refs: R2 Presigned
+    URLs; R2 Limits (single PUT ≤ 5 GiB — the 5 MiB cap is entirely ours).
+
+### 4.7 `platform/r2` adapter
+
+A thin S3-compatible adapter over the R2 endpoint, providing a **presigned PUT**
+(client's direct upload), a **`Head`** (finalize backstop, §4.6), and a
+**`Delete`** (inline delete-previous, §4.6) in Phase 3a:
+
+```go
+type PresignPutInput struct {
+    Key           string
+    ContentType   string
+    ContentLength int64          // best-effort signed; size is NOT enforced here
+                                 //   — the finalize Head is a PATCH-time backstop
+                                 //   only (§4.6), not a hard cap
+    TTL           time.Duration
+}
+type ObjectMetadata struct {
+    ContentLength int64
+    ContentType   string
+}
+type Uploader interface {
+    PresignPut(ctx context.Context, in PresignPutInput) (url string, err error)
+    Head(ctx context.Context, key string) (ObjectMetadata, error)
+    Delete(ctx context.Context, key string) error   // inline delete-previous
+}
+```
+
+- Constructed from R2 config (account ID, access key/secret, bucket, public
+  domain) — injected as env/secrets per the secrets policy, never committed. The
+  credentials themselves are operator-provisioned (release-checklist).
+- SDK types (AWS S3 SDK for R2) **stop at this package** (the `platform` rule);
+  `profile` depends only on the `Uploader` interface.
+- Phase 4 extends this package (private bucket, authorized presigned **GET** for
+  evidence); Phase 3a adds only the public-avatar presigned PUT.
+- **Open, non-blocking classification:** because R2 is reached over the
+  provider-neutral S3 API (not Cloudflare's proprietary API), this could instead
+  live as a neutral `core/objectstore` (per the global architecture note). It is
+  named `platform/r2` for now; revisiting the placement is deferred and does not
+  block 3a.
+
+### 4.8 `notification` feature (token registration)
+
+- **`PUT /api/v1/me/fcm-tokens`** — body `{ token, deviceType }`; **upsert on
+  `token`** (unique): set `user_id = CurrentUser`, `device_type`,
+  `last_active_at = now()` (`updated_at` is bumped by the trigger, not written in
+  the SQL — §4.2). `PUT` is idempotent, matching the client's
+  register-on-start / on-refresh / on-sign-in triggers and the old
+  `onConflict: 'token'` rebind semantics (a device re-logging-in rebinds its
+  token to the new user).
+- **`DELETE /api/v1/me/fcm-tokens`** — body `{ token }`; deletes the row scoped
+  to `user_id = CurrentUser AND token = ?` (a user can only remove their own
+  binding). Called on sign-out.
+- `notification_settings` has **no** read/update endpoint in 3a — the row is
+  created at provisioning (§4.3) with defaults; there is no settings-editing UI
+  today, and `*_reminder_minutes` are consumed by the Phase 4 notification
+  worker. Editing endpoints arrive with that UI's migration.
+- Invalid-token cleanup (currently inside `send-notification`) belongs to the
+  Phase 4 notification-send path, not 3a.
+
+### 4.9 Config
+
+- R2 settings for `platform/r2` (account ID, bucket, public domain, access
+  key/secret) added to the api service config, fail-closed for required values,
+  with dummies in `.env.example` / CI. Secret values follow the secrets policy
+  (operator-provisioned; only names/references committed).
+- No new port or Firebase config (Phase 2 covers those).
+
+---
+
+## 5. Flutter design
+
+### 5.1 `profile` feature → API client + Option E layout
+
+Restructured from `data/ domain/ presentation/` (+ `*Controller`) to the Option
+E layout while the data layer is rewritten (P3a-D8):
+
+```
+lib/features/profile/
+  domain/profile.dart                     # Profile (Freezed): username / avatarUrl /
+                                          #   timezone / timestamps — no id, no Stripe
+  data/profile_repository.dart            # ApiClient-backed; no supabase_flutter
+  data/profile_dto.dart                   # ProfileDto (mirrors /me/profile JSON)
+  data/avatar_upload_dto.dart             # request-upload-url response DTO
+  application/…                           # (only if orchestration warrants it)
+  ui/profile_screen.dart
+  ui/profile_view_model.dart              # was *Controller
+  ui/username_edit_view_model.dart
+  ui/timezone_view_model.dart
+  ui/avatar_edit_view_model.dart
+  ui/widgets/…
+```
+
+- `ProfileRepository` calls `ApiClient` (Phase 2) for the JSON endpoints:
+  `GET /me/profile`, `PATCH /me/profile` (username/timezone/avatar), and
+  `POST /me/avatar/request-upload-url`. The avatar bytes `PUT` goes to the R2
+  `uploadUrl` via the dedicated **`PresignedUploadClient`** (§5.1.1), **not**
+  `ApiClient`. Full 3-step: request-upload-url (ApiClient) → `PUT` bytes
+  (PresignedUploadClient) → `PATCH /me/profile { avatarUrl }` (ApiClient). The
+  avatar view model **pre-checks the file is ≤ 5 MiB before requesting the upload
+  URL** (UX-level early rejection; the server finalize `HEAD` is the backstop,
+  §4.6). Cropping already yields a small 512×512 jpg, so this rarely triggers.
+- The Flutter `Profile` domain drops `id` and `stripe_connect_account_id` to
+  match the new contract (P3a-D2/D6). Other-user profiles will be a separate
+  `PublicProfile` model in Phase 4, not this one.
+- DTOs are **separate files**; the repository maps DTO ↔ domain; domain never
+  imports DTOs (strategy §8).
+- `currentProfileProvider` fetches `GET /me/profile` (keyed off the Phase 2
+  current-user contract's signed-in state). It is **separate** from the auth
+  contract (which stays identity-only, P3a-D7).
+- Username taken → `ApiException(code: "username_taken")` → the existing
+  taken-name UI. Client-side validation (length/charset, skip-if-unchanged) is
+  retained as a fast pre-check; the server is authoritative.
+- `*ViewModel` classes must not define an `update` method (`AsyncNotifier`
+  override clash — project rule); use domain-specific names.
+- `supabase_flutter` removed from this feature (CI import check).
+
+### 5.1.1 `core/network/PresignedUploadClient` — bytes-to-R2 client
+
+The presigned `PUT` must **not** use `ApiClient`: `ApiClient` attaches the
+Firebase `Authorization: Bearer` header (which would leak the token to
+Cloudflare and can break the presigned signature), runs the API error-mapping /
+request-id interceptors (wrong for an R2 response), and could log the URL. So
+`core/network` gains a separate `PresignedUploadClient` — a bare `Dio` that:
+
+- attaches **no** Firebase bearer and runs **none** of the API interceptors;
+- **never logs the presigned URL** (its query string contains the signature,
+  which is a credential) — redact it in any logging;
+- shares only the common **timeout** configuration;
+- `PUT`s the bytes with the `Content-Type` / `Content-Length` matching the
+  request-upload-url call, and surfaces a plain success/failure (not `ApiException`).
+
+### 5.2 `notification` feature → re-enable token sync via Go API
+
+- Re-enable the FCM token sync **disabled in Phase 2 P2-5** (which was keyed on
+  the now-null Supabase user), now against the Go API:
+  - `fcm_service` upserts via `PUT /me/fcm-tokens` on app start,
+    `onTokenRefresh`, and on the Phase 2 auth-state `signedIn` transition.
+  - A refresh/upsert while **signed out is a no-op** (no bearer to authenticate).
+  - The **full FCM token is never logged** (redact in any diagnostics).
+- **Sign-out is orchestrated by an app/application-layer sign-out coordinator,**
+  not by `notification` depending on `auth` (or the reverse). The coordinator
+  runs the legs in order and, critically, calls **`DELETE /me/fcm-tokens`
+  *before* Firebase sign-out** — after sign-out there is no valid bearer to
+  authenticate the delete. Each leg is independent and idempotent: a token-delete
+  failure is logged and the remaining sign-out legs (Phase 5 RC logout, Firebase
+  sign-out) still run. This supersedes the Phase 2 §6.2 sketch that had the auth
+  repository call FCM unregister directly.
+- Restructured to the Option E layout for the parts touched (repository →
+  `data/`, `fcm_service` stays application-layer orchestration in
+  `application/`). The client-side notification **text resolver** (i18n loc-keys)
+  is unchanged — it is not a backend concern.
+- `supabase_flutter` removed from this feature's token path.
+
+### 5.3 Post-login
+
+Unchanged from Phase 2 §6.3: the app enters past login after Firebase auth +
+`GET /api/v1/me` succeed. Profile load (`GET /me/profile`) happens right after
+and is provisioned-guaranteed (eager fan-out), so it does not gate login; a
+transient profile-fetch failure shows a retry, not a limbo.
+
+---
+
+## 6. API contract summary
+
+| Method & path | Auth | Body | Success | Errors |
+|---------------|------|------|---------|--------|
+| `GET /api/v1/me` | yes | — | user + identity (Phase 2, unchanged) | 401/503 |
+| `GET /api/v1/me/profile` | yes | — | `{username, avatarUrl, timezone, createdAt, updatedAt}` | 401/503 |
+| `PATCH /api/v1/me/profile` | yes | `{username?, timezone?, avatarUrl?}` | updated profile | 400 validation, **409 `username_taken`**, 401/503 |
+| `POST /api/v1/me/avatar/request-upload-url` | yes | `{contentType, fileSizeBytes}` | `{uploadUrl, publicUrl, expiresAt}` | 400 (type/size), **429 `rate_limited`**, 401/503 |
+| `PUT /api/v1/me/fcm-tokens` | yes | `{token, deviceType}` | 204 | 400, 401/503 |
+| `DELETE /api/v1/me/fcm-tokens` | yes | `{token}` | 204 | 400, 401/503 |
+
+All errors use the Phase 2 stable envelope `{ error: { code, message, requestId } }`.
+
+---
+
+## 7. Error handling & edge cases
+
+- **Username exhaustion at provisioning** → 5 savepoint-bounded attempts, then
+  the whole provisioning transaction fails with an error (surfaced as a
+  provisioning failure, retryable by the idempotent resolve path). Never an
+  unbounded loop.
+- **Concurrent first sighting** → `user_identities UNIQUE(issuer, subject)`
+  rolls back the loser cleanly (no orphan profile/settings); re-select resolves.
+- **Username taken on edit** → `409 username_taken`, no partial write.
+- **Invalid timezone** → `400 invalid_timezone` (IANA-validated), no write.
+- **avatarUrl tampering** → server **parses** the URL and enforces scheme
+  `https`, no userinfo, exact host (incl. port), and a segment-wise
+  `avatar/{userId}/<file>` path (rejecting `..`, `%2F`, encoded dot segments);
+  string-prefix checks are insufficient. Finalize `HEAD` backstop confirms the
+  object exists and is 1..5 MiB / allowed type (best-effort, not a hard cap — R2
+  cannot cap direct PUT size, §4.6).
+- **Avatar object abuse** → not self-bounding (each presign mints a new key), so:
+  per-user rate limit on presign issuance (`429`) + inline delete-previous bound
+  the objects; abandoned (never-committed) objects are swept in Phase 4;
+  residual pre-launch risk is documented and accepted (§4.6).
+- **FCM token rebind** → a token previously bound to another user is re-bound to
+  the current user on upsert (matches old `onConflict: 'token'`).
+- **Sign-out ordering / token-delete failure** → coordinator deletes the token
+  before Firebase sign-out; a delete failure is logged and does not block the
+  remaining sign-out legs. FCM tokens and presigned URLs are never logged in full.
+- **Profile fetch failure post-login** → retry affordance; login not gated on it
+  (provisioning guarantees the row exists).
+
+---
+
+## 8. Testing & CI
+
+**Go unit:**
+- `profile` username generation: success within 5 attempts; exhaustion errors
+  after exactly 5; generated names satisfy length/charset.
+- Provisioning fan-out: first sighting creates `users` + `user_identities` +
+  `profiles` + `notification_settings` atomically; a forced failure rolls all
+  back (no orphans); concurrent first sighting → one user, no duplicate.
+- `profile.Service` update: username validation, taken-name error mapping,
+  timezone IANA validation (valid accepted, garbage → `invalid_timezone`),
+  avatarUrl host+path parse validation (including bypass attempts like an
+  attacker host with the good URL in the query string).
+- authz isolation: a token for user B cannot read/patch user A's profile or
+  delete A's fcm-token.
+
+**Go API integration** (HTTP + real Postgres + fake `TokenVerifier`):
+- `GET/PATCH /me/profile` happy paths; `409 username_taken`; `400
+  invalid_timezone`; `POST /me/avatar/request-upload-url` type/size validation
+  (R2 presign faked) — including `fileSizeBytes` **0 and > 5 MiB both rejected**;
+  **finalize `HEAD` backstop** — `PATCH /me/profile { avatarUrl }` rejects when
+  the faked `Head` reports the object missing / **0 bytes** / oversized (> 5 MiB)
+  / wrong `Content-Type`, and accepts a valid object; **inline delete-previous** —
+  a valid avatar change calls the faked `Delete` with the *prior* key **after** the
+  DB commit; a **same-URL PATCH retry** (`oldKey == newKey`) does **not** delete;
+  a **DB-update failure** does **not** call `Delete`; a **faked `Delete` failure**
+  is logged but the `PATCH` still returns success (not 503); **rate limit** — `request-upload-url` returns `429 rate_limited` with
+  a `Retry-After` header past the per-user quota; `PUT/DELETE /me/fcm-tokens`
+  upsert/rebind/delete; ownership violations; stable error envelope with
+  `requestId` through the real middleware chain (now including `ResolveUser`).
+
+**R2 smoke test** (optional, real R2, not in unit CI — needs credentials):
+**records the observed behavior** of R2 for a size-mismatched presigned PUT
+(accepted or rejected; `Content-Type` signing is documented, `Content-Length`
+enforcement is not). The finalize `HEAD` (§4.6) is a PATCH-time backstop, not
+authoritative enforcement, so this is informational only — a post-deploy check
+(§12), not a code gate.
+
+**DB integration** (assert-SQL in `backend/db/tests/*.sql`, run by CI as in
+Phase 2): `profiles_username_key` uniqueness + length check; `user_fcm_tokens`
+token uniqueness; FK cascade `users` → profiles / settings / fcm-tokens; no
+orphan rows after a rolled-back provisioning. **`updated_at` trigger:** on **two
+separate seed rows each with a *past* `updated_at`**, assert a normal `UPDATE`
+moves one forward and an `ON CONFLICT DO UPDATE` (fcm-token upsert) moves the
+other forward (do **not** compare against `created_at` right after `INSERT` —
+both equal the transaction time and would be identical). Plus a schema assertion
+that **every table with an `updated_at` column has a `set_updated_at()`
+trigger** (0 offenders) — this covers the retrofitted Phase 1/2 tables too.
+
+**Flutter:**
+- `profile`: DTO ↔ domain mapping; each `*ViewModel` success/error (fake
+  `ApiClient`); avatar 3-step (request-url → PUT → PATCH) with a fake HTTP layer;
+  `username_taken` surfaces the taken-name UI.
+- `notification`: token upsert on start/refresh/sign-in; no-op when signed out.
+- **sign-out coordinator** (app/application layer): FCM `DELETE` is called
+  **before** Firebase sign-out; and when the FCM `DELETE` **fails**, Firebase
+  sign-out still runs (order + failure-continuation both asserted with fakes).
+
+**CI gates:** Go — gofmt, `go vet`, unit, Postgres integration, race, Atlas
+fmt/lint, apply-to-empty-DB, schema-drift, image build. Flutter — dart format,
+`flutter analyze`, tests, **architecture import checks** (`supabase_flutter` not
+imported by `profile`/`notification`; Dio construction only in `core/network`),
+flavored debug build. The Flutter client carries no R2/S3 SDK — presigning is
+server-side and the client only `PUT`s the bytes to the returned `uploadUrl` via
+the dedicated `PresignedUploadClient` (§5.1.1). Per project convention each
+Flutter PR runs `flutter build`
+only; a single emulator pass runs at the end of Phase 3a on the integration
+branch.
+
+---
+
+## 9. PR breakdown
+
+Two PRs into `refactor/go-api-vps`; the branch builds after each (§3). Go first
+(curl-verifiable), then Flutter.
+
+| PR | Layer | Content |
+|----|-------|---------|
+| **P3a-1** | Go | Atlas tables (`profiles`, `notification_settings`, `user_fcm_tokens`) + common `set_updated_at()` trigger on each + **retrofit of existing Phase 1/2 `updated_at` tables** (after Phase 2 merges) + **removal of explicit `updated_at = now()` from existing Go SQL** (trigger becomes sole owner) + the "updated_at ⇒ trigger" assertion; `identity/middleware.go` ResolveUser + `CurrentUser(ctx)` and the fan-out extension (savepoint username retry in `profile`); `platform/r2` presigned PUT + `Head` (finalize size/type backstop) + object delete (inline delete-previous); `profile` feature (`GET/PATCH /me/profile`, `POST /me/avatar/request-upload-url` with **per-user rate limit** + **inline delete-previous** on avatar change); `notification` feature (`PUT/DELETE /me/fcm-tokens`, settings provisioning); all Go unit/API/db tests. *Optional split if too large:* P3a-1a foundation (schema + trigger + middleware + fan-out) / P3a-1b feature endpoints (profile + r2 + notification). |
+| **P3a-2** | Flutter | `profile` → `ApiClient` + `PresignedUploadClient` for the avatar `PUT` + Option E restructure + DTOs; re-enable `notification` token sync against the Go API + Option E restructure; **app-layer sign-out coordinator** (FCM delete before Firebase sign-out, failure-continuation); remove `supabase_flutter` from both; import-check CI; single emulator verification pass. |
+
+---
+
+## 10. Out of scope (deferred)
+
+- reports → Phase 4 (FK + UI coupling to tasks/evidence/judgement).
+- account deletion (eligibility + saga) → Phase 6.
+- reference-data seeding → each consuming phase (Phase 4 matching, Phase 5
+  subscription).
+- Go web / legal pages / Stripe Connect landing / web deletion-request / Next.js
+  retirement → **Phase 3b** (separate spec).
+- `notification_settings` read/update endpoints & UI → whenever that UI migrates.
+- Public other-user profiles → a separate `PublicProfile` resource
+  (`/api/v1/users/{id}`) + Flutter model in **Phase 4**; private R2 downloads
+  (authorized presigned GET for evidence) also Phase 4.
+- Referee payout / Stripe Connect account linkage (the dropped
+  `stripe_connect_account_id`) is designed in **Phase 5**, not carried on
+  `profiles`.
+- **Avatar sweep** (Go port of `sweep-r2-stale-objects`) → **Phase 4** (bundled
+  with the R2 evidence + sweep work). **Requirement:** unlike the current sweep
+  (which unconditionally excludes referenced keys), the Phase 4 sweep must reclaim
+  **abandoned** (never-committed) avatar objects **and** size/type-check the
+  **referenced** avatar object, clearing `avatar_url` if it is invalid (§4.6).
+- **FCM notification send + invalid-token cleanup** (the `send-notification`
+  path) → **Phase 4** notification worker.
+- Phase-2-dependent doc details (exact `backend/db/*` paths, final middleware
+  wiring) are confirmed once Phase 2 merges.
+
+---
+
+## 11. Done criteria (Phase 3a)
+
+- [ ] A clean clone builds and runs; a first-time sign-in provisions `users` +
+      `user_identities` + `profiles` (generated username) + `notification_settings`
+      atomically.
+- [ ] Profile works end-to-end via the Go API: view, edit username (with
+      `username_taken`), change timezone, upload/replace avatar (Go-issued R2
+      presigned PUT). Avatar `request-upload-url` is per-user rate-limited (`429`);
+      a successful avatar change **best-effort deletes** the previous object after
+      the DB commit (inline delete-previous; a delete failure is logged, not
+      surfaced); the finalize `HEAD` backstop rejects missing/0/oversized/
+      wrong-type objects.
+- [ ] FCM token registration/deregistration works via the Go API (Phase 2 P2-5
+      disable removed); no Supabase in the `profile`/`notification` token paths.
+- [ ] Sign-out coordinator deletes the FCM token **before** Firebase sign-out and
+      continues sign-out even if the token delete fails (both tested).
+- [ ] Identity resolution runs in middleware; authenticated handlers read
+      `CurrentUser(ctx)`; a token for one user cannot read/modify another's
+      profile or fcm-token (authz-isolation test passes).
+- [ ] `profile` and `notification` follow the Option E layout (`data`/`domain`/
+      `ui`, `*ViewModel`, separate DTOs).
+- [ ] `platform/r2` isolates the R2 SDK; `profile` depends only on its interface;
+      the avatar byte `PUT` goes through `PresignedUploadClient` (no Firebase
+      bearer reaches R2).
+- [ ] `updated_at` is trigger-maintained on all new + retrofitted tables; the
+      "`updated_at` column ⇒ `set_updated_at()` trigger" assertion passes (0
+      offenders).
+- [ ] CI gates (§8) pass; `/api/v1/me` (Phase 2) contract unchanged.
+
+**Not** Phase 3a criteria: reports; account deletion; reference-data seeding; Go
+web; notification-settings editing; public other-user profiles; payout linkage.
+
+---
+
+## 12. Deployment / operator actions
+
+Independent of code scope; added to the release-checklist when the PR that first
+deploys to **staging** lands (not now).
+
+- **Pre-deploy — R2 configuration** (operator): per-environment credentials,
+  bucket, and public domain for `platform/r2`, injected as secrets (secrets
+  policy: only names/references committed). The api will not serve avatar
+  upload/finalize without these.
+- **Post-deploy — R2 smoke test** (optional, informational): run the real-R2
+  size-mismatch check (§8) against the deployed environment to **record the
+  observed behavior**. The size limit is best-effort via the client pre-check +
+  finalize `HEAD` backstop + rate limit + inline delete-previous + the future
+  Phase 4 sweep (§4.6), not a code gate.

--- a/docs/superpowers/specs/2026-07-25-phase4a-follow-ups.md
+++ b/docs/superpowers/specs/2026-07-25-phase4a-follow-ups.md
@@ -1,0 +1,38 @@
+# Phase 4a — Follow-ups
+
+Items surfaced during the Phase 4a (task authoring + matching) port that are
+deliberately **not** implemented in 4a. Recorded so they can be picked up later
+rather than silently carried or dropped. Companion to
+`2026-07-25-phase4a-task-authoring-matching-design.md`.
+
+## Dropped in 4a (removed dead / no-op code)
+
+| Item | Why dropped | If revived |
+|------|-------------|-----------|
+| `premium` matching strategy | Never implemented: `process_matching` returns no match for `premium`, and `get_point_for_matching_strategy` rejects it. In practice it charges 2 points and always expires + refunds — a broken UX, not a feature. | Design a fresh advanced/premium matching tier; add a `matching_strategy` enum value + real logic. |
+| `direct` matching strategy + `preferred_referee_id` | Never wired: the UI never sends `direct` and never sets `preferred_referee_id`; the cost function rejects non-standard. | Design a referee direct-nomination flow fresh; re-add the column + branch. |
+| `matching_strategy` multi-value dimension | Collapsed to single value `standard` (the only live value). A single-value enum column is kept as a forward-compatible seam. | Add enum values + per-strategy logic when premium/direct are designed. |
+| `matched` / `declined` referee-request states | Unreached in the auto-accept flow (matching jumps straight to `accepted`). | Reintroduce with the referee accept/decline flow (below). |
+| `tasks.fee_amount` / `tasks.fee_currency` | Defined in the Flutter `Task` model but never read anywhere. Dead data. | Reintroduce with a paid-task / reward-amount feature (relate to Phase 5 reward). |
+| KV `matching_config` table | Its only key (`min_due_date_interval_hours`) was removed by a later migration; the table is effectively empty. Replaced by the typed config table. | Add typed columns to the typed `matching_config` instead of a KV bag. |
+| `detect_and_handle_referee_timeouts()` | Dead duplicate of the scheduled, live `detect_and_handle_review_timeouts()` (judgement domain). No cron entry, no callers. Name says "referee" but it detects review timeouts. | The live review-timeout detection is ported in 4c; do not resurrect this duplicate. |
+
+## Intended-but-unbuilt / deferred features
+
+| Item | Notes |
+|------|-------|
+| **Referee accept/decline flow** | Today matching auto-accepts (`pending → accepted`). The intended flow uses `matched` (worker matched, awaiting referee response) → `accepted` / `declined`. The async matching model makes this easier to add. Reintroduces the dropped enum states. |
+| **Premium / advanced matching tier** | See dropped `premium`. Design fresh, not a port. |
+| **`referee_availability` editing (is_accepting / max_concurrent)** | 4a adds the table + matching enforcement (no-op at defaults). The edit endpoint + UI belong to the imminent "accepting on/off + concurrency cap" feature. |
+| **Server-side notification localization** | 4a keeps client-side FCM `loc_key` (reuses the app's i18n, tracks OS locale). Moving localization to Go (resolve text from a `profile.language` + a Go/JSON i18n catalog) gains app-release-free copy updates and richer formatting, at the cost of a second i18n catalog and a reliable user-language source. The `send_notification` job contract `(userID, key, args, data)` is identical either way, so this is a single isolated swap inside the notification service — no upstream changes. High-value; do post-port or as a dedicated small initiative. |
+| **`task_` prefix drop for `evidences`** | 4a drops `task_referee_requests` → `referee_requests`. Apply the same to `task_evidences` → `evidences` in 4b. |
+| **All-requests-expired task terminal state + tasker withdrawal** | An `open` task whose referee requests all expire (zero matched) stays `open` forever — 4c only closes on all-judgements-confirmed, and there is no tasker-facing withdraw/cancel for an open task. This gap exists in the current system too (4a preserves it), but it is a real UX hole surfaced in the 4a spec review. Needs a product decision at the 4a/4c boundary: auto-close/auto-fail when all requests expire, a tasker withdrawal action, or a new terminal task state. Partial expiry (some accepted, some expired) is consistent with 4c close-on-all-confirmed and needs no change. **Decide before 4c.** |
+| **`max_concurrent_assignments` concurrency enforcement** | 4a adds the column + candidate-query filter (no-op at `NULL`). Enforcing the cap under concurrent matching (a `COUNT < cap` race a unique index cannot express) requires a per-referee `pg_advisory_xact_lock` + re-count in the match handler; build it with the availability-cap edit feature that turns the cap on (P4a-D16). |
+| **Verify `min_due_date_interval_hours` enforcement** | The KV key was deleted; confirm where (if anywhere) the "minimum hours between now and due date for open tasks" rule currently lives, and fold any surviving threshold into the typed `matching_config` + the Go open-requirement validation. |
+
+## Product signals (not code)
+
+- **Point-based subscription reception** — a pre-test with acquaintances did not
+  respond well to the points-for-matching subscription model. Port faithfully
+  now; treat a monetization/UX rethink as a separate post-migration initiative.
+  (See the operator memory note.)

--- a/docs/superpowers/specs/2026-07-25-phase4a-task-authoring-matching-design.md
+++ b/docs/superpowers/specs/2026-07-25-phase4a-task-authoring-matching-design.md
@@ -1,0 +1,427 @@
+# Phase 4a — Task Authoring & Matching (Design)
+
+> Part of the Supabase → Go API + VPS refactor. See the strategy doc
+> `docs/superpowers/specs/2026-07-22-supabase-to-go-vps-refactor-design.md` and
+> the Phase 0 baseline `docs/superpowers/specs/2026-07-22-phase0-baseline.md`.
+> Each phase is its own `spec → plan → implementation` cycle.
+
+## §0 Scope & Context
+
+Phase 4 ("core task lifecycle") is the largest phase of the refactor. It is
+decomposed into three sub-phases along the state machine:
+
+- **4a — task authoring + matching** (this document)
+- **4b — evidence + private R2** (upload intents, submit/resubmit, evidence
+  timeout, authorized presigned downloads)
+- **4c — judgement + rating** (judge, confirm, reopen, threads, auto-confirm,
+  review/evidence timeouts, rating)
+
+**This document covers 4a backend only.** The Flutter client for task authoring
+and matching is a separate follow-on `spec → plan` cycle (mirroring Phase 2's
+backend-then-Flutter split and Phase 3a).
+
+**Porting philosophy (locked):** behavior- and concept-preserving port; only the
+*structure* is redesigned (Go `service`/`store`/`handler`/worker, DTOs, no
+*business* DB functions/triggers — `updated_at` is maintained by the common
+`set_updated_at()` trigger per Phase 3a P3a-D11, not by Go). Clearly-poor implementations may
+be improved during the Go port as long as the intent is preserved. Anything that
+is dead, no-op, or deliberately deferred is recorded in the companion follow-up
+doc `2026-07-25-phase4a-follow-ups.md` rather than silently carried or dropped.
+
+**Transitional narrowing (Phase 2 principle):** on the integration branch, the
+Go point/reward system does not exist yet (Phase 5). 4a defines interface seams
+for point locking and referee obligations and wires **no-op stubs**; the real
+implementations arrive in Phase 5 by swapping the wiring, without changing
+matching code.
+
+## §1 Decision Log
+
+| ID | Decision | Rationale |
+|----|----------|-----------|
+| **P4a-D1** | **Split Phase 4 into 4a/4b/4c along the state machine; 4a = task authoring + matching.** | Phase 4 is too large for one spec; the seams to Phase 5 (points, reward) localize to 4a (point lock) and 4c (reward grant). |
+| **P4a-D2** | **This spec = backend only. Flutter is a separate follow-on spec.** | Keeps each spec focused; matches the Phase 2/3a pattern. |
+| **P4a-D3** | **Matching is asynchronous via a worker job**, not a synchronous in-request computation. Publish locks points (seam) + creates N `pending` requests + enqueues a matching job in one transaction and returns immediately (`status: pending`). | The old synchronous behavior was an artifact of running matching inside a DB trigger, not a product-considered behavior. `pending` is already a first-class state. Async unifies the initial-match and the retry paths (today `process_matching` is duplicated across the insert-trigger and the hourly cron), aligns with the Phase 1 durable-job primitive and the at-least-once idempotency requirement (issue #464). Deliberate, recorded deviation; the observable outcome (matched + notified / expired + refunded) is unchanged — only the timing (a moment later, via the worker). |
+| **P4a-D4** | **Phase 5 coupling is expressed as Go interfaces with no-op stubs**: `PointLocker` (lock/refund) and `ObligationChecker`. Interfaces are declared on the consumer (`matching`); `main` wires stubs in 4a and real implementations in Phase 5. `point_source` / `is_obligation` columns are present but their meaning is assigned in Phase 5 (`is_obligation` fixed `false` in 4a). | Go idiom (wrap boundaries whose alternative implementation — Phase 5 — is known); lets matching be fully unit-tested with fakes; Phase 5 injects without editing Phase 4 code. |
+| **P4a-D5** | **Collapse the `matching_strategy` dimension to a single value `standard`.** Drop `premium` and `direct` values and their dead code (per-strategy cost function, strategy selector); keep a single-value enum column as a forward-compatible seam. | Live behavior is already standard-only: the UI only ever sends `standard`, `preferred_referee_id` is never set, and `get_point_for_matching_strategy` already rejects non-standard. `premium`/`direct` are intended-but-unbuilt (follow-up). Keeping a single-value enum makes reintroducing strategies a value-add + branch, not a structural migration. |
+| **P4a-D6** | **Drop unused columns/tables**: `tasks.fee_amount` / `tasks.fee_currency` (defined in the Flutter model but never read), `task_referee_requests.preferred_referee_id` (direct dropped), the KV `matching_config` table (its only key was removed by a later migration). | Dead data/scaffolding; the big-bang migration resets internal data (Phase 7), so no migration cost. Recorded in follow-ups. |
+| **P4a-D7** | **Keep the backend concept name `referee`** (the UI uses its localized referee label; 1:1 mapping). | `referee` is semantically accurate (renders a pass/fail ruling) and a standard general term (academic peer "referees"); it is already pervasive across every backend domain and the `notification_{event}_{recipient}` key convention. Renaming to `reviewer` would be a cross-cutting churn that contradicts the finish-the-port priority and would introduce a permanent term mismatch with the UI. |
+| **P4a-D8** | **Drop the `task_` prefix: `task_referee_requests` → `referee_requests`.** | The task linkage is the `task_id` FK; the prefix is redundant. (`task_evidences` → `evidences` is a 4b follow-up.) |
+| **P4a-D9** | **Single typed config table.** The KV `matching_config` is dropped; the typed singleton (deadline hours + ordering invariant) becomes the one matching config table, seeded by 4a. | Typed columns + CHECK invariants (`open > rematch > cancel`) are type-safe and enforce cross-setting invariants; the KV bag is untyped and already empty. |
+| **P4a-D10** | **Design for multiple referees per task from the start** (schema already supports 1:N). Publish takes a referee count `N`; cap via config `max_referees_per_task` (default 2, current behavior). Matching excludes referees already in an active (pending/accepted) request on the same task. | Retrofitting multi-referee later touches read models, close logic, and matching exclusion; the schema is already 1:N; cheap to keep now. |
+| **P4a-D11** | **Forward-build a per-referee availability parent** `referee_availability` (`user_id` PK, `is_accepting boolean DEFAULT true`, `max_concurrent_assignments int NULL`). 4a adds the table + wires both into the matching candidate query (no-op at defaults); the edit endpoint/UI is deferred to the imminent "accepting on/off + concurrency cap" feature. | The operator confirmed these are imminent features, so this is a stated need, not speculation; adding now avoids a near-future migration (Phase 7 reset removes data cost). |
+| **P4a-D12** | **Build a feature-neutral notification-send foundation in 4a** (`platform/fcm` + `send_notification` worker + invalid-token cleanup), reused by 4b/4c. **Keep client-side localization (FCM `loc_key`)** for the port; the job contract makes a later swap to server-side localization a single isolated change. | Matching notifications are the first consumer of the Phase-4 send path (3a §4.8 deferred it here). `loc_key` reuses the app's existing i18n (no second catalog) and tracks OS locale; server-side localization is a high-value follow-up, not a port. |
+| **P4a-D13** | **`publish` cross-feature transaction** is owned by `task.Service`, which opens the single transaction and passes the tx handle into `matching` via a consumer-declared `RefereeRequestCreator.CreateInTx` seam (mirrors 3a's in-tx provisioner). | Publish spans `task` (status→open) and `matching` (requests + point lock + job enqueue) and must be atomic; one tx opened in one place, shared by handle, keeps the two features' writes all-or-nothing without either feature opening its own tx. |
+| **P4a-D14** | **The transaction boundary uses the `core` tx helper (Unit of Work); stores are typed to the Phase 3a `Querier` interface** (`database.Querier`, introduced by 3a's provisioning fan-out) satisfied by both the pool and a tx. `jobs` gains an `EnqueueInTx` accepting that `Querier` (Phase 1's `Enqueue` is `*sql.DB`-fixed). This plumbing lands first. The exact pgx/`database/sql` tx-helper and FCM Admin SDK messaging APIs are verified against official docs at plan time. | Best-practice tx management; reuses 3a's `Querier` rather than inventing a parallel type; the outbox (same-tx enqueue) is impossible without `EnqueueInTx`. |
+| **P4a-D15** | **`updated_at` is maintained by the common `set_updated_at()` trigger** (Phase 3a P3a-D11), one per new 4a table; Go SQL does **not** write `updated_at`. | Aligns 4a with 3a's convention amendment; no write path (esp. `ON CONFLICT DO UPDATE`) can forget it. `updated_at` is housekeeping, not business logic, so the max-Go stance holds. |
+| **P4a-D16** | **Concurrent matching is guarded against same-task double-assignment by a partial unique index** on `referee_requests (task_id, matched_referee_id) WHERE status = 'accepted' AND matched_referee_id IS NOT NULL`. The match handler treats a `23505` on accept as "lost the race" and leaves the request `pending` (the sweep retries with a fresh candidate set). A "two concurrent match jobs for two requests of the same task, same eligible referee → exactly one assigned" test is required. **`max_concurrent_assignments` cap enforcement under concurrency** (a `COUNT < cap` race a unique index cannot express) is deferred to the imminent availability-cap feature, which must add a per-referee advisory lock (`pg_advisory_xact_lock`) + re-count; at 4a's default (`NULL` = unlimited) the cap is a no-op. | The per-request CAS only guards one request; it cannot stop two requests concurrently selecting the same referee. A DB constraint makes same-task double-assignment impossible regardless of interleaving; the cap race is not live until the cap feature ships. |
+| **P4a-D17** | **`PointLocker` is a per-request lock/refund contract that returns a receipt** so Phase 5 is a pure wiring swap. `LockForRequestInTx(ctx, tx, taskerID, requestID, cost) (pointSource string, err error)` reserves points for one request and returns the funding source recorded on that request's `point_source`; `RefundForRequestInTx(ctx, tx, requestID, reason)` idempotently reverses it, keyed by `requestID`. `CreateInTx` inserts each request, locks per request, and stamps `point_source` from the lock result; the sweep refunds per request. | The original "lock N together, refund per request" left no per-request receipt, so Phase 5 would have had to change matching code to correlate refunds. Per-request lock + a receptor column (`point_source`) keyed by `requestID` makes refund idempotent and swap-only. Per-request locking also gives correct atomic affordability (a tasker who can fund 1 of 2 referees fails the whole publish). |
+| **P4a-D18** | **FCM sending requires a Firebase service-account credential** (worker-only, least-privilege: Firebase Cloud Messaging only). **4a owns adding this secret** through Phase 7a's established file-based secret mechanism: assuming 7a provisions secrets as Docker file-based secrets rendered from BWS at deploy, 4a adds a worker-only Firebase service-account secret delivered the same way and exposed to the worker via `GOOGLE_APPLICATION_CREDENTIALS` (Application Default Credentials). 7a's §6.3 inventory predates 4a's FCM need and does not list it (it records "no Firebase service-account secret" because Phase 2 token *verification* uses `WithoutAuthentication`); this is a 4a-side addition, **not** a change to the 7a docs. | The VPS is not a Google runtime, so ADC needs an explicit service-account file. FCM *sending* (unlike token verification) is an authenticated API and needs the credential. Ref: Firebase Admin SDK setup (`firebase.google.com/docs/admin/setup`). |
+| **P4a-D19** | **The `notification_matching_cancelled_pending_tasker` message is sent at most once per re-match request**, using the job idempotency key `cancelled_pending:{requestID}`: the match handler enqueues it (with that key) when a cancel-originated request finds no candidate; `ON CONFLICT (idempotency_key) DO NOTHING` guarantees once-only even across sweep retries. | Async matching makes "did the re-match succeed?" unknowable at cancel time; deciding the send point + a dedup key removes implementation drift and sweep-retry spam. |
+
+## §2 Data Model
+
+Atlas table-only for *business* logic (no business DB functions/triggers).
+`updated_at` is maintained by the common `set_updated_at()` trigger (P3a-D11,
+P4a-D15) — every new table below carries it. FKs target the Go identity core
+`users(id)` (Phase 2); referee timezone is read from `profiles` (Phase 3a). Full
+deletion semantics are Phase 6.
+
+**Concurrency guard (P4a-D16):** `referee_requests` carries a partial unique
+index `UNIQUE (task_id, matched_referee_id) WHERE status = 'accepted' AND
+matched_referee_id IS NOT NULL`, making same-task double-assignment impossible
+regardless of how concurrent match jobs interleave.
+
+**Tables**
+
+| Table | Notes |
+|-------|-------|
+| `tasks` | Drop `fee_amount`/`fee_currency`. Columns: `id, tasker_id → users(id) ON DELETE SET NULL, title, description, criteria, due_date, status, created_at, updated_at`. `status` enum `task_status` = `draft / open / closed`. |
+| `referee_requests` (was `task_referee_requests`) | `matching_strategy` enum collapsed to single value `standard`; drop `preferred_referee_id`. Columns: `id, task_id → tasks(id) ON DELETE CASCADE, matching_strategy, status, matched_referee_id → users(id) ON DELETE SET NULL, responded_at, point_source, is_obligation, created_at, updated_at`. |
+| `judgements` | Created here (PK = request id, 1:1). 4a only INSERTs `awaiting_evidence` on match and DELETEs on cancel (when still `awaiting_evidence`). Full lifecycle in 4c. |
+| `referee_available_time_slots` | Faithful port (weekly recurring: `dow`, `start_min`, `end_min`, `is_active`; unique `(user_id, dow, start_min)`). `user_id → users(id) ON DELETE CASCADE`. |
+| `referee_blocked_dates` | Faithful port (date ranges `start_date`, `end_date`, `reason`). `user_id → users(id) ON DELETE CASCADE`. |
+| `referee_availability` **(new)** | Per-referee availability knobs. `user_id` PK → `users(id) ON DELETE CASCADE`, `is_accepting boolean NOT NULL DEFAULT true`, `max_concurrent_assignments int NULL` (NULL = unlimited), timestamps. |
+| `matching_config` (typed) | The single matching config table (typed singleton). Fields: `open_deadline_hours`, `cancel_deadline_hours`, `rematch_cutoff_hours` (ordering invariant `open > rematch > cancel`), plus `max_referees_per_task` (default 2) and the matching point cost (flat 1). **Seeded by 4a with the current production values: `open_deadline_hours=24`, `cancel_deadline_hours=12`, `rematch_cutoff_hours=14`.** The KV `matching_config` is dropped. |
+
+**Enums**
+- `task_status`: `draft`, `open`, `closed`.
+- `matching_strategy`: `standard` (single value; seam for future strategies).
+- `referee_request_status`: `pending`, `accepted`, `expired`, `cancelled`,
+  `closed`, `payment_processing`. **Drop `matched`, `declined`** (unreached in
+  the auto-accept flow; reintroduced with the future accept/decline flow —
+  follow-up). 4a drives `pending / accepted / expired / cancelled`; `closed` is
+  4c; `payment_processing` is Phase 5.
+- `judgement_status`: full set exists; 4a only writes `awaiting_evidence`.
+
+## §3 State Machines
+
+**task:** `draft → open → closed`
+- 4a drives `draft → open` (publish, after open-requirement validation).
+  `open → closed` (all judgements confirmed) is 4c.
+
+**referee_request:**
+```
+pending ──(worker: match found)──▶ accepted ──(referee cancel, before cutoff)──▶ cancelled ─▶ (new pending)
+   │                                    │
+   └──(sweep: past rematch cutoff)──▶ expired    └─(4c)─▶ closed  /  (Phase 5) payment_processing
+```
+- 4a drives `pending / accepted / expired / cancelled`.
+
+**judgement:** `awaiting_evidence` (created by 4a on match) → the rest in 4c.
+
+## §4 Matching Algorithm (`standard`, behavior-preserving)
+
+The `match_referee_request` worker attempts one match for a `pending` request:
+
+1. **Candidate selection** — referees whose `referee_available_time_slots`
+   (active) cover the task `due_date` converted to the referee's timezone
+   (day-of-week + minute-of-day), excluding:
+   - the tasker themselves;
+   - referees who previously `cancelled` a request on this task;
+   - referees whose `referee_blocked_dates` cover the due date (in their tz);
+   - referees with `referee_availability.is_accepting = false` **(new)**;
+   - referees whose active workload ≥ `max_concurrent_assignments` **(new)**;
+   - referees already in an active (`pending`/`accepted`) request on this task
+     **(new, for multi-referee)**.
+2. **Least-workload** — restrict to candidates with the minimum active-judgement
+   workload count.
+3. **Obligation priority** — `ObligationChecker` filters least-workload
+   candidates for pending obligations (Phase 5 seam; 4a stub returns none, so
+   this reduces to a random pick from the least-workload set), `is_obligation`
+   recorded (fixed `false` in 4a).
+4. On a match: set request `accepted` (+ `matched_referee_id`, `responded_at`)
+   via a CAS that requires **both** `status='pending'` **and** the task still
+   within the matching window (`due_date > now() + rematch_cutoff_hours`) — so a
+   delayed/stale match job (e.g. after a worker outage crossed the cutoff) cannot
+   assign a referee to a request the sweep should expire. Then INSERT the
+   `awaiting_evidence` judgement, enqueue `send_notification`. On no match (or a
+   failed CAS): leave `pending` (the sweep retries or expires it).
+
+**Concurrency (P4a-D16):** two concurrent match jobs for two requests of the
+same task may both pick the same eligible referee. The partial unique index
+(§2) makes the second `accepted` write fail with `23505`; the handler treats
+that as losing the race and leaves the request `pending` for the sweep to retry
+against a fresh candidate set. Enforcing `max_concurrent_assignments` under
+concurrency (a `COUNT < cap` race) is deferred to the availability-cap feature
+(per-referee `pg_advisory_xact_lock` + re-count); it is a no-op at the 4a default.
+
+## §5 Execution Model
+
+**Publish (synchronous API, one transaction):**
+`task.Service.Publish` opens one tx (via the `core` UoW helper) and:
+1. validate ownership + open requirements → `tasks.status = open`. **Open
+   requirements** (porting `validate_task_open_requirements`): title present;
+   criteria present; **`due_date > now() + matching_config.open_deadline_hours`**
+   (the minimum-lead rule, not merely "in the future"). The point-balance check
+   the old function also did is **not** repeated here — affordability is enforced
+   by `PointLocker.LockForRequestInTx` (a no-op in 4a; real in Phase 5), so a
+   failed per-request lock rolls back publish.
+2. `matching.RefereeRequestCreator.CreateInTx(tx, taskID, taskerID, N)` → for each
+   of N requests: INSERT `pending` `referee_requests` → `PointLocker.LockForRequestInTx(tx, taskerID, requestID, cost)`
+   (stub returns `regular`) → stamp `point_source` on the request → enqueue a
+   `match_referee_request` job (outbox, same tx). Per-request locking gives
+   correct atomic affordability (funding fewer than N fails the whole publish).
+3. commit → return `{ taskId, status: "open", requests: [{id, status:"pending"}] }`.
+
+**Worker jobs (Phase 1 leased jobs):**
+
+| Job | Trigger | Idempotency |
+|-----|---------|-------------|
+| `match_referee_request` | enqueued by publish / cancel | acts only when the request is `pending` (`UPDATE ... WHERE status='pending'` compare-and-set); the judgement INSERT is keyed by request PK (duplicate → already-done). |
+| `sweep_pending_requests` | self-rescheduling (hourly; bucketed idempotency key), schedules the next run **first** so a failed run can't break the chain | per candidate, in one tx: **CAS** `expire WHERE status='pending'` → only then refund via seam + enqueue notification (so a request a concurrent match already accepted is not expired); retry the rest via the same match routine. |
+| `send_notification` | enqueued by matching (reused by 4b/4c) | at-least-once; duplicate event push is low-harm; best-effort dedup by job/notification id. |
+
+These are the first real handlers to which the issue #464 at-least-once
+idempotency checklist applies; call it out in review.
+
+**Cancel:** `POST /referee-requests/{id}/cancel` (assigned referee only, before
+`cancel_deadline_hours`) sets the request `cancelled`, deletes the judgement if
+still `awaiting_evidence`, inserts a new `pending` request (carrying the original
+`point_source`), and enqueues a match job — atomically.
+
+**Cancelled-then-pending notification (P4a-D19):** because matching is async,
+whether the re-match succeeds is unknown at cancel time. The match handler, when
+a **cancel-originated** request (its task has a prior `cancelled` request) finds
+no candidate, enqueues `notification_matching_cancelled_pending_tasker` with
+idempotency key `cancelled_pending:{requestID}` — `ON CONFLICT DO NOTHING`
+guarantees exactly one send per re-match request even across sweep retries.
+
+## §6 Go Structure
+
+Option E layout (`internal/<feature>/` with `domain.go` / `service.go`
+(`Service`) / `store.go` (`Store`) / `handler.go`).
+
+| Package | Role |
+|---------|------|
+| `internal/task` | `Task`/`TaskStatus`; create/update/delete + **publish orchestration** (validation, tx boundary); tasks CRUD store; task handlers. |
+| `internal/matching` | `RefereeRequest`/`RequestStatus`/`RefereeAvailability`/`TimeSlot`/`BlockedDate`; matching, cancel, availability, request creation; requests/availability/config stores; referee & availability handlers; **workers `match_referee_request` / `sweep_pending_requests`**. Declares the `PointLocker`, `ObligationChecker`, and `RefereeRequestCreator` seams. |
+| `internal/notification` (extends 3a) | `Enqueue(tx, …)` (outbox) + send path; token/settings store + invalid-token cleanup; **worker `send_notification`**. |
+| `internal/judgement` (minimal in 4a) | `awaiting_evidence` create / cancel-delete via a `Provisioner` seam; full lifecycle in 4c. |
+| `platform/fcm` **(new)** | Firebase Admin SDK messaging adapter (loc_key multicast send + invalid-token identification); SDK/DTO types stop here. |
+
+**Composition root** (`cmd/peppercheck` api + worker): wires the services, the
+no-op Phase 5 stubs, `platform/fcm`, and registers the job handlers.
+
+## §7 API Contract (`/api/v1`)
+
+Under Phase 2 token-verify + 3a `CurrentUser` middleware; Go-layer ownership
+authz; Phase 2 stable error envelope.
+
+**`/me` vs top-level rule:** `/me/*` = the caller's own account-scoped
+sub-resources and personalized views (identity implicit, no id). Top-level
+`/resource/{id}` = first-class entities addressed by their own id and touched by
+multiple actors; authz decides access.
+
+Tasker task authoring:
+- `POST /tasks` — create draft.
+- `PATCH /tasks/{id}` / `DELETE /tasks/{id}` — own draft only.
+- `POST /tasks/{id}/publish` — draft→open; body `{ refereeCount }`; locks points
+  (stub), creates requests, enqueues matching, returns `pending`.
+- `GET /me/tasks` — own authored tasks (status filter, paging).
+- `GET /tasks/{id}` — task detail + referee-request states (top-level; a referee
+  assigned to it may read it).
+
+Referee:
+- `GET /me/assignments` — tasks the caller referees.
+- `POST /referee-requests/{id}/cancel` — cancel an assignment → re-match.
+
+Referee availability (own — `/me`):
+- `GET/POST/PUT/DELETE /me/availability/time-slots`
+- `GET/POST/PUT/DELETE /me/availability/blocked-dates`
+- (`referee_availability` `is_accepting`/`max_concurrent` editing is out of 4a;
+  the table + matching enforcement only.)
+
+Config:
+- `GET /matching/config` — public deadline settings. Matching cost is flat
+  (1 point/request); the per-strategy cost RPC is removed.
+
+## §7.1 Wire Contract (JSON, camelCase) — pinned for the Flutter client
+
+> **Amendment (2026-07-26, surfaced by the Phase 4a Flutter design review).** §7
+> named endpoints but did not pin request/response bodies to a DTO-implementable
+> granularity, and did not state that task/assignment responses **embed a minimal
+> public profile** for display (tasker + matched referee username/avatar). Both
+> are pinned here so the Flutter DTOs can be written test-first without "confirm
+> the handler later". JSON is **camelCase** (consistent with the Phase 2 `/me` and
+> Phase 3a `/me/profile` responses). Every error is the Phase 2 envelope
+> `{ "error": { "code", "message", "requestId" } }`.
+
+**Minimal public profile (embedded).** Task/assignment responses carry, for the
+tasker and each matched referee, a minimal public profile — this is the Phase-3a-
+deferred `PublicProfile` (that spec deferred other-user profiles to Phase 4). It
+carries **only** display fields; it is not the owner's editable profile:
+
+```json
+{ "userId": "uuid", "username": "user_1a2b3c4d", "avatarUrl": "https://…/…jpg" }
+```
+
+`avatarUrl` may be `null`. Populated on `referee_requests` **only when matched**
+(`matchedRefereeId != null`); `null` while `pending`.
+
+**Task object** (`GET /tasks/{id}`, and the element of the list responses). No
+`feeAmount`/`feeCurrency`, no `matchingStrategy`, no `preferredRefereeId`; **no
+`judgement`/`evidence` in 4a** (those land in 4b/4c):
+
+```json
+{
+  "id": "uuid",
+  "taskerId": "uuid",
+  "title": "…",
+  "description": "…",            // nullable
+  "criteria": "…",               // nullable
+  "dueDate": "2026-08-01T00:00:00Z",  // nullable, RFC3339 UTC
+  "status": "draft",             // draft | open | closed
+  "createdAt": "…", "updatedAt": "…",
+  "tasker": { "userId":"uuid","username":"…","avatarUrl":"…" },  // nullable
+  "refereeRequests": [
+    {
+      "id": "uuid",
+      "taskId": "uuid",
+      "status": "pending",       // pending | accepted | expired | cancelled | closed | payment_processing
+      "matchedRefereeId": "uuid",// nullable (null while pending)
+      "respondedAt": "…",        // nullable
+      "pointSource": "regular",  // nullable
+      "isObligation": false,
+      "createdAt": "…", "updatedAt": "…",
+      "referee": { "userId":"uuid","username":"…","avatarUrl":"…" }  // nullable; set when matched
+    }
+  ]
+}
+```
+
+**Endpoints:**
+
+| Method & path | Request body | Success | Notes |
+|---------------|--------------|---------|-------|
+| `POST /tasks` | `{ "title", "description"?, "criteria"?, "dueDate"? }` | `201` Task (draft, `refereeRequests: []`) | server scopes `taskerId` to `CurrentUser` |
+| `PATCH /tasks/{id}` | any subset of the create body | `200` Task | own draft only |
+| `DELETE /tasks/{id}` | — | `204` | own draft only |
+| `POST /tasks/{id}/publish` | `{ "refereeCount": 1 }` (1..`maxRefereesPerTask`) | `200` Task (`status:"open"`, N `pending` requests) | `400 validation_error` on open-requirement fail; `refereeCount` out of range → `400` |
+| `GET /me/tasks?status=&cursor=&limit=` | — | `200 { "tasks": [Task], "nextCursor": "…"\|null }` | cursor paging |
+| `GET /tasks/{id}` | — | `200` Task | tasker or an assigned referee may read |
+| `GET /me/assignments?cursor=&limit=` | — | `200 { "assignments": [Task], "nextCursor": "…"\|null }` | each Task's `refereeRequests` includes the caller's request; `tasker` embedded for display |
+| `POST /referee-requests/{id}/cancel` | — | `200` Task (updated) | assigned referee only, before cutoff |
+| `GET /matching/config` | — | `200 { "openDeadlineHours":24, "cancelDeadlineHours":12, "rematchCutoffHours":14, "maxRefereesPerTask":2, "matchingPointCost":1 }` | public |
+| `GET /me/availability/time-slots` | — | `200 { "timeSlots": [Slot] }` | `Slot = { "id","dow","startMin","endMin","isActive" }` |
+| `POST /me/availability/time-slots` | `{ "dow","startMin","endMin","isActive" }` | `201` Slot | |
+| `PUT /me/availability/time-slots/{id}` | same | `200` Slot | own only |
+| `DELETE /me/availability/time-slots/{id}` | — | `204` | own only |
+| `GET /me/availability/blocked-dates` | — | `200 { "blockedDates": [Blocked] }` | `Blocked = { "id","startDate","endDate","reason"? }` (dates `YYYY-MM-DD`) |
+| `POST /me/availability/blocked-dates` | `{ "startDate","endDate","reason"? }` | `201` Blocked | |
+| `PUT /me/availability/blocked-dates/{id}` | same | `200` Blocked | own only |
+| `DELETE /me/availability/blocked-dates/{id}` | — | `204` | own only |
+
+The embedded `PublicProfile` is the only cross-feature read the task/matching
+handlers perform against `profiles` (Phase 3a); it is a **read of `username` +
+`avatar_url` by `user_id`**, exposed as a shared minimal projection (not the
+owner's `/me/profile` DTO).
+
+## §8 Notification Foundation
+
+The server emits FCM localization **keys**, not resolved text; the device
+resolves them against the app's i18n (OS locale). Key convention preserved:
+`notification_{event}_{recipient}`, with `title_loc_key = key + '_title'` /
+`body_loc_key = key + '_body'` + args (`.claude/rules/notification-keys.md`).
+
+- `platform/fcm`: Firebase Admin SDK messaging (`firebase.google.com/go/v4/messaging`)
+  — send loc_key multicast (Android `TitleLocKey`/`BodyLocKey`, APNS
+  `title-loc-key`), identify invalid tokens from the response. Exact API verified
+  against official docs at plan time.
+- `internal/notification`: `Enqueue(tx, userID, keyBase, args, data)` writes a
+  `send_notification` job to the outbox in the caller's tx; the worker loads the
+  user's `user_fcm_tokens`, sends via `platform/fcm`, and deletes invalid tokens
+  (the cleanup migrated out of the old `send-notification` edge function, 3a §4.8).
+- The old edge function / `pg_net` / `vault` / `service_role_key` path is removed;
+  the Go worker calls FCM directly.
+
+**Credentials (P4a-D18):** FCM *sending* needs a Firebase service-account
+credential (unlike Phase 2 token *verification*, which uses `WithoutAuthentication`).
+**Assumed 7a mechanism:** 7a renders secrets from BWS into Docker file-based
+secrets at deploy, delivered to the `worker` container. **4a-side work (owned
+here, no 7a doc change):** provision a **worker-only, least-privilege** service
+account (Firebase Cloud Messaging only), store it in BWS, deliver it through that
+same 7a file-secret path, and expose it to the worker via
+`GOOGLE_APPLICATION_CREDENTIALS` so the Admin SDK picks it up through Application
+Default Credentials. 7a's §6.3 inventory predates this and does not list the
+secret; adding it is part of 4a. Ref: `firebase.google.com/docs/admin/setup`.
+
+**4a notification events:** `notification_task_assigned_referee`,
+`notification_request_matched_tasker`, `notification_matching_reassigned_tasker`,
+`notification_matching_expired_refunded_tasker`,
+`notification_matching_cancelled_pending_tasker`.
+
+**Out of 4a (→ 4b/4c):** deadline-reminder scheduling — `notification_settings`
+reminder minutes, the `detect_*_deadline_warnings` jobs, `notification_sent_log`
+dedup.
+
+## §9 Phase 5 Seams
+
+```go
+// declared in internal/matching; stubs wired in main (4a), real impl in Phase 5.
+// database.Querier is the Phase 3a tx/pool interface (P4a-D14).
+type PointLocker interface {
+    // LockForRequestInTx reserves cost points for one request and returns the
+    // funding source recorded on that request's point_source. Phase 5 writes a
+    // ledger keyed by requestID; the 4a stub returns "regular" and no-ops.
+    LockForRequestInTx(ctx context.Context, tx database.Querier, taskerID, requestID uuid.UUID, cost int) (pointSource string, err error)
+    // RefundForRequestInTx idempotently reverses the lock for one request,
+    // keyed by requestID. The 4a stub no-ops.
+    RefundForRequestInTx(ctx context.Context, tx database.Querier, requestID uuid.UUID, reason string) error
+}
+type ObligationChecker interface {
+    FilterObligated(ctx context.Context, candidateIDs []uuid.UUID) ([]uuid.UUID, error)
+}
+```
+- 4a: `noopPointLocker` (`LockForRequestInTx` returns `"regular", nil`;
+  `RefundForRequestInTx` returns nil) + `noObligations` (returns empty);
+  `is_obligation = false`.
+- Phase 5: swap the wiring only; matching code is unchanged (refunds already
+  correlate per request via `requestID` + the stamped `point_source`).
+
+## §10 Testing Strategy
+
+- **Go unit:** task transitions (draft→open validation); candidate selection
+  (availability × timezone × workload × exclusions × `is_accepting` ×
+  `max_concurrent` × same-task exclusion); cancel eligibility (cutoff); match-job
+  CAS idempotency; `PointLocker` called with cost = N × flat; obligation stub.
+- **Postgres integration** (real container): migrations apply to empty DB;
+  constraints/indexes (availability unique, FKs, config ordering invariant, the
+  same-task partial unique index, `set_updated_at` present on every table with
+  `updated_at`); publish atomicity (task open + requests + jobs all-or-nothing;
+  rollback on failure or on a failed per-request lock); match-job idempotency
+  (twice → one referee, one judgement); concurrent match of the **same request**
+  (two workers → exactly one wins via CAS); concurrent match of **two requests of
+  the same task** picking the same eligible referee (→ exactly one accepted, the
+  other left pending via the unique index); user-scoped isolation.
+- **API integration** (HTTP + real Postgres + fake FCM/seams): auth required;
+  ownership violations (403); publish validation; publish returns pending +
+  enqueues; cancel rules; list paging/ordering; stable error envelopes.
+- **Worker:** `match_referee_request` (match / idempotent / leaves pending when
+  no candidate); `sweep_pending_requests` (expire past cutoff + refund seam +
+  notify; retry the rest); `send_notification` (load tokens → fake fcm → invalid
+  token cleanup → at-least-once tolerated).
+- **Characterization:** port the Phase 0 high-risk matching characterization
+  fixtures; assert the Go selection matches the documented algorithm.
+- **CI gates:** gofmt, `go vet`, unit, Postgres integration, race, Atlas
+  fmt/lint, apply-to-empty-DB, schema-drift, image build.
+
+## §11 Completion Criteria ("done")
+
+- Via the Go API a tasker can create/edit/delete a draft and publish (→open:
+  point-lock stub + N referee requests + matching enqueue, atomic); `task` and
+  `matching` have no Supabase imports.
+- `match_referee_request` assigns an available referee respecting availability,
+  timezone, workload, exclusions, `is_accepting`, and `max_concurrent`; creates
+  the `awaiting_evidence` judgement; notifies via `send_notification` + FCM.
+- `sweep_pending_requests` expires past-cutoff pendings (refund stub) and retries.
+- A referee manages availability (slots / blocked-dates) and cancels an
+  assignment before cutoff (→ re-match). Multi-referee (up to the config cap)
+  works.
+- Point/obligation are interface seams with no-op stubs; `is_obligation = false`.
+- `match` / `sweep` / `send` handlers are safe under at-least-once (#464).
+- All tests green; CI gates pass; api/worker shut down cleanly (Phase 1 lifecycle).
+- Flutter is a separate follow-on spec (not in this "done").
+
+## §12 Follow-ups
+
+See `docs/superpowers/specs/2026-07-25-phase4a-follow-ups.md`.

--- a/docs/superpowers/specs/2026-07-26-phase3b-go-web-design.md
+++ b/docs/superpowers/specs/2026-07-26-phase3b-go-web-design.md
@@ -1,0 +1,539 @@
+# Phase 3b — Go Server-Rendered Public Web (Design)
+
+> Status: **Design (approved in brainstorming 2026-07-26).**
+> Part of the Supabase → Go API + VPS refactor. Program strategy:
+> `docs/superpowers/specs/2026-07-22-supabase-to-go-vps-refactor-design.md`
+> (see §22 Phase 3, §9 Web Route Freeze). Phase 0 baseline:
+> `docs/superpowers/specs/2026-07-22-phase0-baseline.md` (§9 Web Route Freeze).
+> Builds on Phase 1 (foundation) and Phase 2 (identity & client boundary).
+> Follows the **implemented** backend conventions (verified 2026-07-26), which
+> differ from some Phase 3a *design* assumptions: `updated_at` is Go-maintained
+> (no `set_updated_at()` trigger exists), stores hold `*sql.DB` directly (no
+> `Querier` interface exists), and DB tests are plain transactional assert-SQL in
+> `backend/db/tests/` (not pgTAP). Sibling:
+> `docs/superpowers/specs/2026-07-25-phase3a-profile-notification-design.md`
+> (Phase 3a defined the 3a/3b split; this document is the 3b half).
+>
+> Each phase is its own `spec → plan → implementation` cycle; this document
+> covers **Phase 3b only**. The implementation plan is produced separately by the
+> writing-plans workflow and is not committed.
+
+---
+
+## 0. Phase 3 split — 3a vs 3b (recap)
+
+Strategy §22 groups Phase 3 ("Low-risk slices + Go web") as one phase. Phase 3a's
+design split it into two independent tracks with different runtimes, deploy
+targets, and test surfaces:
+
+- **Phase 3a** (separate spec) — app data slices behind the Go **JSON API** +
+  Flutter client: profile and notification-token registration.
+- **Phase 3b (this document)** — Go **`html/template`** server-rendered public
+  web: marketing home, legal pages, Stripe Connect return/refresh landing pages,
+  the provider-neutral web account-deletion **request** resource, and retiring
+  the obsolete Next.js web app.
+
+The two tracks share nothing at runtime (JSON API vs server-rendered HTML), which
+is why they are separate spec→plan→implementation cycles.
+
+---
+
+## 1. Purpose & Scope
+
+### 1.1 Purpose
+
+Migrate the current public web app — Next.js 15 (App Router) on Cloudflare
+Workers via OpenNext, served from `peppercheck.dev` — to **Go `html/template`
+pages served from the VPS behind Caddy**, removing Supabase from the web entirely
+and delivering a cutover-ready set of pages on the integration branch. The DNS
+switch, staging verification, and Cloudflare teardown belong to **Phase 7**; 3b
+produces the parity + redirects + tests, not the production cutover.
+
+The public web is also a **marketing surface** (the app's public face), so visual
+fidelity to the current design is a first-class requirement, not an afterthought.
+
+### 1.2 In scope (the 8 "keep" routes + 4 redirects)
+
+Per baseline §9 (Web Route Freeze): **8 keep / 4 redirect**.
+
+**Keep (ported to Go html/template):**
+
+| Route | Notes |
+|-------|-------|
+| `/` and `/{locale}` | Marketing home; preserve locale redirect behavior. |
+| `/{locale}/legal/privacy` | Privacy policy. |
+| `/{locale}/legal/terms` | Terms of service. |
+| `/{locale}/legal/refund` | Cancellation/refund policy (IAP-aligned). |
+| `/{locale}/legal/tokushoho` | Act on Specified Commercial Transactions disclosure (price hardcoded, see §5.3). |
+| `/{locale}/stripe/connect/return` | Static "onboarding complete" landing (path-fixed, see §5.2). |
+| `/{locale}/stripe/connect/refresh` | Static "restart onboarding" landing (path-fixed, see §5.2). |
+| `/{locale}/account/delete` | **Redefined** as an unauthenticated account-deletion **request/instructions** resource (see §4). |
+
+**Redirect (301 → localized home):**
+
+| Route | Decision |
+|-------|----------|
+| `/{locale}/auth/callback` | 301 → `/{locale}` |
+| `/{locale}/login` | 301 → `/{locale}` |
+| `/{locale}/dashboard` | 301 → `/{locale}` |
+| `/{locale}/pricing` | 301 → `/{locale}` |
+
+### 1.3 Out of scope (explicit)
+
+- **Browser-side auth / Firebase JS SDK** — not introduced. 3b has no
+  authenticated web surface (this is the deliberate consequence of §4's request
+  model, and is what keeps 3b small).
+- **Account-deletion saga** (Firebase/RevenueCat/Stripe/R2/DB cross-system
+  deletion, and the email round-trip verification of a web request) → **Phase 6**.
+- **tokushoho price via API** (a machine-readable price source in Go) → **Phase
+  5** (`subscription_plans` is seeded there). 3b hardcodes a reviewed constant.
+- **DNS switch, staging/production droplet verification, Cloudflare Workers
+  teardown, physical production removal of Next.js** → **Phase 7 cutover**.
+
+### 1.4 Invariants (non-negotiable constraints)
+
+- **URL structure is frozen.** The `/{locale}/` (`en`/`ja`) subdirectory prefix
+  and every kept path are preserved **exactly**. The legal and account-deletion
+  URLs are registered in Google Play Data Safety, the App Store, in-app links, and
+  are indexed/back-linked — changing them would require store-console
+  re-registration and old→new redirects. (See §3.4 for why subdirectory over
+  subdomain.)
+- **`/stripe/connect/return` and `/stripe/connect/refresh` paths are fixed**
+  because `payout-setup` (ported to `POST /api/v1/payout/setup` in Phase 5) sends
+  these as Stripe's `return_url`/`refresh_url` **without a locale prefix**; the
+  bare paths must keep resolving (see §5.2).
+
+---
+
+## 2. Store-requirement basis for the deletion resource (§4)
+
+The redefinition of `/{locale}/account/delete` from a self-service authenticated
+delete into an **unauthenticated request/instructions** resource is grounded in
+the official store policies (verified 2026-07-26):
+
+- **Google Play** ([Account deletion requirements](https://support.google.com/googleplay/android-developer/answer/13327111)):
+  requires **both** (a) an in-app path to delete the account, **and** (b) a **web
+  link resource** where users can *request* account deletion. The web resource
+  **does not have to be self-service** — the policy explicitly allows "*an
+  additional link that initiates account deletion, a customer service email or a
+  form they can submit a request through*." The rationale: users who uninstalled
+  the app must be able to request deletion "*without sending the user back to the
+  app*."
+- **Apple** ([Guideline 5.1.1(v)](https://developer.apple.com/news/?id=12m75xbj)):
+  requires **in-app** account deletion. The web page is not what satisfies Apple;
+  Apple is satisfied by the in-app self-service deletion (Phase 6).
+
+**Conclusion:** the 3b web resource permanently satisfies Google Play's "web link
+resource" requirement (b). It is **not** a substitute for the in-app self-service
+deletion that both stores actually require — that is Phase 6. The web resource is
+therefore a request/instructions page forever, by design.
+
+---
+
+## 3. Architecture
+
+### 3.1 Module placement (AGENTS.md naming convention)
+
+- A new **inbound web feature** `internal/web/` holds the `html/template`
+  `Handler`. It returns HTML, is distinct from the JSON API (`internal/api`), but
+  runs in the **same `api` process on the same origin** (baseline §9: the JSON API
+  under `/api/v1` and the web share one origin — no second public hostname).
+- The account-deletion request write path is small and account-scoped. It is
+  implemented either as part of `internal/web` (inbound) delegating to a thin
+  store, or as a tiny `internal/accountdeletion` feature owning the
+  `account_deletion_requests` store. The plan picks one; either way the web
+  handler is the inbound adapter and identity lookup is a dependency (§6.2).
+- Templates and static assets (CSS, fonts) are compiled into the binary via Go
+  **`embed`** — no external asset fetch at runtime, so the **same image runs
+  local/staging/production** (engineering policy: portable, self-contained
+  container).
+
+### 3.2 Routing
+
+The Go router (behind the existing single Caddy reverse-proxy to `api`) dispatches:
+
+- `/api/v1/*` → JSON API (`internal/api`, unchanged).
+- `/`, `/{locale}/*`, static assets → `internal/web`.
+- The 4 removed routes → 301 to localized home.
+
+Caddy itself changes minimally: TLS/HSTS and `reverse_proxy api:{$API_PORT}` stay
+as-is; all path dispatch happens inside the Go process.
+
+### 3.3 Locale routing (replacing next-intl)
+
+- A Go middleware resolves `/{locale}/` (`en`/`ja`), replacing `next-intl`'s
+  locale routing (the Supabase half of the current `src/middleware.ts` is dropped
+  with Supabase; the locale-routing half is reimplemented in Go).
+- A **bare path** without a locale prefix (`/legal/privacy`, `/stripe/connect/return`)
+  redirects to the default-locale version, preserving current behavior.
+- The default locale stays **`en`** (current behavior). Switching the default to
+  `ja` is a product decision recorded as a follow-up (§8), not a 3b change.
+- **`hreflang` annotations are added** to every kept page:
+  `<link rel="alternate" hreflang="ja" …>`, `hreflang="en"`, and
+  `hreflang="x-default"`, cross-linking the ja/en versions. This is the one SEO
+  best-practice gap the current app likely does not emit; the Go port closes it
+  (Google [Managing Multi-Regional and Multilingual Sites](https://developers.google.com/search/docs/specialty/international/managing-multi-regional-sites)).
+- A user-facing language switcher (the current EN/JP switcher) is retained; no
+  automatic Accept-Language redirect is imposed on kept pages.
+
+### 3.4 Why subdirectory, not subdomain (P3b-D6)
+
+Google's guidance ranks ccTLD > subdirectory > subdomain for geo-targeting, but
+**subdirectory is the recommended single-domain option** (best link-equity
+consolidation). For a single bilingual (ja+en) app on one VPS, subdomain's only
+real advantages — independent per-region geo-targeting and separate
+infrastructure/CDN — do not apply. The decisive factor is the frozen URL
+invariant (§1.4): subdirectory preserves every store-registered / indexed URL
+exactly, requiring **no** store-console updates and **no** old→new redirects,
+whereas subdomain would require both plus cross-host `hreflang` and a bare-domain
+locale-redirect decision. Subdirectory is therefore chosen.
+
+### 3.5 i18n content source of truth
+
+The legal/marketing copy currently lives in the next-intl JSON catalogs
+(`peppercheck-webapp/messages/{en,ja}.json`, namespaces `HomePage, Header,
+Footer, StripeConnect, Privacy, Terms, Refund, Tokushoho, AccountDelete`, …). This
+copy is **moved into a Go embedded message catalog (ja/en) as the single source
+of truth**; the Next.js catalogs are removed with the web app (§5.1). The Go
+templates render from this catalog. (Localized copy is data — the ja strings live
+in the catalog per the repo's language convention.)
+
+### 3.6 Fonts & visual fidelity (P3b-D10)
+
+Rendering must be **identical** to the current design (marketing face). Achieved
+by self-hosting the **same** fonts, so only the runtime Google Fonts dependency is
+removed, not the look:
+
+- Ship the current **Inter + Noto Sans JP** as **`woff2`**, embedded via Go
+  `embed` and served same-origin.
+- Load via `@font-face` with **`font-display: swap`**; **`preload`** the primary
+  weights actually used. Serve every `/static/` asset with a **content-based
+  `ETag`** (sha256, computed once at startup) and `Cache-Control: public,
+  max-age=3600` — a fixed-name + hourly-revalidation policy (browsers get a cheap
+  `304` when unchanged). This is chosen over content-hashed filenames because
+  `embed.FS` has no mtime, so `http.FileServer` alone emits no validators; ETag
+  gives correct revalidation for `styles.css` and the CSS-referenced fonts without
+  a build-time fingerprint pipeline.
+- **Noto Sans JP** is large (full JP glyph set is several MB). Use **`unicode-range`
+  split subsets** (the technique Google Fonts itself uses) so the browser
+  downloads only the ranges present on a page — preserving exact design while
+  keeping transfer small, and robust to legal-copy edits. (Static subsetting via
+  glyphhanger is a smaller but more fragile alternative; not chosen.)
+- **License:** Inter and Noto Sans JP are both **SIL Open Font License (OFL)**,
+  which permits self-hosting and redistribution — the embed is license-clean.
+
+> Note: `next/font/google` already self-hosts fonts at build time, so the current
+> app likely has no runtime Google Fonts dependency either; the Go port reproduces
+> the same self-hosted outcome.
+
+---
+
+## 4. Account-deletion request resource
+
+`/{locale}/account/delete` is redefined as an **unauthenticated
+request/instructions** resource — **no browser auth** (P3b-D1, P3b-D2).
+
+### 4.1 Page composition
+
+- **Primary-path guidance:** the page leads with "the reliable way to delete your
+  account is **from within the app**," linking/instructing toward in-app deletion.
+- **Fallback form** (for users who can't use the app — uninstalled, lost device):
+  - Visible fields: **email address (required)** + **one consent checkbox**
+    ("I understand this requests permanent deletion of my account and data") +
+    submit.
+  - Helper text: "enter the email you used to sign in (Google / Apple)"; and "if
+    you don't know it / used Apple Hide My Email, delete from within the app."
+  - Hidden anti-abuse fields: **honeypot** + **signed form token** (see §6).
+- Locale is taken from the URL.
+
+Fields deliberately **omitted**: name (matching is by email; name adds friction,
+no value) and free-text reason (not required by Google Play; free text is a
+spam/abuse storage surface). A reason field, if ever wanted, is at most a single
+optional field.
+
+### 4.2 Request ≠ execution (the safety model, P3b-D3)
+
+The core principle that makes an unauthenticated form safe: **the form only
+records intent; it never deletes.** Because a raw request performs no destructive
+action, "anyone can submit a request" is harmless. The destructive gate is at
+**execution time**, not submission time:
+
+- 3b captures an **unverified** deletion intent into `account_deletion_requests`.
+- **Phase 6** verifies ownership (email round-trip: a confirmation link sent to
+  the account's registered email — only someone controlling that email can
+  confirm; proves control without app login) **before** running the deletion saga.
+
+Trying to move verification to submission time would reintroduce browser auth —
+exactly the surface 3a deferred. "Accept from anyone / verify before execution" is
+what keeps 3b auth-free while remaining store-compliant and safe.
+
+### 4.3 Abuse resistance (P3b-D4, P3b-D5)
+
+Spam is defused structurally so operator confirmation cost scales with *real
+accounts*, not *submissions*:
+
+1. **No email is sent on submission** (removes the email-amplification / inbox-bomb
+   vector and cost). Verification email is a Phase-6, processing-time action, and
+   only to a matched account's registered address, per-account rate-limited.
+2. **Store a row only if the claimed email matches an existing account**
+   (server-side lookup against `user_identities.email`, §6.2 — email is persisted
+   on `user_identities` as a 3b addition, see §6.1). Junk submissions for
+   non-existent emails create **zero rows** and never reach the operator's
+   confirmation queue. Confirmation cost is therefore bounded by real-account
+   matches, which are naturally few.
+3. **Uniform generic response** regardless of match ("if an account with this
+   email exists, we'll process the request") — prevents account enumeration and
+   harassment targeting.
+4. **Honeypot** hidden field (drops naive bots, zero user friction).
+5. **Signed form token + submission-timing check** — a short-lived HMAC-signed
+   token embedded when the page is served; rejects scripted POSTs that never
+   loaded the page and submissions faster than a human could fill. Stateless (no
+   server-side session).
+6. **Per-IP rate limiting** (core middleware) bounds volume.
+7. **Upsert dedup per matched account** — repeated requests for one account
+   collapse to a single row (bounds DB growth).
+
+**Cloudflare Turnstile** (free, near-invisible CAPTCHA) is **not** included
+initially; it is a follow-up to add only if real spam gets through the above. It
+works standalone behind VPS/Caddy (widget + server-side siteverify + one secret).
+
+### 4.4 Phase 6 boundary
+
+3b hands off **"unverified deletion intents tied to real accounts"** and nothing
+more. Phase 6 owns: email round-trip verification (`unverified` → `verified`),
+running the deletion saga, and any per-account verification-email rate limiting.
+Recorded in follow-ups (§8) so Phase 6 knows to consume `account_deletion_requests`.
+
+---
+
+## 5. Redirects, Stripe Connect landing, tokushoho price
+
+### 5.1 Next.js retirement & Supabase-from-web removal (P3b-D11)
+
+- **In 3b, once Go route parity is verified in CI, `peppercheck-webapp/` is
+  deleted on the integration branch** (Next.js, OpenNext, `wrangler` config, the
+  Supabase web SDK usage, and `ci-webapp.yml`). This satisfies strategy §22 Phase
+  3's "done = these features have no Supabase imports; public web routes
+  production-ready."
+- **The live production site is unaffected:** it is served from `main`/Cloudflare
+  until the Phase 7 cutover (the refactor is big-bang on the integration branch,
+  merged to `main` only at Phase 7). Deleting the app on the integration branch
+  does not touch the live site. The one operational caveat — a live-site hotfix
+  before cutover is done on `main` (where the web app still exists) — is inherent
+  to big-bang integration, not specific to this deletion.
+- **Supabase-web verification caveat** (baseline §9.1): a grep for remaining web
+  Supabase deps must match the **`@/lib/supabase` path alias**, not only the
+  `@supabase` package name (`account/delete/page.tsx` used the alias and would not
+  appear in a package-name grep). Better: rely on the Go port completing, not on
+  grep.
+
+### 5.2 Stripe Connect return / refresh (P3b-D7)
+
+- Served as **static Go template pages** at `/{locale}/stripe/connect/{return,refresh}`
+  (equivalent to the current `StaticInfoPage`: "onboarding complete, return to the
+  app" / "onboarding needs restarting"). No auth, no external calls.
+- **Path-fixed:** `payout-setup` (Phase 5 → `POST /api/v1/payout/setup`) sends
+  `return_url`/`refresh_url` as the **bare, locale-less** paths
+  `/stripe/connect/{return,refresh}`. Go must therefore **accept the bare paths**
+  and redirect to the default-locale page (current next-intl behavior). Whatever
+  Stripe redirects the browser to must resolve to the info page.
+- Contact email (`hi@cloveclove.dev`) comes from the i18n catalog (was hardcoded in
+  `StaticInfoPage.tsx`).
+- **Known limitation — `refresh` stays static in 3b (faithful port).** Stripe's
+  Account Links contract specifies that `refresh_url` should *generate a new
+  Account Link and redirect back into onboarding*
+  ([Stripe Account Links](https://docs.stripe.com/api/account_links/create)).
+  That re-issue needs the Stripe Connect integration (identify the account,
+  `accountLinks.create`), which is ported to Go with `payout-setup` in **Phase 5**.
+  The current Next.js prod is also a static "please restart" page, so 3b preserves
+  that behavior and records a Phase 5 follow-up (§8): make `refresh` regenerate the
+  link via a short-lived signed `state` query param. The frozen path is preserved
+  regardless.
+
+### 5.3 Redirects (4 removed routes → localized home)
+
+- `/{locale}/{auth/callback,login,dashboard,pricing}` → **301 → `/{locale}`**.
+- Bare forms (`/login`, …) resolve the locale and 301 uniformly.
+- `pricing`: subscription is **IAP-only** (webapp subscribe is disabled), so its
+  checkout is dead; 301 → home is the minimal choice. A "subscription explanation"
+  section on home or a static info page is optional and not built by default
+  (YAGNI).
+
+### 5.4 tokushoho price (P3b-D8)
+
+- The current page fetches price rows from Supabase; **3b removes that Supabase
+  read** (removing the last Supabase dependency from the legal pages).
+- The price is rendered from a **single reviewed constant** (one Go const / config
+  value referenced by the template). The Act on Specified Commercial
+  Transactions requires showing the real price,
+  which this satisfies.
+- **Launch-blocker linkage:** the baseline records a Premium price discrepancy
+  (**2,580 vs 2,480**). The hardcoded value **must be the reconciled/reviewed
+  price**, and the constant carries a comment referencing that blocker; resolve
+  the discrepancy before shipping.
+- A CI consistency check is **not** built in 3b: there is no machine-readable Go
+  price source to compare against until Phase 5. **Phase 5 follow-up:** switch
+  tokushoho to read the price from the Go subscription endpoint (single source of
+  truth), at which point a consistency check is natural (§8).
+- Other legally mandated fields (seller/contact info) stay as static copy from
+  the i18n catalog. Operator is a **solo operation**; do not use
+  "employee"/team-based wording in the copy (existing policy).
+
+---
+
+## 6. Data model, contracts, security, testing
+
+### 6.1 Data model — one new table + one column addition
+
+**New table `account_deletion_requests`:**
+
+| Column | Notes |
+|--------|-------|
+| `id` | PK. |
+| `user_id` | Matched internal user UUID, **NOT NULL**, **UNIQUE**, FK → `users(id) ON DELETE CASCADE` (a row exists only when the claimed email matched a real account). |
+| `claimed_email` | The email submitted (matched). |
+| `status` | Initially `unverified`; Phase 6 advances to `verified`/`processed`. |
+| `source` | `web`. |
+| `requested_at` | Submission time. |
+| `updated_at` | **Go-maintained** (`updated_at = now()` in each `UPDATE`); no DB trigger (matches the implemented backend convention). |
+
+- **Upsert on `user_id`** (`ON CONFLICT (user_id) DO UPDATE`) so repeated requests
+  for one account collapse to a single row.
+- Declared in a new Atlas schema dir `schema/web/` (registered in `atlas.hcl`
+  `src`); a plain transactional **assert-SQL** test in `db/tests/` covers the
+  unique constraint, cascade, and upsert behavior (repo backend DB-testing
+  convention — not pgTAP).
+
+**Column addition — `user_identities.email` (+ `email_verified`):** email is not
+persisted anywhere today (Phase 2 stores only `issuer`/`subject`; the verified
+token carries `Email` but it is never written). To make §4.3's match-on-real-
+account work, 3b adds `email text` and `email_verified boolean` to
+`user_identities` (the conceptually correct home — email is a per-provider-
+identity attribute, and `users` deliberately holds no provider data), captures it
+from the verified token at provisioning and refreshes it on each login, and adds
+a `lower(email)` index for case-insensitive lookup. This modifies the implemented
+Phase 2 identity code (opportunistic, same integration branch).
+
+**Match safety:** the lookup (`FindUserByEmail`) matches **only `email_verified`
+rows** and resolves to a user **only when unambiguous** — if the same verified
+email maps to more than one distinct user it returns `ErrNotFound` (fail safe;
+never picks an arbitrary account). The login-time refresh keeps the stored email
+current, avoiding stale matches.
+
+**State machine (write-time enforced):** `account_deletion_requests.status` moves
+`unverified → verified → processed`, advanced **only by Phase 6**. The public
+form's upsert writes only `unverified` and is guarded (`ON CONFLICT (user_id) DO
+UPDATE … WHERE status = 'unverified'`), so a third party who merely knows an email
+**cannot revert** a Phase-6-confirmed request back to `unverified`. A DB assert-SQL
+test covers this.
+
+### 6.2 Backend contracts
+
+- **Account existence lookup:** `internal/identity` gains `FindUserByEmail`
+  (a thin extension of the existing store, `struct { db *sql.DB }`), returning
+  `ErrNotFound` on no match. A new domain feature `internal/accountdeletion`
+  (domain + `Store.Upsert` + `Service.RequestDeletion`) consumes it via a
+  consumer-declared interface (web → accountdeletion → identity, one-way).
+- **Public POST handler** (`internal/web`): rate-limit → body cap → honeypot →
+  consent → signed form token/timing → `accountdeletion.Service.RequestDeletion(claimedEmail)`
+  (which normalizes the email, looks up the account, and upserts on match).
+  **Response:** normally the uniform generic response (a PRG **303** redirect to
+  `?submitted=1`) — identical for match, no-match, honeypot, bad token, and
+  missing consent, so no account existence leaks. **Exception:** if
+  `RequestDeletion` returns an infrastructure error (the request was NOT saved),
+  return a **generic 503** retry page instead — never a "submitted" 303 — so the
+  user is not misled into thinking a lost request succeeded. The 503 is
+  independent of account match, so it too leaks nothing.
+- **Signed form token:** on page render, embed an HMAC-signed token over
+  `{issued_at, nonce}`; the POST verifies signature, expiry, and a minimum
+  elapsed time. **Stateless** (no server session). The signing key is a new
+  secret `WEB_FORM_SIGNING_KEY`, loaded via the env/file-secret pattern
+  (`lookupEnvOrFile`) and delivered through Phase 7a's BWS → Docker file-based
+  secret mechanism, scoped to the `api` service (a 3b-side addition, not a change
+  to the 7a docs).
+- **Rate limiting:** per-IP, via a **new** in-memory limiter middleware written in
+  `internal/web` (no rate-limit middleware exists in the codebase yet). Client IP
+  is taken from `X-Forwarded-For` (set by Caddy); this bounds casual abuse, not a
+  determined spoofer — Turnstile is the escalation.
+- Stores hold `*sql.DB` directly and run any transactions inline via `BeginTx`
+  (the codebase has no `Querier` interface or tx/UoW helper).
+
+### 6.3 Security & privacy
+
+- **Account existence non-disclosure** (uniform response) prevents enumeration and
+  harassment.
+- **No confirmation email in 3b** (amplification prevention); verification/sending
+  is Phase 6.
+- `claimed_email` handling is minimal (a match key + Phase-6 verification target);
+  **PII is never logged**.
+- **CSP header is emitted** on every web response by the web handler — a strict
+  policy (`default-src 'self'; script-src 'none'; style-src 'self'; font-src 'self';
+  img-src 'self' data:; form-action 'self'; base-uri 'self'; frame-ancestors 'none';
+  object-src 'none'`), plus `X-Content-Type-Options: nosniff` and a
+  `Referrer-Policy`. The pages are self-contained (embedded CSS/fonts, no external
+  hosts, no JavaScript), so this policy is enforceable as-is; a header test asserts
+  it. Self-hosting alone does not enable CSP — the header must be set, and is.
+
+### 6.4 Testing (strategy §24 "Web (in Go CI)")
+
+- **Template render tests** for all kept pages × `ja`/`en`.
+- **Per-locale route tests** + **`hreflang` output** verification.
+- **Redirect tests**: the 4 removed routes → localized home; bare Stripe Connect
+  paths → default-locale page.
+- **Deletion form tests** (fake identity store): valid token / honeypot tripped /
+  timing too fast / rate-limited / matched vs unmatched email producing the
+  **identical** response / upsert dedup.
+- **Embedded-asset validation**: fonts/CSS are compiled in and resolve.
+- **No CI job reads committed secrets or local secret files.**
+
+---
+
+## 7. Decision log
+
+| ID | Decision | Rationale |
+|----|----------|-----------|
+| **P3b-D1** | Phase 3 already split into 3a/3b; **3b = Go `html/template` public web (static/near-static + redirects), no browser auth.** | Different runtime/deploy/test surface from 3a's JSON API; the request-only deletion model (D2/D3) removes the only reason 3b would need browser auth. |
+| **P3b-D2** | Redefine the web deletion route as an **unauthenticated request/instructions** resource. | Google Play requires a web *request* resource that need not be self-service; it permanently satisfies that requirement and is not a substitute for in-app deletion (Apple's requirement, Phase 6). (§2) |
+| **P3b-D3** | **Request ≠ execution:** the web only queues an *unverified* intent; verification (email round-trip) and execution are Phase 6. | Makes an unauthenticated form safe without browser auth; a raw request performs no destructive action. |
+| **P3b-D4** | Accept from anyone, but **store a row only on a real-account email match**; **uniform generic response**; **no email on submission**. | Bounds operator confirmation cost to real accounts; prevents enumeration/harassment; removes the email-amplification vector. |
+| **P3b-D5** | Anti-abuse layers: honeypot + signed form token + timing + per-IP rate limit + per-account upsert. Turnstile only if needed later. | Low-friction, no third-party dependency, no added secret; sufficient at this scale. |
+| **P3b-D6** | **Locale = subdirectory `/{locale}/` (kept)** + add `hreflang`; not subdomain. | Preserves frozen store-registered/indexed URLs (no console updates, no old→new redirects); single origin; best link-equity for one bilingual app on one VPS. (§3.4) |
+| **P3b-D7** | 4 removed routes → **301 to localized home**; Stripe Connect return/refresh are **path-fixed static pages** accepting bare paths. | Uniform simple rule for dead auth/subscription URLs; `payout-setup` sends locale-less bare paths that must keep resolving. |
+| **P3b-D8** | Act on Specified Commercial Transactions price = **hardcoded reviewed constant** (referencing the 2,580 vs 2,480 blocker); Phase 5 switches to API read. | No machine-readable Go price source exists until Phase 5; the Act requires a real price now. |
+| **P3b-D9** | Move the i18n copy from the next-intl catalogs into a **Go embedded catalog as the single source of truth**. | The web app is deleted in 3b; the copy must live somewhere Go can render it. |
+| **P3b-D10** | Self-host the **same** fonts (Inter + Noto Sans JP) as embedded `woff2` (Noto = `unicode-range` split), `font-display: swap`, `preload`, and content-`ETag` + `max-age=3600` revalidation for `/static/`. | Preserves the marketing design exactly while removing runtime Google Fonts dependency; OFL permits self-hosting; ETag revalidation avoids a fingerprint build pipeline for a small site. |
+| **P3b-D11** | **Delete `peppercheck-webapp/` on the integration branch in 3b** once parity is verified; Cloudflare/DNS teardown is Phase 7. | Satisfies Phase 3 "no Supabase imports in web"; avoids carrying two web stacks; the live site (main/Cloudflare) is unaffected until cutover. |
+| **P3b-D12** | The only new table is **`account_deletion_requests`** (name includes "account" for clarity vs other deletion concepts); the deletion domain lives in a dedicated **`internal/accountdeletion`** feature, not folded into `identity`. | Self-documenting; consistent with the existing `check_account_deletable` / `delete-account` vocabulary. Deletion is an account-lifecycle concern (Phase 6 grows it into the cross-system saga), distinct from identity's auth responsibility; `accountdeletion` is the precise bounded name (vs a broad `account` grab-bag). The split is for responsibility isolation + Phase 6 forward-compat, **not** DB least-privilege (roles are shared `peppercheck_app`). |
+| **P3b-D13** | **Persist `email` (+ `email_verified`) on `user_identities`**, captured from the verified token at provisioning and refreshed on login; add `FindUserByEmail`. | Email is not stored today, so match-on-real-account (P3b-D4) is otherwise impossible. Email is a per-provider-identity attribute, so `user_identities` is the conceptually correct, best-practice home (`users` holds no provider data by design). |
+| **P3b-D14** | **Follow the implemented backend conventions, not the Phase 3a *design* assumptions:** `updated_at` is Go-maintained (no `set_updated_at()` trigger), stores hold `*sql.DB` directly (no `Querier`), DB tests are plain assert-SQL in `db/tests/` (not pgTAP). The form-signing key `WEB_FORM_SIGNING_KEY` is a new secret via `lookupEnvOrFile` + 7a's file-secret delivery. | The codebase (verified 2026-07-26) has none of the Phase 3a-designed helpers; coupling 3b to unimplemented 3a work would block it. Keep 3b self-contained on the current conventions. |
+
+---
+
+## 8. Follow-ups (recorded, not built in 3b)
+
+| Item | Owner phase | Notes |
+|------|-------------|-------|
+| tokushoho price via API | Phase 5 | Read from the Go subscription endpoint once `subscription_plans` is the source of truth; add a consistency check then. |
+| Stripe Connect `refresh` re-issues an Account Link | Phase 5 (**cutover release criterion**) | Regenerate the link (`accountLinks.create`) + 302 into onboarding, identifying the account via a short-lived signed `state`; ships with the Go `payout-setup` port. 3b ships a static page (faithful port of current prod). Required before production cutover so onboarding recovers from an expired link. |
+| Consume `account_deletion_requests` | Phase 6 | Email round-trip verification (`unverified` → `verified`), run the deletion saga, per-account verification-email rate limiting. |
+| Cloudflare Turnstile on the deletion form | Optional | Add only if real spam gets past the §4.3 layers. |
+| Default locale `ja` vs `en` | Optional (product) | 3b keeps current default `en`; switching is a product decision, not a URL best-practice change. |
+| "Subscription explanation" content for `pricing` | Optional | Default is a 301 to home; add a home section / static page only if wanted. |
+
+---
+
+## 9. "Done" means
+
+- The 8 keep pages render via Go `html/template` in `ja`/`en`, **preserve the
+  current design**, and emit `hreflang`.
+- The 4 removed routes 301 to localized home. Stripe Connect return/refresh resolve
+  at the fixed paths (including bare, locale-less paths).
+- The account-deletion request resource works **without auth** (store-on-match,
+  uniform response, anti-abuse layers), backed by `account_deletion_requests`.
+- The web has **no Supabase imports** (`peppercheck-webapp/` deleted on the
+  integration branch).
+- Fonts/CSS are embedded and self-hosted; no runtime external-asset fetch.
+- The Web CI gates pass; no CI job reads committed secrets.
+- **Not** in 3b's "done": DNS switch, staging/production droplet verification, and
+  Cloudflare teardown — those are the Phase 7 cutover (3b delivers a cutover-ready
+  state).

--- a/docs/superpowers/specs/2026-07-26-phase4a-flutter-task-authoring-matching-design.md
+++ b/docs/superpowers/specs/2026-07-26-phase4a-flutter-task-authoring-matching-design.md
@@ -1,0 +1,545 @@
+# Phase 4a Flutter — Task Authoring & Matching Client (Design)
+
+> Part of the Supabase → Go API + VPS refactor. Program strategy:
+> `docs/superpowers/specs/2026-07-22-supabase-to-go-vps-refactor-design.md`;
+> Phase 0 baseline `docs/superpowers/specs/2026-07-22-phase0-baseline.md`.
+> This is the **Flutter follow-on** to the Phase 4a **backend** spec
+> `docs/superpowers/specs/2026-07-25-phase4a-task-authoring-matching-design.md`
+> (its §7 API contract is the source of truth for the endpoints consumed here)
+> and its companion `docs/superpowers/specs/2026-07-25-phase4a-follow-ups.md`.
+>
+> Each phase is its own `spec → plan → implementation` cycle; this document
+> covers **Phase 4a Flutter only**. The implementation plan is produced
+> separately by the writing-plans workflow and is not committed.
+>
+> **Design-ahead:** as of writing, the integration branch `refactor/go-api-vps`
+> has Phase 1 + Phase 2 merged; Phase 3a and Phase 4a **backend** are designed
+> but not yet implemented. This spec targets the Phase 4a backend §7 contract and
+> the Phase 3a Flutter client foundation (`ApiClient` write verbs, the `AppUser`
+> current-user contract, the `PresignedUploadClient`/`me_repository` patterns),
+> both of which land before this plan executes.
+
+---
+
+## §0 Scope & Context
+
+Phase 4a ("task authoring + matching") is the first task-lifecycle slice. The
+backend spec ported the server side (Go `service`/`store`/`handler`/worker, async
+matching, availability, notification-send foundation). **This document is the
+Flutter client** that consumes that backend, mirroring the Phase 2/3a
+backend-then-Flutter split.
+
+**Porting philosophy (locked, inherited):** behavior- and concept-preserving
+port; only the *structure* is redesigned (Option E layout, `ApiClient` instead of
+the Supabase SDK, DTOs mirroring the HTTP contract). Clearly-poor client
+implementations may be improved during the port as long as intent is preserved;
+anything dropped or deferred is recorded in §10.
+
+**Transitional narrowing (Phase 2/3a principle):** on the integration branch, the
+downstream lifecycle (evidence → 4b, judgement → 4c) and the point/reward system
+(Phase 5) are not migrated. 4a Flutter makes **task authoring + matching + referee
+availability** work end-to-end against the Go API; downstream sections remain
+non-functional until their phase, which is expected and accepted.
+
+### In scope
+
+- **Task authoring** — create / edit / delete a draft; **publish** (a first-class
+  verb now, `{ refereeCount }`).
+- **Home** — the tasker's own task list and the referee's assignment list.
+- **Task detail (4a portions)** — task info + referee-request states + referee
+  cancel; the screen straddles 4b/4c/report (§2.4, P4aF-D3).
+- **Referee availability** — weekly time slots + blocked dates (mounted on the
+  Profile screen).
+- **Referee-request cancel** — before cutoff → re-match.
+- **Matching config read** — `GET /matching/config` for the cancel-cutoff (§2.2).
+- **Matching notifications** — the 5 loc-keys already exist client-side; verify
+  only (§2.6).
+- **A shared `core` progressive poller** — extracted for the async-matching
+  refresh, reusable across the app (§2.7, P4aF-D6).
+
+### Out of scope (deferred, narrowing)
+
+- **evidence** submission / private-R2 download UI → Phase 4b.
+- **judgement** / rating / threads UI → Phase 4c.
+- **reports** UI (`report_menu_button`) → deferred within Phase 4 (its entry
+  points live inside task/evidence/judgement screens; hidden in 4a, §2.4).
+- **Point cost / wallet / affordability UI** in the publish flow → Phase 5
+  (P4aF-D1). The point system (`billing`) is not migrated in 4a.
+- **`referee_availability` `is_accepting` / `max_concurrent` editing UI** → the
+  imminent availability-cap feature (backend adds the table + matching
+  enforcement only; no editing endpoint in 4a).
+- **IAP/subscription progressive-poll retrofit** onto the new shared poller →
+  Phase 5 (billing/IAP migrates then; §2.7).
+
+---
+
+## §1 Decision Log
+
+| ID | Decision | Rationale |
+|----|----------|-----------|
+| **P4aF-D1** | **Publish screen = an explicit referee-count selector (1..config `maxRefereesPerTask`); send `{ refereeCount }`. Remove all point cost / balance / affordability UI from the publish flow.** Drop the `billing` `get_point_for_matching_strategy` read. The old "matching-strategy selector" widget (which doubled as an implicit count picker and rendered `Npt`) is rebuilt as a count selector. | The point system (`billing`) is not migrated until Phase 5, the backend publish point-lock is a no-op stub in 4a, and the Supabase wallet balance is being torn down — so a cost/affordability UI in 4a would be misleading and depend on removed code. A plain count selector is the least-surprising narrowing; cost/balance re-integrate in Phase 5. Backend collapses `matching_strategy` to a single `standard` and takes an explicit `refereeCount`, so the strategy selector has no remaining product meaning. |
+| **P4aF-D2** | **Async-matching UX = client-side progressive polling** (`[1,1,2,2,3]s`, the established IAP cadence) while any request is `pending`, plus the existing pull-to-refresh / `onResume` invalidation. **FCM drives notification display only** — the FCM receipt is **not** wired to provider invalidation. Screen/data updates are **always** sourced from the Go API. No Realtime. | Backend D3 made matching async (publish → `pending`, worker matches a moment later), so the tasker now sees `pending` immediately where the old DB trigger showed a completed match synchronously. Polling smoothly surfaces the `pending → accepted` transition in-screen; FCM (best-effort, permission-gated, possibly delayed) is a *nudge to look*, not a UI-correctness path. A true server-push (SSE/WebSocket) would require api↔worker coordination (e.g. `LISTEN/NOTIFY`) + persistent connections through Caddy — unjustified operational complexity at pre-launch, single-VPS scale for one transition. Keeping the API the single source of refresh keeps correctness independent of push delivery. |
+| **P4aF-D3** | **Task detail straddles phases; migrate the 4a portions only; the downstream sections are NOT mounted in 4a.** Migrate task info + referee-request states + cancel to the Go API, and migrate the "am I the tasker / the assigned referee" **role check to the Phase 2 `AppUser` (internal UUID) contract**. The evidence (4b), judgement (4c), evidence-timeout, and report sections are **not mounted** in 4a — their mount points remain in the screen as commented markers (`// Phase 4b`/`4c`) re-activated in those phases. **Completion criterion:** `task_detail_screen.dart` and its 4a widgets carry **zero `supabase_flutter` import** and opening a matched task triggers no Supabase call. **Refinement of brainstorming decision 3 (2026-07-26 review):** the earlier "render empty (no Go data)" plan does not remove Supabase — `JudgementSection` / `EvidenceSubmissionSection` read `Supabase.instance.client.auth` *before* their empty-state branch, and an accepted request makes the evidence gate mount them. Not-mounting is the clean way to keep the straddle shell while executing no Supabase path; it stays consistent with the chosen "preserve the composition, downstream non-functional until its phase" intent. | Matches the Phase 2/3a narrowing precedent. The role check via Supabase auth is *already* broken post-Phase-2, so moving it to `AppUser` is required regardless. Not-mounting avoids editing the 4b/4c-owned widgets (scope creep) while guaranteeing no live Supabase reference. |
+| **P4aF-D7** | **The consumed wire contract is pinned in the backend spec §7.1 (camelCase JSON) before Flutter DTOs are written**, and task/assignment responses **embed a minimal `PublicProfile`** (`userId`, `username`, `avatarUrl`) for the tasker and each matched referee. The Flutter side introduces a `PublicProfile` domain + DTO (the Phase-3a-deferred other-user profile), and `Task.tasker` / `RefereeRequest.referee` become `PublicProfile?`. DTOs are **camelCase** (matching the Go API), replacing the old snake_case PostgREST `@JsonKey` mapping. | The review found §7 too coarse to write DTOs test-first, and the home cards / referee cards / detail display avatar+username from the aggregated profile — deleting the PostgREST reshaping requires the Go API to return that profile explicitly. Pinning the contract + embedding the minimal projection makes the DTO tasks executable and keeps the display working without a separate per-user fetch. |
+| **P4aF-D4** | **Backend-mirroring client cleanups:** drop `Task.feeAmount` / `Task.feeCurrency` (backend drops the columns; already dead in the client); remove `matching_strategy` from the client (single `standard`; the selector is gone) and `RefereeRequest.preferredRefereeId`; remove `matched` / `declined` from the client's request-status derivation. The referee-side `'synthetic-id'` fake `RefereeRequest` hack (`fetchActiveRefereeTasks`) is resolved by the real request row returned by `GET /me/assignments`. | Keeps the client contract aligned with the reshaped backend; removes dead/foreign fields and a fragile placeholder. Dropped states/columns are recorded in the backend follow-up doc. |
+| **P4aF-D5** | **Restructure the touched features (`task`, `matching`, `home`) to the Option E layout** (`data/ domain/ application/ ui/`, `*ViewModel` notifiers, DTOs in separate files) as opportunistic refactoring while their data layer is rewritten — mirroring Phase 3a's `profile`/`notification` restructure. Scoped to the migrated features, not a repo-wide rename. | Strategy §15 — improve code you are already touching. Today these use `presentation/` + `*Controller`; Option E brings them in line with `features/auth` and the Phase 3a features. |
+| **P4aF-D6** | **Extract a shared, provider-neutral progressive poller into `core`** (`lib/core/async/progressive_poller.dart`), consumed by matching in 4a. **Do not retrofit the existing IAP/subscription poller in 4a** (billing/IAP migrates in Phase 5, which adopts the shared poller then). | The `[1,1,2,2,3]s` cadence now has ≥2 consumers (IAP subscription refresh + matching); a single primitive removes duplication and standardizes cancellation/backoff. Retrofitting IAP now would pull Phase-5 billing code into 4a scope; deferring keeps the phase boundary clean while still delivering the shared abstraction. |
+
+---
+
+## §2 Feature Design
+
+Global constraints (inherited from Phase 2/3a Flutter):
+
+- **One HTTP client for JSON:** features call `ApiClient`
+  (`lib/core/network/api_client.dart`; Phase 3a added `patchJson`/`postJson`/
+  `putJson`/`deleteJson`); no feature builds its own Dio.
+- **Retry policy:** only idempotent GET auto-retries once on 401;
+  `POST`/`PATCH`/`PUT`/`DELETE` never auto-retry (Phase 2).
+- **`supabase_flutter` must not be imported** by `task` / `matching` / `home`
+  after this plan (CI architecture import check, extending the Phase 2/3a rule).
+- **`firebase_auth` only in `features/auth`** (unchanged). Role checks read the
+  Phase 2 `AppUser` current-user contract, not Firebase/Supabase directly.
+- **DTOs are separate files** mirroring the HTTP contract; the repository maps
+  DTO ↔ domain; domain never imports DTOs.
+- **No `update` method name** on any `AsyncNotifier`-based `*ViewModel`
+  (project rule — `invalid_override`); use domain-specific names.
+- **Spacing** uses `SizedBox` (not per-item `Padding`); use `AppSizes`
+  constants, never hardcoded pixels (project rules).
+- Referee is shown with the localized referee label in the UI (unchanged);
+  internal identifiers stay English `referee`.
+
+### 2.1 `task` — authoring & publish
+
+Rewrite `data/task_repository.dart` onto `ApiClient`; restructure to Option E.
+
+- `POST /tasks` — create a draft (`{ title, description?, criteria?, dueDate? }`).
+- `PATCH /tasks/{id}` — edit own draft.
+- `DELETE /tasks/{id}` — delete own draft.
+- `POST /tasks/{id}/publish` — **new first-class verb**, body `{ refereeCount }`,
+  returns `{ taskId, status: "open", requests: [{ id, status: "pending" }] }`.
+- `GET /tasks/{id}` — task detail + referee-request states.
+- `GET /me/tasks` — own authored tasks (status filter, paging).
+
+Changes:
+
+- **Publish is separated from the status selector.** Today "publish" is
+  implicitly "set status `open` and save via `update_task`". The new UI keeps a
+  draft save (`POST`/`PATCH`) and a distinct **Publish** action that calls
+  `POST /tasks/{id}/publish` with the chosen `refereeCount` (P4aF-D1). Draft
+  open-requirement validation (title, criteria, `dueDate` lead time) is
+  server-authoritative; the client keeps a fast pre-check but surfaces the
+  server's `400` on failure.
+- **Referee-count selector** replaces the strategy selector: 1..N where **N =
+  `matchingConfigProvider.maxRefereesPerTask`** (default 2), not a hard-coded 2
+  (review item 3). While the config is loading, the selector is disabled (or caps
+  at 1); if a previously-selected count exceeds a newly-loaded max, it is clamped
+  down. This prevents the client sending `refereeCount: 2` when the server cap is
+  1. No `Npt` cost, no balance gate (P4aF-D1).
+- `Task` domain drops `feeAmount` / `feeCurrency` and no longer carries
+  `matching_strategy` (P4aF-D4). DTOs are **camelCase** (matching the Go API,
+  P4aF-D7): `TaskDto`, `RefereeRequestDto`, and a `PublicProfileDto` mirror
+  §7.1's JSON; the manual PostgREST join-reshaping (`judgements`→`judgement`,
+  `profiles`→`referee`) and the old snake_case `@JsonKey` mapping are deleted.
+  `Task.tasker` / `RefereeRequest.referee` become `PublicProfile?` (P4aF-D7).
+- Status-derivation (`getDetailedStatuses`) is kept but pruned: `matched` /
+  `declined` removed; evidence/judgement-derived states become inert in 4a (no
+  data) and are re-enabled in 4b/4c.
+
+### 2.2 `matching` — availability, cancel, config
+
+Rewrite `data/matching_repository.dart` onto `ApiClient`; restructure to Option E.
+
+- **Time slots:** `GET/POST/PUT/DELETE /me/availability/time-slots`. Domain
+  `RefereeAvailableTimeSlot` (dow, startMin, endMin, isActive) unchanged. The
+  read continues to show active slots; the active/inactive toggle UI stays
+  deferred (matches the backend "editing deferred" stance).
+- **Blocked dates:** `GET/POST/PUT/DELETE /me/availability/blocked-dates`. Domain
+  `RefereeBlockedDate` (startDate, endDate, reason?) unchanged.
+- **Cancel:** `POST /referee-requests/{id}/cancel` (assigned referee only, before
+  cutoff → re-match). Replaces the Supabase `cancel_referee_assignment` RPC.
+- **Cancel cutoff via config (P4aF-D2/config):** replace the hard-coded
+  `kRefereeCancelDeadlineHours = 12` client mirror with a read of
+  `GET /matching/config` (`cancel_deadline_hours`), cached; the button visibility
+  computes the cutoff from the fetched config. Server remains authoritative (the
+  cancel `POST` still rejects past-cutoff); the config read only removes client
+  drift. `matching_constants.dart` is removed (or reduced to non-deadline
+  constants if any remain).
+- `RefereeRequest` domain drops `preferredRefereeId` (P4aF-D4).
+
+### 2.3 `home` — task list & assignment list
+
+- `activeUserTasksProvider` → `TaskRepository.fetchMyTasks()` (`GET /me/tasks`);
+  `activeRefereeTasksProvider` → **`MatchingRepository.fetchMyAssignments()`**
+  (`GET /me/assignments`) — assignments are a matching-owned resource, so the call
+  lives in `MatchingRepository`, not `TaskRepository` (review item 4); the matching
+  repository foundation is therefore built **before** home consumes it. Both via
+  `ApiClient`; Supabase removed.
+- The referee assignment list now carries **real request rows** (id, status,
+  matched referee) with the embedded `tasker` `PublicProfile` from
+  `GET /me/assignments`, deleting the `'synthetic-id'` placeholder (P4aF-D4).
+- Existing refresh triggers (pull-to-refresh, `AppLifecycleListener.onResume`
+  invalidation) are preserved. The publish → pending → accepted transition adds
+  progressive polling (§2.7 / §3).
+
+### 2.4 Task detail straddle (P4aF-D3)
+
+`task_detail_screen.dart` composes 4a and downstream sections. In 4a:
+
+- **Migrated (Go API):** `task_detail_info_section`, `tasker_referees_section`
+  (request states), `withdraw_matching_button` (cancel), and the current-user /
+  role check.
+- **Role check → `AppUser`:** replace every `Supabase.instance.auth` /
+  Supabase-uid comparison ("am I the tasker / the assigned referee") with the
+  Phase 2 current-user contract (internal UUID). This is required, not optional
+  (the Supabase auth path is gone post-Phase-2).
+- **Downstream sections (evidence 4b / judgement 4c / evidence-timeout):** **not
+  mounted** in 4a (P4aF-D3). Their mount points stay as commented markers
+  (`// Phase 4b`/`4c`) and return when those phases migrate the widgets to the Go
+  API. This is required (not just cosmetic): `JudgementSection` /
+  `EvidenceSubmissionSection` read `Supabase.instance.client.auth` before their
+  empty-state branch, and an accepted request would otherwise mount the evidence
+  section — so "render empty" cannot avoid a live Supabase call; not-mounting can.
+- **Report menu:** not mounted in 4a.
+- **Completion criterion:** `grep supabase_flutter` over `task_detail_screen.dart`
+  and its 4a widgets is empty; opening a matched task issues no Supabase call.
+
+### 2.5 Current-user / role (concrete)
+
+Today role decisions read the **Supabase auth uid** directly, scattered across
+widgets:
+
+```dart
+// task_detail_screen.dart
+if (Supabase.instance.client.auth.currentUser?.id == displayTask.taskerId) ...
+// withdraw_matching_button.dart — each widget resolves it itself
+final userId = Supabase.instance.client.auth.currentUser?.id;
+for (final r in task.refereeRequests) { if (r.matchedRefereeId == userId) return r; }
+```
+
+**Why the swap is a drop-in:** after Phase 2 + the 4a backend, `task.taskerId`
+and `refereeRequest.matchedRefereeId` are **internal UUIDs** (`users(id)`), and
+the Phase 2 `AppUser.internalUserId` is that same internal UUID — the ID spaces
+match, so only the *source* of the current id changes.
+
+**Target — hybrid (pure derivation + a thin provider).** The derivation is a
+**pure, Riverpod-neutral** function on the domain (unit-testable without a
+container); a thin `taskRoleProvider` **composes** the two async sources and
+delegates to it, and the (already-`Consumer`) widgets `ref.watch` the provider —
+no prop-drilling, and the role stays live-correct as polling updates the task.
+
+```dart
+// lib/features/task/domain/task_viewer_role.dart  (the tested core — no Riverpod)
+class TaskViewerRole {
+  final bool isTasker;
+  final RefereeRequest? myRequest;          // the request matched to me, or null
+  const TaskViewerRole({required this.isTasker, required this.myRequest});
+  bool get isAssignedReferee => myRequest != null;
+}
+extension TaskRoleX on Task {
+  TaskViewerRole viewerRole(String? internalUserId) {
+    if (internalUserId == null) return const TaskViewerRole(isTasker: false, myRequest: null);
+    return TaskViewerRole(
+      isTasker: taskerId == internalUserId,
+      myRequest: refereeRequests
+          .where((r) => r.matchedRefereeId == internalUserId).firstOrNull,
+    );
+  }
+}
+
+// lib/features/task/ui/task_role_provider.dart  (thin — no logic, just composition)
+@riverpod
+Future<TaskViewerRole> taskRole(Ref ref, String taskId) async {
+  final task = await ref.watch(taskDetailProvider(taskId).future); // §2.7 owner
+  final me   = await ref.watch(currentAppUserProvider.future);     // Phase 2 contract
+  return task.viewerRole(me?.internalUserId);                      // delegate to the pure fn
+}
+
+// widgets (already ConsumerWidgets) watch it directly — no params threaded down:
+final role = ref.watch(taskRoleProvider(taskId));
+role.whenData((r) { if (r.isTasker) /* mount TaskerRefereesSection */ });
+// WithdrawMatchingButton reads taskRoleProvider(task.id).myRequest itself.
+```
+
+- **Not over-engineering here:** the role is needed by ~3 detail-tree widgets that
+  are already `Consumer`s and composes two async sources — a provider removes
+  prop-drilling and unifies `loading`/`error` as `AsyncValue`, matching how the
+  task itself is consumed. The derivation logic stays in the **pure function**
+  (keeping the provider a ~5-line delegate and the logic container-free testable);
+  it would only be over-engineering if the logic lived *in* the provider or the
+  role were needed in a single place.
+- **Composition ordering:** `taskRoleProvider` watches `taskDetailProvider` (the
+  §2.7 poll-state owner) + `currentAppUserProvider`, so the poller + `taskDetail`
+  notifier are built **before** the role provider and the detail-screen migration.
+- **Single source:** `currentAppUserProvider` (`AsyncValue<AppUser?>`,
+  `features/auth`). The detail screen is post-login, so `internalUserId` is
+  available; the `loading` / `null` case degrades to "no role-specific sections".
+- **Pure derivation → unit-testable** without Riverpod (tasker / assigned-referee
+  / neither branches).
+- **Repository-side auth reads vanish:** the `_client.auth.currentUser?.id` uses
+  in `task_repository` (own-task filter; the synthetic-request self-id injection)
+  disappear because `GET /me/tasks` / `GET /me/assignments` scope by the
+  server-side `CurrentUser` — the client no longer supplies its own id.
+- No new endpoint; `GET /api/v1/me` (Phase 2) already provides identity.
+
+### 2.6 Notifications (verify-only)
+
+- The 5 matching loc-keys already resolve client-side via
+  `notification/application/notification_text_resolver.dart` and the generated
+  `slang` catalog: `notification_request_matched_tasker`,
+  `notification_task_assigned_referee`,
+  `notification_matching_reassigned_tasker`,
+  `notification_matching_cancelled_pending_tasker`,
+  `notification_matching_expired_refunded_tasker` (each `_title` / `_body`).
+- **4a Flutter adds no new i18n.** Verify the `locArgs` ordering
+  (`[0]`=taskTitle, `[1]`=deadline) matches what the Go `send_notification`
+  worker emits (backend §8). The FCM **token-sync** path is Phase 3a's concern,
+  not re-touched here. FCM stays notification-display only (P4aF-D2).
+
+### 2.7 `core` progressive poller (P4aF-D6)
+
+A provider-neutral primitive extracted to `lib/core/async/progressive_poller.dart`:
+
+```dart
+/// Polls [fetch] on a backoff [schedule] until [isDone] or cancellation.
+/// After the schedule is exhausted, polling stops (bounded, no infinite loop).
+Future<T> pollUntil<T>({
+  required Future<T> Function() fetch,
+  required bool Function(T) isDone,
+  List<Duration> schedule = kDefaultProgressiveSchedule, // [1,1,2,2,3]s
+  CancellationToken? cancel, // stop on screen dispose / navigation away
+});
+```
+
+- **Matching consumer — state owner (P4aF-D2, review-refined):** the poll runs on
+  the **task-detail screen only** (not `home`; home keeps pull-to-refresh /
+  `onResume` invalidation + the FCM nudge — polling every home card is heavier and
+  unnecessary). The existing `taskProvider(id)` is a read-only `FutureProvider`,
+  so it cannot hold poll-updated state; 4a introduces a **`taskDetail` codegen
+  `AsyncNotifier` family** (`@riverpod class TaskDetail extends _$TaskDetail`,
+  family-keyed by `taskId`) that owns the task state. Its `pollUntilMatched()`
+  runs `pollUntil(fetch: repo.getTask(taskId), isDone: (t) => t.refereeRequests
+  .every((r) => r.status != 'pending'))` and, **per Riverpod v3**, guards every
+  post-`await` write with `if (!ref.mounted) return;` before `state = AsyncData(t)`
+  and cancels the `CancellationToken` via `ref.onDispose(token.cancel)` (verified
+  against the Riverpod v3 docs — `ref.mounted`, `ref.onDispose`). The poll is
+  bounded by the schedule and cancelled on dispose; it starts after a successful
+  publish and when opening a still-`pending` task.
+- **IAP retrofit deferred to Phase 5** (P4aF-D6): the existing
+  `in_app_purchase_controller` poller is left untouched in 4a and adopts this
+  primitive when billing/IAP migrates.
+
+---
+
+## §3 Async-Matching UX (detail)
+
+Old behavior: publish ran matching synchronously in a DB trigger, so returning to
+`home` showed an already-matched task. New behavior: publish returns `pending`;
+the worker matches shortly after.
+
+Client flow after a successful publish:
+
+1. Publish returns `{ status: "open", requests: [pending…] }`; the UI shows the
+   task as matching in progress (`pending`).
+2. The **progressive poller** (§2.7) runs `[1,1,2,2,3]s`, re-fetching until every
+   request leaves `pending` (→ `accepted` or, past cutoff, `expired`), or the
+   schedule ends, or the user leaves the screen (cancellation).
+3. On `accepted`, the referee card / status updates in-place to show that a
+   referee was found.
+4. If the schedule ends still-pending (rare; slow worker/outage), the user can
+   pull-to-refresh, and `onResume` re-invalidates on return; the FCM
+   `request_matched_tasker` push (backend-sent) nudges the user to reopen.
+
+Data correctness is always API-sourced; FCM is display-only (P4aF-D2). No
+Realtime, no `LISTEN/NOTIFY`, no api↔worker push channel.
+
+---
+
+## §4 API Contract Consumed (mirror of backend §7)
+
+| Method & path | Purpose | Client site |
+|---------------|---------|-------------|
+| `POST /tasks` | create draft | task_repository |
+| `PATCH /tasks/{id}` | edit own draft | task_repository |
+| `DELETE /tasks/{id}` | delete own draft | task_repository |
+| `POST /tasks/{id}/publish` | publish → pending (`{refereeCount}`) | task_repository |
+| `GET /me/tasks` | own authored tasks | home |
+| `GET /tasks/{id}` | task detail + request states | task detail |
+| `GET /me/assignments` | tasks the caller referees | home |
+| `POST /referee-requests/{id}/cancel` | cancel assignment → re-match | matching |
+| `GET/POST/PUT/DELETE /me/availability/time-slots` | weekly slots | matching |
+| `GET/POST/PUT/DELETE /me/availability/blocked-dates` | blocked dates | matching |
+| `GET /matching/config` | deadline settings (cancel cutoff) | matching |
+
+All errors use the Phase 2 stable envelope `{ error: { code, message, requestId } }`
+→ `ApiException`. `GET /api/v1/me` (identity) is Phase 2, unchanged.
+
+---
+
+## §5 Option E Restructure (P4aF-D5)
+
+Per feature, while the data layer is rewritten (`presentation/` + `*Controller`
+→ `data/ domain/ application/ ui/` + `*ViewModel`, DTOs separate):
+
+```
+lib/features/task/
+  domain/task.dart                     # no feeAmount/feeCurrency/matching_strategy
+  domain/task_creation_request.dart    # + refereeCount on publish
+  data/task_dto.dart                    # mirrors Go JSON (no PostgREST reshaping)
+  data/task_repository.dart             # ApiClient-backed; no supabase_flutter
+  application/…                         # publish orchestration if warranted
+  ui/task_creation_screen.dart
+  ui/task_creation_view_model.dart      # was *Controller
+  ui/task_detail_screen.dart
+  ui/task_detail_view_model.dart
+  ui/widgets/…                          # referee-count selector replaces strategy
+lib/features/matching/
+  domain/referee_request.dart           # drop preferredRefereeId
+  domain/referee_available_time_slot.dart / referee_blocked_date.dart
+  data/*_dto.dart + matching_repository.dart  # ApiClient; no supabase_flutter
+  data/matching_config_dto.dart          # GET /matching/config
+  ui/…_view_model.dart / widgets/…
+lib/features/home/
+  ui/home_view_model.dart                # lists via task/matching repos (no poll; poll is detail-only)
+lib/features/task/ui/task_detail_view_model.dart  # AsyncNotifier owner; runs the poll (detail-only)
+lib/core/async/progressive_poller.dart   # shared (P4aF-D6)
+```
+
+Follow the existing `features/auth` and the Phase 3a `profile`/`notification`
+structure as templates.
+
+---
+
+## §6 Transitional Narrowing — "runnable" after 4a Flutter
+
+On the integration branch, after this plan the app:
+
+- ✅ builds and launches; signs in and resolves the internal user (Phase 2);
+  profile / FCM-token work (Phase 3a);
+- ✅ **task authoring** works via the Go API: create/edit/delete a draft, publish
+  (→ pending), see it become accepted (progressive polling);
+- ✅ **home** shows own tasks and referee assignments from the Go API;
+- ✅ **referee availability** (time slots / blocked dates) editable via the Go API;
+- ✅ **cancel** an assignment before cutoff → re-match;
+- ⏸ **evidence / judgement / reports / points** remain non-functional until their
+  phases (expected, §0). Their sections of the task-detail screen are **not
+  mounted** in 4a (re-mounted in 4b/4c); the report menu is not mounted.
+
+`Supabase.initialize(...)` **remains** in startup for still-un-migrated features;
+`task` / `matching` / `home` stop importing `supabase_flutter` (CI import check).
+
+---
+
+## §7 Testing & CI
+
+**Flutter unit / widget:**
+
+- **task:** `TaskDto` ↔ `Task` mapping (no fee/strategy fields); repository calls
+  (`POST/PATCH/DELETE /tasks`, `POST /tasks/{id}/publish` **sends `refereeCount`**,
+  `GET /tasks/{id}`, `GET /me/tasks` **paging over `nextCursor`**) against a fake
+  `ApiClient`; publish view-model happy path + server `400` open-requirement
+  error; referee-count selector bounds (**1..config `maxRefereesPerTask`**, clamp
+  + loading).
+- **status derivation:** `Task.getDetailedStatuses` on the **4a data shape**
+  (`judgement`/`evidence` always null), **pending-first** (matches the poll's
+  `isDone`) — tasker: any pending → `matching`; else any accepted →
+  `matching_complete`; else all expired → `matching_failed` (so `[accepted,
+  pending]` → `matching`, not `matching_complete`); referee: `matching` (pending),
+  `matching_complete` (accepted), inactive (expired). Must not infer `matching`
+  from a null judgement. (Display state `matching_complete`, **not** the deleted
+  request status `matched`.)
+- **matching:** availability CRUD mapping + calls; cancel calls
+  `POST /referee-requests/{id}/cancel`; cancel-button visibility uses the
+  **config-fetched** cutoff (not a constant); `GET /matching/config` mapping.
+- **home:** `GET /me/tasks` / `GET /me/assignments` mapping (**multi-page**); the
+  assignment list carries real request rows (no `'synthetic-id'`).
+- **progressive poller (core):** stops on `isDone`; stops when the schedule is
+  exhausted (bounded); stops on cancellation (no poll after dispose); the
+  matching consumer transitions pending → accepted and halts.
+- **task detail:** role check reads `AppUser` via `taskRoleProvider` (tasker vs
+  referee vs neither); evidence/judgement/report sections **not mounted**; opening
+  a matched task issues **no Supabase call**.
+- **Option E / rules:** each `*ViewModel` success/error; no `update` method name;
+  `SizedBox` spacing / `AppSizes` (lint-guarded).
+
+**CI gates:** dart format, `flutter analyze`, `flutter test`, **architecture
+import checks** (`supabase_flutter` not imported by `task`/`matching`/`home`; Dio
+construction only in `core/network`), flavored debug build
+(`flutter build apk --debug -t lib/main_dev.dart`). Per project convention the PR
+runs `flutter build` only; a **single emulator pass** runs at the end on the
+integration branch (§9).
+
+---
+
+## §8 PR Breakdown
+
+**One Flutter PR** into `refactor/go-api-vps` (operator preference — easier to
+grasp as a unit); the branch stays buildable. Internal task ordering matches the
+plan's **T1–T12** (see the plan for full detail):
+
+1. **T1** domain cleanup — `PublicProfile`, `TaskViewerRole`, 4a status
+   derivation, drop fee/strategy fields (+ type-ripple consumers).
+2. **T2** task DTOs (camelCase) + repository over `ApiClient` (publish, paging).
+3. **T3** matching repository foundation — config + assignments + cancel
+   (`MatchingRepository` gains `ApiClient`, keeps Supabase for availability).
+4. **T4** `home` lists over the Go API (consumes T2 + T3 — hence T3 precedes T4).
+5. **T5** `task` Option E restructure + config-bounded referee-count publish UI.
+6. **T6** `core` progressive poller.
+7. **T7** `taskDetail` `AsyncNotifier` family + matching-result polling.
+8. **T8** `taskRoleProvider` + task-detail role migration; downstream not mounted.
+9. **T9** `matching` availability + Option E (removes Supabase from matching).
+10. **T10** config-driven withdraw button (cancel).
+11. **T11** matching notification loc-key verification.
+12. **T12** CI import checks + full analyze/test + single emulator pass.
+
+*Optional split* if review grows too large (mirrors the Phase 3a escape hatch):
+split T1–T5 (task/home/matching data) from T6–T10 (poller/detail/availability).
+
+**Depends on:** Phase 4a **backend** (endpoints live) and the Phase 3a **Flutter**
+merge (`ApiClient` write verbs, `AppUser` current-user contract). Execute after
+both are in place. Until then this is design-ahead.
+
+---
+
+## §9 Done Criteria (Phase 4a Flutter)
+
+- [ ] A tasker can create / edit / delete a draft and **publish** (`refereeCount`)
+      via the Go API; the task shows `pending`, then `accepted` via progressive
+      polling (no manual refresh needed while on-screen).
+- [ ] `home` shows own tasks (`GET /me/tasks`) and referee assignments
+      (`GET /me/assignments`) with **real** request rows; no `'synthetic-id'`.
+- [ ] A referee edits availability (time slots / blocked dates) and cancels an
+      assignment before cutoff (→ re-match); the cancel cutoff comes from
+      `GET /matching/config`.
+- [ ] Task detail's role check reads the Phase 2 `AppUser` contract via
+      `taskRoleProvider`; evidence / judgement / report sections are **not
+      mounted**; no Supabase call is made when opening a matched task.
+- [ ] `task` / `matching` / `home` follow the Option E layout and no longer
+      import `supabase_flutter` (CI import check passes).
+- [ ] The publish flow shows **no** point cost / balance UI (Phase 5 re-adds).
+- [ ] The shared `core` progressive poller is bounded and cancelable; the matching
+      consumer uses it; the IAP poller is untouched (Phase 5 retrofit).
+- [ ] The 5 matching notification loc-keys resolve with correct `locArgs`.
+- [ ] CI gates pass; a single emulator pass verifies the end-to-end flow.
+
+**Not** 4a Flutter criteria: evidence, judgement, rating, reports UI, point
+cost/wallet, availability accepting/concurrency editing, IAP poller retrofit.
+
+---
+
+## §10 Out of Scope / Follow-ups
+
+- **evidence UI** → Phase 4b. **judgement / rating UI** → Phase 4c.
+- **reports UI** → deferred within Phase 4 (entry points live inside
+  task/evidence/judgement screens; hidden in 4a).
+- **Point cost / wallet / affordability UI in publish** → Phase 5 (with the
+  billing migration).
+- **`referee_availability` accepting-toggle / concurrency-cap editing UI** → the
+  imminent availability-cap feature.
+- **IAP/subscription progressive-poll retrofit** onto the shared `core` poller →
+  Phase 5.
+- **Server-side notification localization** (backend follow-up) would let the
+  client stop resolving loc-keys; out of scope here, tracked in the backend
+  follow-up doc.
+- **Active/inactive time-slot toggle UI** → whenever that editing feature ships
+  (backend reads active slots only today).

--- a/docs/superpowers/specs/2026-07-26-phase4b-evidence-private-r2-design.md
+++ b/docs/superpowers/specs/2026-07-26-phase4b-evidence-private-r2-design.md
@@ -1,0 +1,410 @@
+# Phase 4b — Evidence & Private R2 (Design)
+
+> Part of the Supabase → Go API + VPS refactor. See the strategy doc
+> `docs/superpowers/specs/2026-07-22-supabase-to-go-vps-refactor-design.md`, the
+> Phase 0 baseline `docs/superpowers/specs/2026-07-22-phase0-baseline.md`, and the
+> Phase 4a spec `docs/superpowers/specs/2026-07-25-phase4a-task-authoring-matching-design.md`.
+> Each phase is its own `spec → plan → implementation` cycle.
+
+## §0 Scope & Context
+
+Phase 4 ("core task lifecycle") is decomposed into three sub-phases along the
+state machine (P4a-D1):
+
+- **4a — task authoring + matching** (done: spec written).
+- **4b — evidence + private R2** (this document): upload intents, submit / update
+  / resubmit, evidence-timeout, **authorized presigned downloads from a private
+  R2 bucket**, evidence deadline reminders, R2 stale-object hygiene.
+- **4c — judgement + rating** (judge, confirm, reopen, threads, auto-confirm,
+  review timeouts, rating).
+
+**This document covers 4b backend only.** The Flutter client for evidence is a
+separate follow-on `spec → plan` cycle (mirroring Phase 2 / 3a / 4a).
+
+**Porting philosophy (locked, inherited from 4a):** behavior- and
+concept-preserving port; only the *structure* is redesigned (Go
+`service`/`store`/`handler`/worker, DTOs, no *business* DB functions/triggers —
+`updated_at` is maintained by the common `set_updated_at()` trigger per P3a-D11 /
+P4a-D15, not by Go). Clearly-poor implementations may be improved during the Go
+port as long as the intent is preserved. Anything dead, no-op, or deliberately
+deferred is recorded in §11 Follow-ups rather than silently carried or dropped.
+
+**Transitional narrowing (Phase 2 / 4a principle):** on the integration branch
+the Go point/reward system (Phase 5) and the judgement lifecycle beyond
+`awaiting_evidence` (4c) do not exist yet. 4b implements the full evidence
+lifecycle it owns, expressing its dependencies on 4c (`rejected` state, task
+closure) and Phase 5 (point consume + referee reward on evidence-timeout) as **Go
+interface seams with no-op stubs**. 4c and Phase 5 arrive by swapping the wiring,
+without changing evidence code. Code paths that require a state only 4c produces
+(resubmit needs `rejected`) are built but **dormant** until 4c ships — the same
+forward-build pattern 4a used for `in_review` (produced by 4b, consumed by 4c).
+
+**Dependencies on prior phases:**
+- Phase 2 — Firebase token verify + internal user UUID; stable error envelope.
+- Phase 3a — `platform/r2` presigned-PUT adapter (`PresignPut` / `Head` /
+  `Delete`, avatar public-domain served); `CurrentUser(ctx)` auth middleware;
+  `notification_settings` (already carries `evidence_reminder_minutes int[]
+  NOT NULL DEFAULT '{10}'`, `evidence_reminder_even_if_submitted`); the
+  `send_notification` outbox/worker foundation groundwork; `set_updated_at()`.
+- Phase 4a — `tasks`, `referee_requests`, `judgements` (created
+  `awaiting_evidence` on match); `internal/task`, `internal/matching`,
+  `internal/notification` (send path + `platform/fcm`); the `core` UoW tx helper
+  + `database.Querier`; the leased-jobs primitive (+ `EnqueueInTx`).
+
+## §1 Decision Log
+
+| ID | Decision | Rationale |
+|----|----------|-----------|
+| **P4b-D1** | **Implement the full evidence lifecycle in 4b as forward-build with seams** (upload intents, submit, update, resubmit, evidence-timeout detection + confirm, authorized downloads). `rejected` (4c) and point/reward settlement (Phase 5) are Go interface seams with no-op stubs. | Matches 4a §0's assignment of submit/resubmit/evidence-timeout to 4b and the established transitional-narrowing pattern (4a builds `in_review` with no consumer until 4c). Keeps 4c/Phase 5 as pure wiring swaps. |
+| **P4b-D2** | **Private-bucket downloads = the Go API issues short-lived presigned GET URLs after authorization and embeds them in the read response.** `platform/r2` gains `PresignGet`. The client never receives R2 keys or credentials; presigned URLs are generated per-read, never persisted. | Resolves the launch-blocker (baseline §5.3 #5: evidence must not use a public domain). Matches the engineering policy ("the Go API issues presigned URLs; never hand keys to the client"). R2 keeps serving the bytes (edge delivery, no API bandwidth bottleneck). S3 presigning is a **local HMAC operation** (no R2 round-trip), so embedding URLs in reads is cheap. Authorization happens once, in the Go API. |
+| **P4b-D3** | **Evidence uses a new, dedicated private R2 bucket.** Avatars stay on the existing public bucket + public domain (3a unchanged). The stale-object sweep targets both buckets (via two feature-owned workers, P4b-D7). | Sensitivity-appropriate separation. R2 cannot cleanly make one prefix private and another public under a single public custom domain, so prefix-mixing on one bucket does not work. Avatars are intentionally public (P3a-D6) — shown to many people in many contexts; evidence is private. |
+| **P4b-D4** | **Drop unused evidence columns/enums** (recorded in §11): `public_url` → drop (private bucket; presigned GET generated on read); `file_url` → consolidate into a single `object_key` (R2 key only); `processing_status` / `error_message` → drop (no server-side image pipeline — normalization is client-side, `ImageNormalizer`, JPEG re-encode); `evidence_status` enum (`pending_upload` / `ready`) → drop (`pending_upload` is never persisted — `submit_evidence` inserts `ready` directly; a row's existence *is* "ready"). | Dead data/scaffolding; the Phase 7 reset removes any migration cost. The two-phase upload-status was designed but never used (the client uploads to R2 first, then submits metadata). |
+| **P4b-D5** | **Drop the `task_` prefix: `task_evidences` → `evidences`, `task_evidence_assets` → `evidence_assets`** (the 4a follow-up for evidences). | The task linkage is the `task_id` FK; the prefix is redundant. Consistent with 4a's `task_referee_requests` → `referee_requests`. |
+| **P4b-D6** | **Evidence is a task-singleton in the API: `/tasks/{id}/evidence` (singular), no top-level `/evidence/{id}`.** The table stays plural (`evidences`). | Evidence is exactly one per task (task-level, shared across all referees; submit creates it, update/resubmit edit it) and "evidence" is an uncountable noun — both point to a singular singleton path. Matches the in-repo precedent 3a `profiles` (plural table) ↔ `/me/profile` (singular singleton API): table plurality and API-resource singularity follow independent conventions. `judgements` stays plural + id-addressed because it is genuinely N-per-task (per referee). |
+| **P4b-D7** | **Two feature-owned stale-object sweeps, not one shared cron:** `sweep_evidence_objects` in `internal/evidence` (age-based, private bucket) and `sweep_orphan_avatars` in `internal/profile` (orphan-based, public bucket). | The legacy single `sweep-r2-stale-objects` cron mixed two features. Splitting is correct regardless of future upload contexts: different buckets, different retention logic (evidence = 90-day age; avatar = "not the current `avatar_url`" orphan with a grace period), and feature ownership (an evidence sweep reaching into `profiles` is a cross-feature reach). New upload contexts each get their own feature-owned sweep instead of growing a central grab-bag. |
+| **P4b-D8** | **Evidence-timeout settlement splits by concern.** The `detect_evidence_timeouts` worker owns the `awaiting_evidence → evidence_timeout` transition, the referee-request close, and both notifications. The **financial settlement (consume tasker's locked points + grant referee reward) is a Phase 5 seam** (`EvidenceTimeoutSettler`), no-op in 4b. `confirm_evidence_timeout` sets `is_confirmed` and calls a **4c task-closure seam** (no-op in 4b). | Mirrors 4a's split (its sweep does "expire → refund via seam → notify"): the worker owns the state machine + notifications; only the point/reward math is deferred to Phase 5. Task closure (open → closed on all judgements confirmed) is 4c, exactly as in 4a. |
+| **P4b-D9** | **Enforce the task-singleton at the DB layer: `UNIQUE (task_id)` on `evidences`;** a `23505` on insert maps to `409 conflict`. Submit's judgement transition must affect ≥1 row or the whole tx rolls back. | The state gate (submit requires an `awaiting_evidence` judgement) does not stop two concurrent submits from both passing the gate and both inserting an evidence row before either commits. A unique constraint makes double-create impossible regardless of interleaving; the transition-rowcount check closes the submit-vs-timeout race (a submit whose judgements a concurrent `evidence_timeout` already moved must not create evidence). (Review 2026-07-26 #1, #3.) |
+| **P4b-D10** | **Server-verified, task-bound object keys.** The upload key is `evidence/{due-date}/{task-id}/{uuid}.{ext}` (task-scoped, not just date+uuid). On submit/update/resubmit the server (a) rejects any `objectKey` whose prefix does not match the target task, and (b) calls `r2.Head` to confirm the object exists and to read its **actual** `Content-Type` and size — the DB stores the **R2-reported** metadata, never the client-supplied values. `evidence_assets` carries `UNIQUE (object_key)`. | The legacy `generate-upload-url` trusted client-submitted asset metadata and used a task-agnostic key, so a client could persist an arbitrary/other-task/nonexistent key with spoofed size/type. Task-binding + `Head` (already available in `platform/r2` from 3a's finalize backstop) closes this; a "clearly-poor implementation improved during the port" per §0. (Review 2026-07-26 #2.) |
+| **P4b-D11** | **Evidence retention = image-file purge at 90 days, records retained (matches the privacy policy).** The privacy policy commits to: *evidence image files are auto-deleted 90 days after the task due date*, while *task-related content (incl. evidence text/metadata) is retained anonymized*. So `sweep_evidence_objects` deletes the **R2 object** for any asset whose task `due_date` is >90 days past and sets `evidence_assets.purged_at`; it **keeps the DB rows**. `ViewForTask` returns purged assets with no `downloadUrl` and a `purged` flag; the client renders an empty/"deleted" frame. A separate orphan pass deletes **unreferenced** objects (abandoned uploads, or objects removed by update/resubmit) older than a short grace period. | The legacy sweep deleted objects by age but left the DB rows, breaking references (the public URL 404'd too) — a latent bug. Deleting the DB rows as well (data-minimization) would contradict the policy's "evidence retained anonymized." Purge-object-keep-record + graceful empty-frame is the faithful, correct implementation of the stated policy (privacy `retention.evidenceFiles`). (Review 2026-07-26 #4.) |
+| **P4b-D12** | **Evidence invariants: at least one asset always; `due_date > now()` enforced on every evidence write.** Submit requires ≥1 asset; update/resubmit must not remove the last asset (reject if the result would be zero). `due_date > now()` is checked inside the submit **and** update transactions (not only at upload-URL issuance); resubmit already checks it. | Ports the legacy `validate_evidence_due_date` trigger, which fired on evidence **INSERT and UPDATE** (an upload URL minted before the deadline could otherwise be submitted after it). The ≥1-asset rule prevents a meaningless empty evidence record. (Review 2026-07-26 #5, additional.) |
+
+## §2 Data Model
+
+Atlas table-only for *business* logic (no business DB functions/triggers).
+`updated_at` is maintained by the common `set_updated_at()` trigger (P3a-D11,
+P4a-D15) — every new table carries it. FKs target the Go identity core
+`users(id)` (Phase 2) and `tasks(id)` (Phase 4a). Full deletion semantics are
+Phase 6 (the FKs below are `ON DELETE CASCADE` from the task, matching today).
+
+```
+evidences                          (was task_evidences)
+  id           uuid PK  DEFAULT gen_random_uuid()
+  task_id      uuid NOT NULL → tasks(id) ON DELETE CASCADE
+  description  text NOT NULL
+  created_at   timestamptz NOT NULL DEFAULT now()
+  updated_at   timestamptz NOT NULL DEFAULT now()      -- set_updated_at trigger
+  -- task-level: one evidence per task, shared across all referees.
+  -- `evidence_status` enum dropped (P4b-D4); a row's existence == "ready".
+  UNIQUE (task_id)                       -- singleton enforced (P4b-D9); 23505 → 409
+
+evidence_assets                    (was task_evidence_assets)
+  id              uuid PK  DEFAULT gen_random_uuid()
+  evidence_id     uuid NOT NULL → evidences(id) ON DELETE CASCADE
+  object_key      text NOT NULL          -- R2 key in the private evidence bucket
+                                         -- (consolidates file_url + public_url)
+                                         -- format: evidence/{due-date}/{task-id}/{uuid}.{ext} (P4b-D10)
+  file_size_bytes bigint NOT NULL        -- R2-reported (from Head), not client input (P4b-D10); >0
+  content_type    text   NOT NULL        -- R2-reported (from Head), re-checked against the allow-list (P4b-D10)
+  purged_at       timestamptz            -- set when the 90-day sweep deletes the R2 object (P4b-D11); NULL = live
+  created_at      timestamptz NOT NULL DEFAULT now()
+  updated_at      timestamptz NOT NULL DEFAULT now()   -- set_updated_at trigger
+  UNIQUE (object_key)                    -- (P4b-D10)
+  INDEX (evidence_id)
+```
+**Dropped vs the legacy schema** (→ §11): `task_evidences.status` +
+`evidence_status` enum; `task_evidence_assets.public_url`,
+`.file_url` (→ `object_key`), `.processing_status`, `.error_message` and their
+indexes.
+
+**Multi-referee:** evidence is task-level. `submit` transitions **all** of the
+task's `awaiting_evidence` judgements to `in_review`; the referee notification is
+sent to every matched referee.
+
+## §3 State Machine & Reachability (within 4b)
+
+The judgement rows are created `awaiting_evidence` by 4a on match. 4b drives the
+evidence-adjacent transitions:
+
+```
+awaiting_evidence ──(submit_evidence)──────────────▶ in_review ──(4c: judge)──▶ …
+        │                                                 ▲
+        │                                        (update_evidence: edit in place,
+        │                                         no state change, no reopen)
+        │
+        └──(detect_evidence_timeouts: due_date passed, no evidence)──▶ evidence_timeout
+                                                                            │
+                                              (confirm_evidence_timeout)────┘ is_confirmed=true
+                                                                            → 4c closure seam
+
+rejected ──(resubmit_evidence: reopen_count<1)──▶ in_review     [DORMANT until 4c]
+```
+
+| Transition | Trigger | Reachable in 4b? |
+|---|---|---|
+| `awaiting_evidence → in_review` | submit_evidence | ✅ (4a produces `awaiting_evidence`) |
+| in-review edit (no reopen) | update_evidence | ✅ |
+| `awaiting_evidence → evidence_timeout` | `detect_evidence_timeouts` worker | ✅ |
+| `evidence_timeout` + `is_confirmed=true` | confirm_evidence_timeout (tasker) | ✅ (closure is a 4c seam) |
+| `rejected → in_review` (`reopen_count+1`) | resubmit_evidence | ⛔ dormant — `rejected` is produced by 4c; built now, exercised after 4c |
+
+## §4 Phase 5 & 4c Seams
+
+Declared on the consumer (`internal/evidence`); `main` wires no-op stubs in 4b,
+real implementations later. `database.Querier` is the Phase 3a tx/pool interface
+(P4a-D14).
+
+```go
+// Phase 5 — financial settlement on evidence timeout. Extends the 4a
+// PointLocker family. The 4a PointLocker locked the tasker's points per request
+// at publish; on evidence timeout those points are CONSUMED (not refunded) and
+// the referee is REWARDED.
+type EvidenceTimeoutSettler interface {
+    // SettleInTx consumes the tasker's locked cost for this request and grants
+    // the referee reward, keyed by requestID (== judgementID) for idempotency.
+    // The 4b stub no-ops. Phase 5 writes the point/reward ledgers.
+    SettleInTx(ctx context.Context, tx database.Querier, requestID uuid.UUID) error
+}
+
+// 4c — task closure after a tasker confirms a terminal judgement.
+type TaskCloser interface {
+    // CloseIfAllConfirmedInTx closes the task (open → closed) iff every one of
+    // its judgements is confirmed. The 4b stub no-ops (task close is 4c, as in
+    // 4a). Phase 4c provides the real check.
+    CloseIfAllConfirmedInTx(ctx context.Context, tx database.Querier, taskID uuid.UUID) error
+}
+```
+
+- 4b stubs: `EvidenceTimeoutSettler` no-ops; `TaskCloser` no-ops.
+- Phase 5 / 4c: swap the wiring only; evidence code unchanged (settlement
+  correlates per `requestID`; closure is a task-scoped check).
+
+## §5 Go Structure (extends 4a / 3a)
+
+Option E layout (`internal/<feature>/` with `domain.go` / `service.go` /
+`store.go` / `handler.go`).
+
+| Package | Role |
+|---|---|
+| `internal/evidence` **(new)** | `Evidence` / `EvidenceAsset` domain; service (request-upload-url; submit; update; resubmit; read-with-download-URLs; confirm-evidence-timeout); `store.go` (evidences/assets CRUD, timeout detection query); `handler.go`; **workers `detect_evidence_timeouts` + `sweep_evidence_objects`**. Declares the `EvidenceTimeoutSettler` (P5) and `TaskCloser` (4c) seams. |
+| `internal/notification` (4a extended) | Adds the `notification_sent_log` dedup table + store; **worker `detect_evidence_deadline_warnings`** (tasker-facing evidence reminder); the 4b evidence notification events. Reuses the 4a `send_notification` outbox + `platform/fcm`. |
+| `internal/profile` (3a extended) | Adds **worker `sweep_orphan_avatars`** (orphan avatar objects on the public bucket, using `profiles.avatar_url`). No new endpoints. |
+| `platform/r2` (3a extended) | Adds `PresignGet` (authorized download URLs) and private-evidence-bucket selection alongside the existing public-avatar bucket. SDK/DTO types stop here. |
+
+**Read integration:** the evidence read model (assets + embedded presigned
+download URLs) is surfaced through 4a's `GET /tasks/{id}` and
+`GET /me/assignments` detail for authorized viewers (see §6). `internal/evidence`
+exposes a read method the `task`/`matching` handlers call to enrich their detail
+responses (a consumer-declared seam, mirroring 4a's cross-feature composition),
+keeping evidence's presign logic inside `internal/evidence`.
+
+**Composition root** (`cmd/peppercheck` api + worker): wires the services, the
+no-op Phase 5 / 4c stubs, the private evidence bucket in `platform/r2`, and
+registers the new job handlers.
+
+## §6 API Contract (`/api/v1`)
+
+Under Phase 2 token-verify + 3a `CurrentUser` middleware; Go-layer ownership
+authz; Phase 2 stable error envelope. Evidence is a task-singleton (P4b-D6).
+
+**Tasker — evidence authoring (all under the task singleton):**
+- `POST /tasks/{id}/evidence/request-upload-url` — issue a presigned PUT for the
+  **private evidence bucket**. Validates: task ownership; `content_type` in the
+  allow-list; `file_size_bytes` within the 5 MiB cap (best-effort, per 3a §4.6 —
+  R2 enforces the signed `Content-Type`, size is a client pre-check + a `Head`
+  backstop, not a hard guarantee); **`due_date > now()`** (evidence cannot be
+  uploaded after the due date — ports `validate_evidence_due_date`, now a Go
+  service check per baseline §4.6). The presign **signs `Content-Type`**; TTL
+  600 s; **task-bound** object key `evidence/{YYYY-MM-DD from due_date}/{task-id}/{uuid}.{ext}`
+  (P4b-D10). → `{ uploadUrl, objectKey, expiresIn }`.
+- `PUT /tasks/{id}/evidence` — **submit**. Body `{ description, assets:
+  [{ objectKey }] }` (client sends only the key; size/type come from R2). One tx:
+  gate on task ownership + **`due_date > now()`** (P4b-D12) + ≥1 asset + at least
+  one `awaiting_evidence` judgement; for each asset verify the **key prefix
+  matches this task** and `r2.Head` succeeds, **re-check the R2-reported
+  `content_type` is in the allow-list and size is >0 and ≤5 MiB**, and store the
+  **R2-reported** `content_type`/`file_size_bytes` (NOT NULL; P4b-D10); insert the evidence (a `23505` on
+  `UNIQUE(task_id)` → `409 conflict`, P4b-D9); transition all of the task's
+  `awaiting_evidence` judgements → `in_review` — if that affects **0 rows**, roll
+  the whole tx back (a concurrent `evidence_timeout` won, P4b-D9/#3); enqueue
+  `notification_evidence_submitted_referee` per matched referee.
+- `PATCH /tasks/{id}/evidence` — **update** (edit while `in_review`, no reopen).
+  Body `{ description, assetsToAdd?[{objectKey}], assetIdsToRemove? }`. One tx:
+  gate on ownership + `in_review` + **`due_date > now()`** (P4b-D12); `Head`-verify
+  + prefix-check each added asset (adopt R2 metadata); apply removals/additions
+  but **reject if the result would leave 0 assets** (P4b-D12); enqueue
+  `notification_evidence_updated_referee`.
+- `POST /tasks/{id}/evidence/resubmit` — **resubmit** after rejection
+  (`rejected` && `reopen_count < 1` && `due_date > now()`). Edits evidence,
+  transitions the task's `rejected` judgements → `in_review` with
+  `reopen_count + 1`, enqueues `notification_evidence_resubmitted_referee`.
+  **Dormant until 4c** (no `rejected` judgement exists before 4c).
+
+**Tasker — evidence-timeout:**
+- `POST /judgements/{id}/confirm-evidence-timeout` — the tasker acknowledges an
+  `evidence_timeout` judgement (`is_confirmed = true`), then the 4c `TaskCloser`
+  seam runs (no-op in 4b). Idempotent (already-confirmed → no-op).
+
+**Read (extends 4a detail responses):**
+- `GET /tasks/{id}` and `GET /me/assignments` detail — for authorized viewers
+  (the task's **tasker** or a **matched referee**), the response includes the
+  task's evidence: `{ description, assets: [{ id, contentType, fileSizeBytes,
+  downloadUrl, purged }] }`, where `downloadUrl` is a **short-lived presigned
+  GET** for the private bucket, generated per-read (P4b-D2). For a **purged**
+  asset (`purged_at` set by the 90-day sweep, P4b-D11) `purged` is `true`,
+  `downloadUrl` is omitted/null, and no presign is attempted; the client renders
+  an empty/"deleted" frame. Unauthorized callers never reach this read model (403
+  at the task/authz layer), so they never receive a URL.
+
+## §7 Workers
+
+Phase 1 leased jobs. These are subject to the issue #464 at-least-once
+idempotency checklist (call it out in review, as in 4a).
+
+| Job | Trigger | Idempotency |
+|---|---|---|
+| `detect_evidence_timeouts` | self-rescheduling (~5 min; bucketed idempotency key; schedules the next run first) | Per candidate, one tx: **CAS** `UPDATE judgements SET status='evidence_timeout' WHERE status='awaiting_evidence' AND <task due_date passed> AND <no evidence row>` → only on success: `EvidenceTimeoutSettler.SettleInTx` (P5 no-op) + close the referee request + enqueue `notification_evidence_timeout_tasker` / `_referee`. A row already transitioned by a concurrent run is skipped by the CAS. |
+| `detect_evidence_deadline_warnings` | self-rescheduling (~1 min) | Candidate = judgement **`awaiting_evidence` with no evidence row** (legacy parity — see §8) whose task `due_date` is within one of the tasker's `evidence_reminder_minutes` offsets. Enqueue `notification_evidence_deadline_warning_tasker`. **Dedup via `notification_sent_log`** `UNIQUE (user_id, event_key, dedup_key)` (`dedup_key = task_id:offset`) so a reminder is sent at most once per (tasker, task, offset) — one reminder per task even with multiple referee judgements. |
+| `send_notification` | reused from 4a | unchanged (at-least-once; duplicate push low-harm; best-effort dedup by job/notification id). |
+| `sweep_evidence_objects` | self-rescheduling (daily) | **(1) 90-day purge (P4b-D11):** for each `evidence_assets` row whose task `due_date` is >90 days past and `purged_at IS NULL`, delete the R2 object and set `purged_at=now()` — **keep the DB row**. **(2) orphan pass:** delete objects under `evidence/` in the private bucket that have **no** referencing `evidence_assets.object_key` and are older than a short grace period (abandoned uploads / assets removed by update/resubmit). `dry_run` supported; deletes are idempotent. |
+| `sweep_orphan_avatars` (`internal/profile`) | self-rescheduling (daily) | Delete objects under `avatar/<userId>/` in the **public bucket** that are not the user's current `profiles.avatar_url`, with a 10-minute grace period to avoid racing a fresh upload. `dry_run` supported. |
+
+## §8 Notification Foundation (4b additions)
+
+Reuses the 4a send path: the server emits FCM localization **keys**
+(`notification_{event}_{recipient}`, `title_loc_key = key + '_title'` /
+`body_loc_key = key + '_body'` + args; `.claude/rules/notification-keys.md`); the
+device resolves them (client-side `loc_key`, P4a-D12). `notification_settings`
+(reminder minutes) already exists from 3a — 4b adds no settings columns.
+
+**New in 4b:**
+- `notification_sent_log` table + store — reminder dedup, `UNIQUE (user_id,
+  event_key, dedup_key)` (deferred from 4a §8).
+- `detect_evidence_deadline_warnings` worker (§7).
+
+**Reminder target state (clarified):** the legacy `detect_evidence_deadline_warnings`
+targets **`awaiting_evidence` judgements with no evidence row** — a reminder to
+submit before the deadline. `notification_settings.evidence_reminder_even_if_submitted`
+exists in the schema but is **read nowhere** (not by the legacy function, not by
+the client) — it is inert config. 4b ports the live behavior (awaiting + no
+evidence) and records `even_if_submitted` as inert in §11; wiring it up (remind
+even after submission, i.e. include `in_review`) is a deliberate future feature,
+not a port (YAGNI).
+
+**4b events:** `notification_evidence_submitted_referee`,
+`notification_evidence_updated_referee`,
+`notification_evidence_resubmitted_referee` (dormant until 4c),
+`notification_evidence_timeout_tasker`, `notification_evidence_timeout_referee`,
+`notification_evidence_deadline_warning_tasker`.
+
+**Out of 4b (→ 4c):** review-deadline reminders (`detect_review_deadline_warnings`,
+referee-facing) and auto-confirm reminders — 4c adds those jobs on the same
+`notification_sent_log` foundation.
+
+## §8.5 Operator & Post-deploy Actions (private R2 bucket)
+
+The private evidence bucket is new infrastructure and needs operator provisioning
+per environment; these are **post-deploy actions**, tracked via the
+`release-checklist` skill (not code). (Review 2026-07-26 #7.)
+
+- **Create a dedicated evidence bucket per environment** (staging, production),
+  separate from the public avatar bucket.
+- **Public access disabled** — no public/custom domain bound to the evidence
+  bucket (evidence is only ever reached via presigned URLs).
+- **Bucket-scoped credentials** — an access key/secret restricted to the evidence
+  bucket, delivered through the Phase 7a file-based secret mechanism (BWS →
+  Docker file-secret); the api/worker read them from `core/config` (`R2Evidence`).
+  Never reuse the avatar bucket's credentials.
+- **CORS** — configure CORS on the evidence bucket so browser clients can use the
+  presigned URLs: allowed origins (the app/web origins), methods `GET` + `PUT`,
+  and the `Content-Type` header. A presigned URL fails in a browser without CORS
+  even when the signature is valid. (Native mobile HTTP does not enforce CORS, but
+  the webapp and any browser preview do.) Ref: Cloudflare R2 CORS docs
+  (`developers.cloudflare.com/r2/buckets/cors/`) — verify the exact JSON at setup.
+- **Smoke test on staging then production** — request an upload URL, PUT a small
+  image, submit evidence, read it back as an authorized viewer and confirm the
+  presigned GET renders; confirm an unauthorized caller gets 403.
+
+## §9 Testing Strategy
+
+- **Go unit:** submit authz + state gate (only `awaiting_evidence`); update gate
+  (`in_review`); resubmit gate (`rejected` && `reopen_count<1` && before due);
+  upload-intent validation (content-type, size, `due_date>now`, key derivation);
+  evidence-timeout candidate selection (due passed × no evidence); presigned-GET
+  URL construction (correct bucket/key/TTL); `EvidenceTimeoutSettler` /
+  `TaskCloser` stubs invoked with the right args.
+- **Postgres integration** (real container): migrations apply to empty DB;
+  constraints/indexes/FKs; `set_updated_at` present on every new table with
+  `updated_at`; submit atomicity (evidence + assets + all judgements→in_review +
+  notification jobs all-or-nothing); `detect_evidence_timeouts` idempotency
+  (twice → one transition, one settle-seam call, one pair of notifications);
+  concurrent timeout of the same judgement (CAS → exactly one wins);
+  `notification_sent_log` dedup (reminder sent once); user-scoped isolation.
+- **API integration** (HTTP + real Postgres + **fake R2 / fake seams**): auth
+  required; ownership violations (403); upload-intent validation; submit →
+  in_review + jobs enqueued; update/resubmit gates; **authorized read embeds a
+  presigned GET; a non-owner/non-referee cannot read evidence (403) and receives
+  no URL**; confirm-evidence-timeout idempotency; stable error envelopes.
+- **Worker:** `detect_evidence_timeouts` (transition + settle-seam + close +
+  notify; idempotent; skips already-transitioned); `detect_evidence_deadline_warnings`
+  (reminder once via `notification_sent_log`); `sweep_evidence_objects` /
+  `sweep_orphan_avatars` (age/orphan selection, grace period, `dry_run`, against
+  a fake object store).
+- **Characterization:** port the Phase 0 high-risk evidence fixtures (submit →
+  in_review across multiple referees; evidence-timeout detection; resubmit
+  reopen-once).
+- **Review-2026-07-26 additions (required):** concurrent-submit → exactly one
+  evidence row (`UNIQUE(task_id)` → the loser gets 409); submit with a foreign/
+  nonexistent/oversized object key rejected (prefix check + `Head`); DB stores
+  R2-reported metadata, not client input; submit-vs-timeout race (a submit whose
+  judgements a concurrent timeout moved rolls back and creates no evidence, and
+  the self-contained timeout CAS never fires once evidence exists); `due_date`
+  guard rejects submit **and** update after the deadline; update/resubmit cannot
+  remove the last asset; reminder dedup collides only within (user, event, task,
+  offset); `sweep_evidence_objects` purges the object + sets `purged_at` but keeps
+  the DB row for >90-day evidence, deletes true orphans, and never touches a
+  <90-day referenced object; `ViewForTask` returns `purged=true`/no URL for a
+  purged asset.
+- **CI gates:** gofmt, `go vet`, unit, Postgres integration, race, Atlas
+  fmt/lint, apply-to-empty-DB, schema-drift, image build.
+
+## §10 Completion Criteria ("done")
+
+- Via the Go API a tasker can request an evidence upload URL (private bucket),
+  submit evidence (→ all `awaiting_evidence` judgements go `in_review`, referees
+  notified), and update it while in review. `evidence` has no Supabase imports.
+- An **authorized** viewer (tasker or matched referee) reads the task and
+  receives short-lived **presigned GET** URLs for evidence assets from the
+  **private** bucket; an unauthorized caller gets 403 and no URL. No public
+  evidence domain is used.
+- `detect_evidence_timeouts` transitions past-due evidence-less judgements to
+  `evidence_timeout`, closes the referee request, notifies both parties, and
+  calls the Phase 5 settlement seam (no-op in 4b); a tasker can confirm the
+  timeout (task closure is the 4c seam, no-op in 4b).
+- `detect_evidence_deadline_warnings` sends the tasker reminder at most once
+  (`notification_sent_log`).
+- `sweep_evidence_objects` (private bucket, 90-day) and `sweep_orphan_avatars`
+  (public bucket, orphan + grace) run as separate feature-owned workers with
+  `dry_run`.
+- Resubmit is implemented but dormant until 4c; point/reward settlement and task
+  closure are interface seams with no-op stubs.
+- `detect_evidence_timeouts` / `detect_evidence_deadline_warnings` / sweeps are
+  safe under at-least-once (#464).
+- All tests green; CI gates pass; api/worker shut down cleanly (Phase 1
+  lifecycle).
+- Flutter is a separate follow-on spec (not in this "done").
+
+## §11 Follow-ups
+
+**Dropped in 4b (removed dead / no-op schema):**
+
+| Item | Why dropped | If revived |
+|------|-------------|-----------|
+| `evidence_status` enum (`pending_upload` / `ready`) + `task_evidences.status` | `pending_upload` never persisted — the client uploads to R2 first, then submits metadata, which inserted `ready` directly. A row's existence *is* "ready". | Re-add a status column if a server-tracked two-phase upload-intent (record intent → confirm) is ever built. |
+| `task_evidence_assets.public_url` | The public-domain URL is the launch-blocker being removed; downloads are now authorized presigned GETs generated per-read. | n/a (public delivery of evidence is the anti-goal). |
+| `task_evidence_assets.file_url` | Consolidated into `object_key` (the R2 key is the only durable reference needed). | n/a. |
+| `task_evidence_assets.processing_status` / `.error_message` | Reserved for a server-side image pipeline that was never built; normalization is client-side (`ImageNormalizer`). | Re-add if a server-side processing/derivative pipeline is introduced. |
+| Single shared `sweep-r2-stale-objects` cron | Split into two feature-owned workers (P4b-D7). | n/a (the split is the improvement). |
+
+**Deferred / seams to resolve later:**
+
+| Item | Notes |
+|------|-------|
+| **Resubmit dormancy** | Built in 4b but not reachable until 4c produces `rejected`. 4c must include a resubmit → judge round-trip in its tests. |
+| **Phase 5 `EvidenceTimeoutSettler`** | 4b no-ops the consume/reward. Phase 5 wires the real point-consume + referee-reward ledgers, keyed by `requestID`. |
+| **4c `TaskCloser`** | 4b no-ops task closure on confirm. 4c provides the all-judgements-confirmed close (shared with the rest of the judgement lifecycle). |
+| **Reminder settings read/update endpoints** | `notification_settings.*_reminder_minutes` are consumed by 4b's worker but have no read/update endpoint yet (deferred by 3a to "whenever that UI migrates"). |
+| **Best-effort size cap** | The 5 MiB cap remains best-effort (3a §4.6): client pre-check + `Head` backstop + sweep; a hard cap would need a Go-API proxy, deliberately avoided. Note 4b's `Head`-at-submit now enforces the cap at persist time (reject oversize), so the cap is stronger than 3a's avatar path. |
+| **Flutter cache keying + purged frames** | With private downloads, `downloadUrl` changes per-read; the Flutter spec must key its image cache by `object_key` / asset id, not URL, and render an empty/"deleted" frame for `purged=true` assets (P4b-D11). Recorded for the 4b Flutter spec. |
+| **`evidence_reminder_even_if_submitted` is inert** | Defined in `notification_settings` (3a) but read nowhere; 4b ports the live behavior only (remind while `awaiting_evidence`, no evidence). Wiring "remind even after submission" (include `in_review`) is a future feature, not a port. |
+| **Evidence retention reconciled to policy** | P4b-D11 implements the privacy policy (`retention.evidenceFiles`): purge image files 90 days after due date, keep records. If the policy's retention window or scope changes, update the sweep's cutoff + the purged-frame copy together. |
+```


### PR DESCRIPTION
## Summary

- record the pending Phase 3a profile/notification and Phase 3b public-web designs
- record the Phase 4a backend/Flutter matching and Phase 4b evidence/R2 designs
- record Phase 4a deferred follow-ups

## Why

These accepted design decisions need durable, reviewable records before the corresponding implementation work.

## Validation

- `git diff --check`
- verified that GitHub-facing prose uses English, except localization source data (none in these documents)
- direct pre-commit hooks for the changed paths (all non-applicable)

## Deployment

Documentation only; this PR introduces no deployable behavior or operator action.