### PR TITLE
chore(backend): add BWS-based dev secret injection for local Compose

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -26,10 +26,16 @@ API_PORT=8765
 # stack boot offline; set the real per-env project to actually authenticate.
 FIREBASE_PROJECT_ID=peppercheck-local
 # Cloudflare R2 (avatar uploads via platform/r2). Dummy values let the stack
-# boot; avatar upload/finalize only works against a real bucket + credentials,
-# which are injected at runtime as secrets per environment (never committed).
+# boot; avatar upload/finalize only works against a real bucket + credentials.
+# R2_ACCOUNT_ID / R2_BUCKET / R2_PUBLIC_DOMAIN are non-secret (see
+# internal/core/config/config.go) — to test against a real dev bucket, just
+# replace these three with real values in your own .env.
 R2_ACCOUNT_ID=r2-local-account
-R2_ACCESS_KEY_ID=r2-local-key
-R2_SECRET_ACCESS_KEY=r2-local-secret
 R2_BUCKET=peppercheck-avatars-local
 R2_PUBLIC_DOMAIN=cdn.local.example.com
+# R2_ACCESS_KEY_ID / R2_SECRET_ACCESS_KEY are real credentials — never put a
+# real value here. Run `make up BWS_PROJECT_ID=<id>` instead to inject the
+# real dev credential via Bitwarden Secrets Manager for one run; see
+# docs/development/bws-development.md.
+R2_ACCESS_KEY_ID=r2-local-key
+R2_SECRET_ACCESS_KEY=r2-local-secret

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -15,9 +15,13 @@ TEST_POSTGRES_PORT ?= 55432
 help: ## Show available targets
 	grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN{FS=":.*?## "}{printf "  %-9s %s\n", $$1, $$2}'
 
-up: ## Start the core stack (creates .env from the template if missing)
+up: ## Start the core stack (creates .env if missing). Add BWS_PROJECT_ID=<id> to inject real dev secrets via Bitwarden Secrets Manager (see docs/development/bws-development.md)
 	[ -f .env ] || cp .env.example .env
-	docker compose up -d --build
+	@if [ -n "$(BWS_PROJECT_ID)" ]; then \
+		scripts/bws-dev-up.sh "$(BWS_PROJECT_ID)"; \
+	else \
+		docker compose up -d --build; \
+	fi
 
 down: ## Stop the stack (keep volumes)
 	docker compose down

--- a/backend/README.md
+++ b/backend/README.md
@@ -21,8 +21,11 @@ first. Run `make help` for all targets.
 
 `.env` holds **non-sensitive local defaults only** (throwaway dev passwords, an
 age public key). Never put a real provider secret or real DB password in it —
-real secrets are injected at runtime via Bitwarden Secrets Manager / Docker
-secrets (Phase 7).
+staging/production secrets are injected at runtime via Bitwarden Secrets
+Manager / Docker secrets (Phase 7). For local development against a real
+external service (e.g. R2 avatar uploads), run
+`make up BWS_PROJECT_ID=<id>` instead — see
+[docs/development/bws-development.md](../docs/development/bws-development.md).
 
 ## Structure
 

--- a/backend/compose.yaml
+++ b/backend/compose.yaml
@@ -89,13 +89,15 @@ services:
       # R2 (avatar uploads). R2_ACCOUNT_ID / R2_BUCKET / R2_PUBLIC_DOMAIN are
       # non-secret (see internal/core/config/config.go) and come from .env;
       # fill in real values there for local testing against a real bucket.
-      # R2_ACCESS_KEY_ID / R2_SECRET_ACCESS_KEY are real credentials: local
-      # dummies let the api construct the client and exercise the avatar flow
-      # shape without reaching a real bucket (avatars disabled, 503), and
-      # `make up BWS_PROJECT_ID=<id>` overrides them with the real dev
-      # credential via Bitwarden Secrets Manager (see
-      # docs/development/bws-development.md) — Compose gives that injected
-      # process-environment value precedence over the .env dummy below.
+      # R2_ACCESS_KEY_ID / R2_SECRET_ACCESS_KEY are real credentials: with the
+      # dummy values below the api still constructs an R2 client (r2.New only
+      # rejects empty fields, not placeholder ones — see #483) that presigns
+      # against a nonexistent account, so a real upload attempt fails at the
+      # client PUT step rather than at the api. `make up BWS_PROJECT_ID=<id>`
+      # overrides these two with the real dev credential via Bitwarden Secrets
+      # Manager (see docs/development/bws-development.md) — Compose gives that
+      # injected process-environment value precedence over the .env dummy
+      # below.
       R2_ACCOUNT_ID: ${R2_ACCOUNT_ID:-r2-local-account}
       R2_ACCESS_KEY_ID: ${R2_ACCESS_KEY_ID:-r2-local-key}
       R2_SECRET_ACCESS_KEY: ${R2_SECRET_ACCESS_KEY:-r2-local-secret}

--- a/backend/compose.yaml
+++ b/backend/compose.yaml
@@ -86,10 +86,16 @@ services:
       LOG_LEVEL: info
       FIREBASE_PROJECT_ID: ${FIREBASE_PROJECT_ID:?FIREBASE_PROJECT_ID is required (set it in .env; a dummy like peppercheck-local is fine locally)}
       DATABASE_URL: postgres://peppercheck_app:${POSTGRES_APP_PASSWORD:?POSTGRES_APP_PASSWORD is required}@postgres:5432/peppercheck?sslmode=disable
-      # R2 (avatar uploads). Local dummies let the api construct the client and
-      # exercise the avatar flow shape; they don't reach a real bucket. Real
-      # per-env credentials are operator-provisioned at deploy (design §12), not
-      # here. When these are absent the api still boots with avatars disabled (503).
+      # R2 (avatar uploads). R2_ACCOUNT_ID / R2_BUCKET / R2_PUBLIC_DOMAIN are
+      # non-secret (see internal/core/config/config.go) and come from .env;
+      # fill in real values there for local testing against a real bucket.
+      # R2_ACCESS_KEY_ID / R2_SECRET_ACCESS_KEY are real credentials: local
+      # dummies let the api construct the client and exercise the avatar flow
+      # shape without reaching a real bucket (avatars disabled, 503), and
+      # `make up BWS_PROJECT_ID=<id>` overrides them with the real dev
+      # credential via Bitwarden Secrets Manager (see
+      # docs/development/bws-development.md) — Compose gives that injected
+      # process-environment value precedence over the .env dummy below.
       R2_ACCOUNT_ID: ${R2_ACCOUNT_ID:-r2-local-account}
       R2_ACCESS_KEY_ID: ${R2_ACCESS_KEY_ID:-r2-local-key}
       R2_SECRET_ACCESS_KEY: ${R2_SECRET_ACCESS_KEY:-r2-local-secret}

--- a/backend/scripts/bws-dev-up.sh
+++ b/backend/scripts/bws-dev-up.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Starts the local Compose stack with real dev secrets injected from Bitwarden
+# Secrets Manager (bws). See docs/development/bws-development.md.
+set -euo pipefail
+
+if [ "$#" -ne 1 ]; then
+  echo "usage: $0 <BWS development project ID>" >&2
+  exit 2
+fi
+
+if ! command -v bws >/dev/null 2>&1; then
+  echo "bws is not installed; install the Bitwarden Secrets Manager CLI first (see docs/development/bws-development.md)" >&2
+  exit 127
+fi
+
+if [ -z "${BWS_ACCESS_TOKEN:-}" ] && command -v security >/dev/null 2>&1; then
+  # This machine account's token is shared across repos that read the same
+  # BWS `development` project (see docs/development/bws-development.md). The
+  # value is read only into this process tree, never written to disk here.
+  BWS_ACCESS_TOKEN="$(security find-generic-password -a "$(id -un)" -s "bws-local-access-token" -w 2>/dev/null || true)"
+  export BWS_ACCESS_TOKEN
+fi
+
+if [ -z "${BWS_ACCESS_TOKEN:-}" ]; then
+  echo "BWS_ACCESS_TOKEN is required; add bws-local-access-token to macOS Keychain or set it for this one command" >&2
+  exit 2
+fi
+
+# The project ID is not secret. bws injects only this project's secret values
+# (e.g. R2_ACCESS_KEY_ID, R2_SECRET_ACCESS_KEY) into Compose's process
+# environment; BWS_ACCESS_TOKEN itself is never listed in compose.yaml or
+# passed to a container. .env is still loaded as normal -- Compose gives
+# process-environment variables precedence over .env, so the bws-injected
+# values override the .env dummies for the keys bws actually provides, while
+# every other variable (non-secret config and required-but-non-secret
+# variables such as POSTGRES_PASSWORD and API_PORT) keeps coming from .env.
+exec bws run --project-id "$1" -- docker compose up -d --build

--- a/docs/development/bws-development.md
+++ b/docs/development/bws-development.md
@@ -9,8 +9,13 @@ today that's the Cloudflare R2 avatar upload/finalize flow.
 
 `make up BWS_PROJECT_ID=<id>` injects real credential values from Bitwarden
 Secrets Manager (`bws`) into the Compose stack for the duration of that one
-run. This is optional: plain `make up` (no `BWS_PROJECT_ID`) keeps working on
-dummies, with avatar upload disabled (503).
+run. This is optional: plain `make up` (no `BWS_PROJECT_ID`) keeps working
+without it, exercising the avatar upload/finalize code path against a
+nonexistent R2 account rather than a real bucket (see [#483][] — the shipped
+dummy values don't currently make the api fail closed the way earlier docs in
+this area assumed).
+
+[#483]: https://github.com/cloveclovedev/peppercheck/issues/483
 
 This repository shares the `development` Bitwarden Secrets Manager project
 with other personal projects on the same free-tier account (capped at 3

--- a/docs/development/bws-development.md
+++ b/docs/development/bws-development.md
@@ -1,0 +1,111 @@
+# Bitwarden Secrets Manager Development Injection
+
+## Scope
+
+Local development normally boots on non-sensitive dummy values in
+`backend/.env` (copied from `backend/.env.example`). That's enough to build
+and exercise most flows, but not ones that call a real external service —
+today that's the Cloudflare R2 avatar upload/finalize flow.
+
+`make up BWS_PROJECT_ID=<id>` injects real credential values from Bitwarden
+Secrets Manager (`bws`) into the Compose stack for the duration of that one
+run. This is optional: plain `make up` (no `BWS_PROJECT_ID`) keeps working on
+dummies, with avatar upload disabled (503).
+
+This repository shares the `development` Bitwarden Secrets Manager project
+with other personal projects on the same free-tier account (capped at 3
+projects and 3 machine accounts). The local machine account can read that
+project only — it must never receive a staging or production access token.
+
+## What goes through bws vs. what goes in `.env`
+
+`backend/internal/core/config/config.go` classifies each R2 variable:
+
+- **Real credentials** — `R2_ACCESS_KEY_ID`, `R2_SECRET_ACCESS_KEY`. These
+  alone use the fail-closed `*_FILE` convention and are the only R2 values
+  that go through `bws`.
+- **Non-secret config** — `R2_ACCOUNT_ID`, `R2_BUCKET`, `R2_PUBLIC_DOMAIN`.
+  Read with plain `os.Getenv`, same as `FIREBASE_PROJECT_ID`. These never go
+  through `bws`; set real values directly in your own (gitignored) `.env`
+  when you want to point at a real dev bucket.
+
+`.env`'s "non-sensitive only" rule is about never writing a *real secret
+value* into it — it's not exclusive to secrets. Non-secret config with a real
+value is fine there, exactly like `FIREBASE_PROJECT_ID`.
+
+## Secrets in bws
+
+Create the following in the `development` project:
+
+```text
+R2_ACCESS_KEY_ID
+R2_SECRET_ACCESS_KEY
+```
+
+These are deliberately **not** namespaced with a `PEPPERCHECK_`-style prefix:
+they're a single Cloudflare R2 API token shared across this operator's
+personal projects that use R2 for local dev, scoped to the buckets those
+projects need. Rotate it once and every project sharing it picks up the new
+value. A future dev secret that is genuinely peppercheck-specific (not meant
+to be reused by another project) should still get a `PEPPERCHECK_` prefix to
+avoid colliding with another project's secret name in this shared project.
+
+Provisioning the underlying Cloudflare R2 token and the dev bucket(s) it can
+reach, and populating these two values in Bitwarden, is a manual operator
+step — not automated here.
+
+Extend the bws secret set per phase as later features (Phase 4 private-R2
+evidence, Phase 5 Stripe/RevenueCat, ...) introduce real dev-side credentials.
+
+## Local setup
+
+1. Install the native `bws` executable from the official Bitwarden Secrets
+   Manager CLI release and place it on `PATH`.
+2. Create (or reuse, if already set up for another project sharing this
+   account) a read-only `local-development` machine account and grant it
+   access to the `development` project only.
+3. Store its access token in macOS Keychain with service name
+   `bws-local-access-token` and your macOS account name. Do not put it in
+   `.env`, shell startup files, Docker Compose files, or the repository. This
+   Keychain entry is shared across every local repository that reads the same
+   `development` project — there is only one token, not one per repository.
+4. Set real, non-secret values for `R2_ACCOUNT_ID`, `R2_BUCKET`, and
+   `R2_PUBLIC_DOMAIN` in `backend/.env` (see above — these don't go through
+   bws).
+5. Run:
+
+   ```bash
+   cd backend
+   make up BWS_PROJECT_ID=<development-project-id>
+   ```
+
+## How it works
+
+`make up BWS_PROJECT_ID=<id>` still creates `backend/.env` from the template
+if missing, then runs `backend/scripts/bws-dev-up.sh <id>` instead of a plain
+`docker compose up`. The script:
+
+- Fails closed if `bws` isn't installed.
+- Reads `BWS_ACCESS_TOKEN` from the `bws-local-access-token` Keychain item
+  into its own process tree (falling back to an already-exported
+  `BWS_ACCESS_TOKEN`, e.g. for a one-shot override), and fails closed if
+  neither is available.
+- Runs `bws run --project-id <id> -- docker compose up -d --build`. Only the
+  selected project's secret values reach that one process tree; the BWS
+  access token itself is never listed in Compose or passed to a container.
+
+No compose.yaml mapping is needed: `bws run` sets `R2_ACCESS_KEY_ID` and
+`R2_SECRET_ACCESS_KEY` directly in the process environment, and Docker
+Compose resolves variables from the process environment before falling back
+to `.env`, so those two values simply override the `.env` dummies for that
+run. Every other variable — including the non-secret R2 config above — keeps
+coming from `.env` either way, since bws never provides those.
+
+## Out of scope
+
+- Staging/production secret injection — already handled by the deploy
+  pipeline (`scripts/ship-deployment.sh`, environment-scoped GitHub Actions
+  secrets), which uses separate, dedicated staging/production BWS projects.
+- CI — stays on `.env.example` dummies.
+- Flutter-side secrets (Google OAuth, etc.) — live in the app build, handled
+  separately.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -25,7 +25,9 @@ curl http://localhost/readyz
 
 `make up` creates `backend/.env` from the committed example when it is missing.
 That file is local-only. Keep real provider credentials and production secrets
-out of it.
+out of it. To exercise a flow that calls a real external service (e.g. R2
+avatar uploads), run `make up BWS_PROJECT_ID=<id>` instead — see
+[Bitwarden Secrets Manager development injection](development/bws-development.md).
 
 Stop the stack while preserving data with `make down`. Use `make down-v` only
 when intentionally discarding the local database and WAL archive.


### PR DESCRIPTION
## Summary

`make up BWS_PROJECT_ID=<id>` now optionally wraps `docker compose up` with `bws run`, injecting the real dev R2 credential (`R2_ACCESS_KEY_ID`, `R2_SECRET_ACCESS_KEY`) from Bitwarden Secrets Manager into that one run.

Plain `make up` (no `BWS_PROJECT_ID`) is unchanged — it still boots on `.env` dummies with avatar upload disabled (503).

## Design notes

`backend/internal/core/config/config.go` already classifies R2 config: `R2_ACCOUNT_ID` / `R2_BUCKET` / `R2_PUBLIC_DOMAIN` are non-secret (plain `os.Getenv`), while `R2_ACCESS_KEY_ID` / `R2_SECRET_ACCESS_KEY` are real credentials (the fail-closed `*_FILE`-capable lookup). Only the latter two go through BWS.

The BWS `development` project is shared across the operator's personal projects (free-tier cap of 3 projects / 3 machine accounts). These two secrets are deliberately unprefixed — a single Cloudflare R2 API token reused across projects that need one — rather than namespaced like a `PEPPERCHECK_`-style prefix. A future dev secret that's genuinely peppercheck-specific should still get a prefix to avoid colliding with another project's secret name in the same shared project; this is documented in `docs/development/bws-development.md`.

No `compose.yaml` mapping was needed: `bws run` sets `R2_ACCESS_KEY_ID` / `R2_SECRET_ACCESS_KEY` directly in the process environment, and Compose already resolves the process environment before falling back to `.env`, so the existing plain variable expressions pick up the injected values automatically.

## Changes

- `backend/scripts/bws-dev-up.sh` (new) — fail-closed if `bws` is missing or `BWS_ACCESS_TOKEN` is unavailable (read from the macOS Keychain item `bws-local-access-token`, shared with other local repos reading the same BWS project); then `bws run --project-id <id> -- docker compose up -d --build`.
- `backend/Makefile` — `up` accepts `BWS_PROJECT_ID=<id>` to route through the script above.
- `backend/compose.yaml` — comment-only clarification of which `R2_*` vars are secret vs non-secret; no functional change.
- `backend/.env.example` — split the R2 comment block: account/bucket/public-domain are non-secret (fill in real values directly in your own `.env`); access-key/secret are real credentials (never a real value here, use BWS injection instead).
- `backend/README.md`, `docs/getting-started.md` — point at the new doc and `make up BWS_PROJECT_ID=<id>`.
- `docs/development/bws-development.md` (new) — full local setup + design rationale.

## Documentation

Documentation is updated in this PR (`docs/development/bws-development.md`, `backend/README.md`, `docs/getting-started.md`) since this changes a documented command and introduces new operator setup steps.

## Related

- Closes #480
- A separate, deferred issue (#481) was filed during design discussion for reconsidering which `compose.yaml` env vars require `.env` vs. get a compose-level default — out of scope here.
- Real Cloudflare R2 dev-bucket provisioning and populating the two BWS secret values is a manual operator step, not part of this PR.

## Test plan

- [x] `docker compose config` parses correctly with the updated `compose.yaml`
- [x] Plain `make up` still boots; `/livez` and `/readyz` return ok/ready; container env still shows only plain dummy `R2_*` values (no regression)
- [x] `make up BWS_PROJECT_ID=<dummy-id>` correctly reads the Keychain token and reaches `bws run` (verified via the expected `bws` CLI error for an invalid project ID; a real project ID is an operator follow-up)
- [x] `shellcheck` passes on `backend/scripts/bws-dev-up.sh`
- [ ] End-to-end avatar upload against a real dev R2 bucket (operator follow-up, needs real BWS secret values)
