### PR TITLE
fix(flutter): pin JDK 21 for local Android builds

### DIFF
--- a/.claude/rules/flutter.md
+++ b/.claude/rules/flutter.md
@@ -5,10 +5,12 @@
 After modifying Dart source files, verify the app compiles:
 
 ```bash
-cd peppercheck_flutter && flutter build apk --debug -t lib/main_dev.dart 2>&1 | tail -10
+cd peppercheck_flutter && flutter build apk --debug --flavor dev -t lib/main_dev.dart 2>&1 | tail -10
 ```
 
-The project uses flavored entry points (`main_dev.dart`, `main_staging.dart`, `main_production.dart`), not `lib/main.dart`.
+The project uses flavored entry points (`main_dev.dart`, `main_staging.dart`, `main_production.dart`), not `lib/main.dart`. Pass `--flavor dev` to match the entry point; without a flavor, Gradle builds every flavor and Flutter reports a misleading "failed to produce an .apk file" even on a successful build.
+
+Local Android builds require a JDK ≤ 21; the JDK 25/26 that Android Studio / Homebrew now ship is too new for the pinned Gradle/AGP toolchain. See `docs/development/flutter/android-jdk.md`.
 
 ## Riverpod Controller Naming
 

--- a/docs/development/flutter/android-jdk.md
+++ b/docs/development/flutter/android-jdk.md
@@ -1,0 +1,108 @@
+# Android build JDK
+
+Local Android builds pin **JDK 21** (an LTS release). This document records why
+and how to set it up, so the next Android-Studio-driven JDK bump does not
+require rediscovering the problem.
+
+## Symptom
+
+`flutter build apk --debug`, `flutter run`, and `scripts/dev-run.sh --android`
+fail early with a Gradle error whose message is just a JDK version string:
+
+```
+FAILURE: Build failed with an exception.
+* What went wrong:
+25.0.2
+java.lang.IllegalArgumentException: 25.0.2
+	at org.jetbrains.kotlin.com.intellij.util.lang.JavaVersion.parse(...)
+```
+
+## Cause
+
+Flutter runs Gradle with the JDK it resolves in this order: the JDK bundled
+with the latest Android Studio (its JBR), then `JAVA_HOME`, then `java` on
+`PATH`. The Android Studio JBR is therefore used by default, and recent Android
+Studio releases bundle **JDK 25**; the Homebrew `openjdk` formula is now on
+**JDK 26**. Setting `JAVA_HOME` alone does **not** help, because the bundled JBR
+takes precedence over it — only `flutter config --jdk-dir` overrides the JBR.
+
+The pinned Android toolchain cannot run on JDK 25/26:
+
+- Kotlin Gradle plugin `JavaVersion.parse()` throws on any JDK 25+ version
+  string ([KT-83610][]).
+- Gradle's own compatibility matrix requires **Gradle 9.1.0+ for JDK 25** and
+  **9.4.0+ for JDK 26** ([Gradle compatibility][]); this project pins Gradle
+  8.14.
+
+## Why not just upgrade to support JDK 25/26
+
+Making the toolchain accept JDK 25/26 means moving to Gradle 9.x, which forces
+Android Gradle Plugin (AGP) 9.x (AGP 8.x does not support Gradle 9). That path
+is currently blocked for this app:
+
+- AGP 9.0 removed support for *applying* the Kotlin Gradle Plugin
+  (`org.jetbrains.kotlin.android`, which this project uses), and Flutter's
+  official guidance is to **not** upgrade to AGP 9 yet
+  ([Flutter built-in Kotlin migration][], [flutter/flutter#181383][]).
+- Firebase's Flutter plugins are not yet AGP 9 compatible
+  ([firebase/flutterfire#17987][]), and this app depends on them.
+- The pinned Flutter (3.38.3, 2025-11) predates AGP 9.0 stable (2026-01).
+
+So local builds stay within the **JDK 17–21** range that Flutter and AGP 8.x
+support.
+
+## Setup
+
+Install a JDK 21 and point Flutter at it (a one-time, per-machine setting):
+
+```sh
+brew install openjdk@21
+flutter config --jdk-dir="$(brew --prefix openjdk@21)/libexec/openjdk.jdk/Contents/Home"
+```
+
+Homebrew's `openjdk@21` is a standard OpenJDK build and is equivalent to any
+other JDK 21 (including Android Studio's JBR) for command-line Gradle builds;
+installing it through Android Studio is not required. Note that `openjdk@21` is
+keg-only and is not registered with `/usr/libexec/java_home`, so the JDK home
+must be referenced by its explicit path as above.
+
+`scripts/dev-run.sh --android` performs this automatically: if Flutter has no
+`--jdk-dir` set (or it points at a JDK newer than 21), the script finds a
+JDK 17/21 and configures it, or tells you to `brew install openjdk@21` if none
+is present.
+
+## Verify
+
+```sh
+cd peppercheck_flutter
+flutter build apk --debug --flavor dev -t lib/main_dev.dart
+```
+
+Pass `--flavor dev`; without a flavor, Gradle builds every flavor and Flutter
+reports a misleading "failed to produce an .apk file" even though the build
+succeeded.
+
+## Trade-off and revisit trigger
+
+This pin must be revisited whenever the default JDK changes — a new machine, or
+an Android Studio update that moves the bundled JBR again — because Flutter will
+fall back to the (too-new) JBR until `--jdk-dir` is set. Revisit the underlying
+constraint when Flutter and the Firebase Flutter plugins support AGP 9 /
+built-in Kotlin; at that point the toolchain can move to Gradle 9.x + AGP 9.x
+and use the bundled JDK directly.
+
+## References
+
+- [KT-83610][] — `JavaVersion.parse()` fails on Java 25
+- [Gradle compatibility][] — JDK ↔ Gradle version matrix
+- [Flutter built-in Kotlin migration][]
+- [flutter/flutter#181383][] — Flutter plugins should support AGP 9.0
+- [firebase/flutterfire#17987][] — Firebase Flutter plugins AGP 9 incompatibility
+- Tracking issue: [#484][]
+
+[KT-83610]: https://youtrack.jetbrains.com/issue/KT-83610
+[Gradle compatibility]: https://docs.gradle.org/current/userguide/compatibility.html
+[Flutter built-in Kotlin migration]: https://docs.flutter.dev/release/breaking-changes/migrate-to-built-in-kotlin
+[flutter/flutter#181383]: https://github.com/flutter/flutter/issues/181383
+[firebase/flutterfire#17987]: https://github.com/firebase/flutterfire/issues/17987
+[#484]: https://github.com/cloveclovedev/peppercheck/issues/484

--- a/peppercheck_flutter/README.md
+++ b/peppercheck_flutter/README.md
@@ -29,6 +29,12 @@ Platform Firebase configuration is local and must not be committed. See the
 [repository getting-started guide](../docs/getting-started.md) for the complete
 path and port overrides.
 
+Android builds pin JDK 21; the bundled Android Studio / Homebrew JDK (25/26) is
+too new for the current Gradle/AGP toolchain. `scripts/dev-run.sh --android`
+configures this automatically. See
+[Android build JDK](../docs/development/flutter/android-jdk.md) for one-time
+setup and the rationale.
+
 ## Verify changes
 
 ```sh

--- a/scripts/dev-run.sh
+++ b/scripts/dev-run.sh
@@ -80,6 +80,57 @@ start_backend() {
   printf ' TIMEOUT\n'; echo "backend not responding — check: (cd backend && make logs)"; exit 1
 }
 
+# Local Android builds pin JDK 21: the pinned Gradle 8.14 + AGP 8.11 toolchain
+# can't run on the JDK 25/26 that Android Studio / Homebrew now ship (KT-83610),
+# and Flutter uses Android Studio's bundled JBR unless --jdk-dir overrides it.
+# See docs/development/flutter/android-jdk.md.
+ANDROID_JDK_MAX=21
+
+jdk_major() { # $1 = JDK home; echoes the major version (e.g. 21), or nothing
+  "$1/bin/java" -version 2>&1 | sed -n '1s/.*version "\([0-9][0-9]*\).*/\1/p'
+}
+
+compatible_jdk() { # echoes a JDK home whose major <= ANDROID_JDK_MAX, or nothing
+  local c major
+  for c in \
+    "$(brew --prefix openjdk@21 2>/dev/null)/libexec/openjdk.jdk/Contents/Home" \
+    "$(brew --prefix openjdk@17 2>/dev/null)/libexec/openjdk.jdk/Contents/Home" \
+    "$(/usr/libexec/java_home -v 21 2>/dev/null)" \
+    "$(/usr/libexec/java_home -v 17 2>/dev/null)"; do
+    [ -x "$c/bin/java" ] || continue
+    major="$(jdk_major "$c")"
+    [ -n "$major" ] && [ "$major" -le "$ANDROID_JDK_MAX" ] && { echo "$c"; return 0; }
+  done
+  return 1
+}
+
+ensure_android_jdk() {
+  local configured major jdk
+  configured="$(flutter config --machine 2>/dev/null \
+    | sed -n 's/.*"jdk-dir"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')"
+  if [ -n "$configured" ] && [ -x "$configured/bin/java" ]; then
+    major="$(jdk_major "$configured")"
+    if [ -n "$major" ] && [ "$major" -le "$ANDROID_JDK_MAX" ]; then
+      echo "==> Android build JDK: $configured (JDK $major, via flutter --jdk-dir)"
+      return 0
+    fi
+    echo "==> Flutter's configured JDK ($configured, JDK ${major:-?}) is too new for the pinned Gradle 8.14 + AGP 8.11 toolchain."
+  fi
+  if jdk="$(compatible_jdk)"; then
+    echo "==> Pinning Flutter Android build JDK to $jdk"
+    echo "    (reset with: flutter config --jdk-dir=\"\"; see docs/development/flutter/android-jdk.md)"
+    flutter config --jdk-dir="$jdk" >/dev/null
+  else
+    cat >&2 <<'EOF'
+==> No JDK 17 or 21 found. The pinned Gradle 8.14 + AGP 8.11 toolchain cannot run
+    on the JDK 25/26 that Android Studio / Homebrew now ship. Install one and retry:
+        brew install openjdk@21
+    See docs/development/flutter/android-jdk.md for the full rationale.
+EOF
+    exit 1
+  fi
+}
+
 boot_ios() {
   echo "==> Booting iOS Simulator"
   open -a Simulator || true
@@ -122,6 +173,7 @@ OSA
 run_in_dir() { echo "cd '$FLUTTER_DIR' && $FLUTTER_RUN -d $1"; }
 
 # --- main ---
+[ "$RUN_ANDROID" -eq 1 ] && ensure_android_jdk
 [ "$START_BACKEND" -eq 1 ] && start_backend
 [ "$RUN_IOS" -eq 1 ] && boot_ios
 [ "$RUN_ANDROID" -eq 1 ] && boot_android

--- a/scripts/dev-run.sh
+++ b/scripts/dev-run.sh
@@ -84,22 +84,28 @@ start_backend() {
 # can't run on the JDK 25/26 that Android Studio / Homebrew now ship (KT-83610),
 # and Flutter uses Android Studio's bundled JBR unless --jdk-dir overrides it.
 # See docs/development/flutter/android-jdk.md.
+# AGP 8.11 requires JDK 17+, and the pinned Gradle 8.14 can't run on JDK 22+,
+# so a usable Android build JDK must be in the 17-21 range.
+ANDROID_JDK_MIN=17
 ANDROID_JDK_MAX=21
 
 jdk_major() { # $1 = JDK home; echoes the major version (e.g. 21), or nothing
   "$1/bin/java" -version 2>&1 | sed -n '1s/.*version "\([0-9][0-9]*\).*/\1/p'
 }
 
-compatible_jdk() { # echoes a JDK home whose major <= ANDROID_JDK_MAX, or nothing
-  local c major
+jdk_supported() { # $1 = major version; true when within [ANDROID_JDK_MIN, ANDROID_JDK_MAX]
+  [ -n "$1" ] && [ "$1" -ge "$ANDROID_JDK_MIN" ] && [ "$1" -le "$ANDROID_JDK_MAX" ]
+}
+
+compatible_jdk() { # echoes a JDK home whose major is in the supported range, or nothing
+  local c
   for c in \
     "$(brew --prefix openjdk@21 2>/dev/null)/libexec/openjdk.jdk/Contents/Home" \
     "$(brew --prefix openjdk@17 2>/dev/null)/libexec/openjdk.jdk/Contents/Home" \
     "$(/usr/libexec/java_home -v 21 2>/dev/null)" \
     "$(/usr/libexec/java_home -v 17 2>/dev/null)"; do
     [ -x "$c/bin/java" ] || continue
-    major="$(jdk_major "$c")"
-    [ -n "$major" ] && [ "$major" -le "$ANDROID_JDK_MAX" ] && { echo "$c"; return 0; }
+    jdk_supported "$(jdk_major "$c")" && { echo "$c"; return 0; }
   done
   return 1
 }
@@ -110,11 +116,11 @@ ensure_android_jdk() {
     | sed -n 's/.*"jdk-dir"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')"
   if [ -n "$configured" ] && [ -x "$configured/bin/java" ]; then
     major="$(jdk_major "$configured")"
-    if [ -n "$major" ] && [ "$major" -le "$ANDROID_JDK_MAX" ]; then
+    if jdk_supported "$major"; then
       echo "==> Android build JDK: $configured (JDK $major, via flutter --jdk-dir)"
       return 0
     fi
-    echo "==> Flutter's configured JDK ($configured, JDK ${major:-?}) is too new for the pinned Gradle 8.14 + AGP 8.11 toolchain."
+    echo "==> Flutter's configured JDK ($configured, JDK ${major:-?}) is outside the supported ${ANDROID_JDK_MIN}-${ANDROID_JDK_MAX} range for the pinned Gradle 8.14 + AGP 8.11 toolchain."
   fi
   if jdk="$(compatible_jdk)"; then
     echo "==> Pinning Flutter Android build JDK to $jdk"


### PR DESCRIPTION
## Context

Android debug builds (`flutter build apk --debug`, `flutter run`, and `scripts/dev-run.sh --android`) fail early on this machine with a Gradle error whose message is just a JDK version string:

```
FAILURE: Build failed with an exception.
* What went wrong:
25.0.2
java.lang.IllegalArgumentException: 25.0.2
	at org.jetbrains.kotlin.com.intellij.util.lang.JavaVersion.parse(...)
```

Flutter runs Gradle with the JDK bundled by the latest Android Studio (its JBR) unless `--jdk-dir` overrides it. Recent Android Studio bundles JDK 25, and the Homebrew `openjdk` is now 26. The pinned Gradle 8.14 + AGP 8.11.1 + Kotlin 2.2.20 toolchain cannot run on either ([KT-83610](https://youtrack.jetbrains.com/issue/KT-83610); Gradle needs 9.1+ for JDK 25 and 9.4+ for JDK 26). Setting `JAVA_HOME` does not help — the bundled JBR takes precedence over it, verified by forcing `JAVA_HOME` to JDK 21 and still getting the JDK 25 crash.

Closes #484.

## Decision: pin JDK 21, do not upgrade the toolchain (yet)

Making the toolchain accept JDK 25/26 means Gradle 9.x, which forces AGP 9.x (AGP 8.x does not support Gradle 9). That path is currently blocked for this app:

- AGP 9.0 removed support for *applying* the Kotlin Gradle Plugin (which this project uses), and Flutter officially advises against upgrading to AGP 9 ([migrate-to-built-in-kotlin](https://docs.flutter.dev/release/breaking-changes/migrate-to-built-in-kotlin), [flutter/flutter#181383](https://github.com/flutter/flutter/issues/181383)).
- The Firebase Flutter plugins are not yet AGP 9 compatible ([firebase/flutterfire#17987](https://github.com/firebase/flutterfire/issues/17987)), and this app depends on them.
- The pinned Flutter (3.38.3, 2025-11) predates AGP 9.0 stable (2026-01).

So local builds stay within the JDK 17–21 range Flutter and AGP 8.x support. The fix pins JDK 21 via `flutter config --jdk-dir`.

## Changes

- `scripts/dev-run.sh`: a preflight for `--android` that resolves the effective build JDK; when it is newer than 21 (or unset, so Flutter would fall back to the JBR) it finds a JDK 17/21 and configures `--jdk-dir`, or instructs `brew install openjdk@21` when none is present. Fails fast before starting Docker/emulators.
- `docs/development/flutter/android-jdk.md` (new): cause, why the toolchain is not upgraded, one-time setup, and the revisit trigger.
- `peppercheck_flutter/README.md`, `.claude/rules/flutter.md`: link the doc. The verify command now passes `--flavor dev` — without a flavor, Gradle builds every flavor and Flutter reports a misleading "failed to produce an .apk file" even on a successful build.

## Verification

- `brew install openjdk@21` → `flutter config --jdk-dir=<openjdk@21>` → `flutter build apk --debug --flavor dev -t lib/main_dev.dart` → `✓ Built build/app/outputs/flutter-apk/app-dev-debug.apk` (JDK 25 crash gone).
- `scripts/dev-run.sh` preflight: `bash -n` clean; `ensure_android_jdk` proceeds when JDK 21 is configured, and its major-version guard detects a configured JBR 25 and auto-repins to JDK 21.

## Trade-off

The pin must be revisited whenever the default JDK changes (new machine, or an Android Studio update that moves the bundled JBR), and the underlying constraint should be revisited once Flutter and the Firebase Flutter plugins support AGP 9 / built-in Kotlin. Recorded in the doc.

## Documentation

Adds `docs/development/flutter/android-jdk.md` and links it from the Flutter README; no architecture, port, or public-behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DgmCsFDkNvWgeAXZbrGbSW
