### PR TITLE
feat(flutter): add run-and-verify skill and streamline dev-run.sh

### DIFF
--- a/.claude/rules/flutter.md
+++ b/.claude/rules/flutter.md
@@ -5,12 +5,19 @@
 After modifying Dart source files, verify the app compiles:
 
 ```bash
-cd peppercheck_flutter && flutter build apk --debug --flavor dev -t lib/main_dev.dart 2>&1 | tail -10
+scripts/dev-run.sh --build 2>&1 | tail -10
+```
+
+This runs a debug APK compile check with the JDK-21 pin and `--flavor dev`
+applied automatically (no backend or emulator). It wraps:
+
+```bash
+cd peppercheck_flutter && flutter build apk --debug --flavor dev -t lib/main_dev.dart
 ```
 
 The project uses flavored entry points (`main_dev.dart`, `main_staging.dart`, `main_production.dart`), not `lib/main.dart`. Pass `--flavor dev` to match the entry point; without a flavor, Gradle builds every flavor and Flutter reports a misleading "failed to produce an .apk file" even on a successful build.
 
-Local Android builds require a JDK ≤ 21; the JDK 25/26 that Android Studio / Homebrew now ship is too new for the pinned Gradle/AGP toolchain. See `docs/development/flutter/android-jdk.md`.
+Local Android builds require a JDK ≤ 21; the JDK 25/26 that Android Studio / Homebrew now ship is too new for the pinned Gradle/AGP toolchain. `scripts/dev-run.sh` pins it automatically. See `docs/development/flutter/android-jdk.md`.
 
 ## Riverpod Controller Naming
 

--- a/.claude/skills/run-and-verify/SKILL.md
+++ b/.claude/skills/run-and-verify/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: run-and-verify
+description: Run the PepperCheck app + Go backend locally and verify a change end-to-end (backend and iOS/Android simulators). Use when starting the local stack or manually verifying a change — follow the canonical scripts/dev-run.sh / make paths and the SoT docs instead of invoking docker compose or gradle directly.
+---
+
+# Run and verify locally
+
+Canonical way to bring up the local stack and verify a change by hand. The
+detailed steps live in the docs — this skill routes you to them and flags the
+non-obvious traps. Treat [`docs/getting-started.md`](../../../docs/getting-started.md)
+as the source of truth; do not run `docker compose`, `gradlew`, or `flutter run`
+directly when a `scripts/dev-run.sh` / `make` path exists.
+
+## Choose the launcher
+
+- **Primary worktree / single stack** → `scripts/dev-run.sh` (below).
+- **Several isolated backends in parallel worktrees** → `scripts/worktree/dev.sh`
+  (`backend-up`, `flutter-run`, `status`, `backend-down`). It isolates each
+  worktree's Compose project, volumes, and ports. See
+  [`docs/development/git-worktrees.md`](../../../docs/development/git-worktrees.md).
+  Do not use `dev-run.sh` for parallel backends.
+
+## Run the single stack
+
+```sh
+scripts/dev-run.sh --android            # ensure backend is up, then run Android
+scripts/dev-run.sh --ios                # ensure backend is up, then run iOS
+scripts/dev-run.sh --backend --android  # rebuild/restart backend, then run app
+scripts/dev-run.sh --backend            # (re)build/restart the backend only
+```
+
+- A bare platform flag ensures the backend (starts it only if it is not already
+  up on `--caddy-port`), leaving a running backend and its data untouched.
+- Pass `--backend` after editing backend code to force a rebuild/restart. For a
+  full reset including the local DB, use `cd backend && make reset`.
+- Run one platform at a time; see `scripts/dev-run.sh --help` for port and AVD
+  options and [`docs/operations/local-ports.md`](../../../docs/operations/local-ports.md).
+
+## Who runs the interactive app
+
+`dev-run.sh --ios|--android` execs `flutter run` in the foreground, so
+interactive hot reload (`r` / `R` / `q`) works **only when a human runs it in
+their own terminal**. An agent invoking it as a captured command cannot relay
+keystrokes and will just block. Division of labour:
+
+- **Agent** manages the backend (`scripts/dev-run.sh --backend`) and uses
+  `scripts/dev-run.sh --build` for a compile check (JDK-pinned, flavored debug
+  APK; no backend or emulator needed).
+- **Human** runs the interactive app (`scripts/dev-run.sh --android`); the
+  idempotent backend check means it will not disturb the agent's backend.
+
+## Gotchas
+
+- **Real external services (R2 avatar upload).** Plain `make up` / `dev-run.sh`
+  works without secrets, but the R2 avatar-upload flow is non-functional and, per
+  [#483](https://github.com/cloveclovedev/peppercheck/issues/483), fails *open* —
+  it returns a presigned URL to a nonexistent account instead of erroring. To
+  exercise it, inject real dev secrets: `make up BWS_PROJECT_ID=<id>` (find the id
+  with `bws project list`). Everything else (auth/login, `/me`, profile,
+  notification tokens) works without it. See
+  [`docs/development/bws-development.md`](../../../docs/development/bws-development.md).
+- **Manual `flutter build apk`** (only when not using `dev-run.sh`) needs
+  `--flavor dev`, and Android requires a JDK ≤ 21. `dev-run.sh` handles both;
+  direct builds do not. See [`.claude/rules/flutter.md`](../../rules/flutter.md)
+  and [`docs/development/flutter/android-jdk.md`](../../../docs/development/flutter/android-jdk.md).
+
+## Automated checks
+
+Lint, format, analyze, and tests are enforced by the pre-commit hooks and CI —
+this skill covers launching the stack and manual verification, not re-running
+those checks. The check commands, if you need them, are under "Verify changes"
+in [`docs/getting-started.md`](../../../docs/getting-started.md).

--- a/docs/development/bws-development.md
+++ b/docs/development/bws-development.md
@@ -84,6 +84,13 @@ evidence, Phase 5 Stripe/RevenueCat, ...) introduce real dev-side credentials.
    make up BWS_PROJECT_ID=<development-project-id>
    ```
 
+   Find the `development` project's id with `bws project list` (it reads the
+   same `BWS_ACCESS_TOKEN` described below):
+
+   ```bash
+   bws project list
+   ```
+
 ## How it works
 
 `make up BWS_PROJECT_ID=<id>` still creates `backend/.env` from the template

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -40,22 +40,38 @@ From the repository root:
 scripts/dev-run.sh --ios
 ```
 
-Use `--android` for Android, or omit the platform flag to start both. The script
-starts the Go backend, waits for the API, boots the selected simulator or
-emulator, and runs the Flutter dev flavor.
+Use `--android` for Android. Run one platform at a time — `flutter run` holds
+the terminal for interactive hot reload (`r` / `R` / `q`). A platform flag
+ensures the backend is up (starting it only if it is not already answering),
+boots the selected simulator or emulator, and runs the Flutter dev flavor.
 
-Useful options:
+Backend control:
 
 ```sh
-scripts/dev-run.sh --android --avd NAME
-scripts/dev-run.sh --ios --no-backend
-scripts/dev-run.sh --ios --caddy-port 18080 --postgres-port 15432
+scripts/dev-run.sh --android            # ensure backend is up, then run Android
+scripts/dev-run.sh --backend --android  # rebuild/restart backend, then run Android
+scripts/dev-run.sh --backend            # (re)build/restart the backend only
 ```
 
+Pass `--backend` after editing backend code to force `make up` (rebuild changed
+images, recreate changed containers). Without it, a running backend is left
+untouched. For a full reset including the local database, use `make reset`.
+
+Other options:
+
+```sh
+scripts/dev-run.sh --build                          # Android debug APK compile check (no backend/emulator)
+scripts/dev-run.sh --android --avd NAME
+scripts/dev-run.sh --android --caddy-port 18080 --postgres-port 15432
+```
+
+`--build` compiles a debug APK with the JDK-21 pin and `--flavor dev` applied,
+as a quick compile check.
+
 See [local port configuration](operations/local-ports.md) when running multiple
-worktrees or products concurrently. See
-[parallel development with worktrees](development/git-worktrees.md) for the
-repository worktree workflow.
+worktrees or products concurrently. To run several isolated backends in parallel
+worktrees, use `scripts/worktree/dev.sh` — see
+[parallel development with worktrees](development/git-worktrees.md).
 
 ## Verify changes
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -55,7 +55,8 @@ scripts/dev-run.sh --backend            # (re)build/restart the backend only
 
 Pass `--backend` after editing backend code to force `make up` (rebuild changed
 images, recreate changed containers). Without it, a running backend is left
-untouched. For a full reset including the local database, use `make reset`.
+untouched. For a full reset including the local database, use
+`cd backend && make reset`.
 
 Other options:
 

--- a/scripts/dev-run.sh
+++ b/scripts/dev-run.sh
@@ -1,22 +1,42 @@
 #!/usr/bin/env bash
-# One-shot local dev stack for hands-on Firebase auth testing (macOS).
-#   1. starts the backend (Go api + Postgres + Caddy) via docker compose,
+# One-shot local dev stack for hands-on Firebase auth testing (macOS, primary
+# worktree / single stack). For running several isolated backends in parallel
+# worktrees, use scripts/worktree/dev.sh instead — see docs/development/git-worktrees.md.
+#   1. ensures the backend (Go api + Postgres + Caddy) is up via docker compose,
 #      pinning FIREBASE_PROJECT_ID so real Firebase tokens verify, and waits
 #      until GET /api/v1/me responds
-#   2. boots the iOS Simulator and/or an Android emulator
-#   3. runs the Flutter dev flavor on each — a single platform runs in the
-#      foreground (interactive hot reload); both platforms each get their own
-#      Terminal window so hot reload keeps working in each
+#   2. boots the iOS Simulator or Android emulator
+#   3. execs the Flutter dev flavor in the foreground (interactive hot reload:
+#      press r / R / q) — one platform at a time
 #
-# Usage:
-#   scripts/dev-run.sh                       # both iOS + Android (default)
-#   scripts/dev-run.sh --ios                 # iOS only
-#   scripts/dev-run.sh --android             # Android only
-#   scripts/dev-run.sh --no-backend          # skip starting the backend
+# Backend handling:
+#   --ios / --android      ensure the backend is up (start it only if it is not
+#                          already answering on --caddy-port), then run the app
+#   --backend              force `make up` (rebuild changed images + recreate
+#                          changed containers) — use after editing backend code
+#   --backend --android    rebuild/restart the backend AND run the app, one shot
+#   --backend              (alone) bring the backend up without running an app
+# For a full reset incl. the local DB, use `cd backend && make reset` instead.
+#
+# --build compiles a debug Android APK (JDK pin + --flavor dev) as a
+# non-interactive compile check — no backend, no emulator. Use it (rather than a
+# bare `flutter build apk`) so the JDK-21 pin and flavor are always applied.
+#
+# Usage (pass at least one of --backend, --ios, --android, --build; --build is standalone):
+#   scripts/dev-run.sh --android             # ensure backend, run Android
+#   scripts/dev-run.sh --ios                 # ensure backend, run iOS
+#   scripts/dev-run.sh --backend             # (re)build/restart backend only
+#   scripts/dev-run.sh --backend --android   # rebuild backend, then run Android
+#   scripts/dev-run.sh --build               # Android debug APK compile check
 #   scripts/dev-run.sh --avd NAME            # Android AVD (default below; see: flutter emulators)
 #   scripts/dev-run.sh --caddy-port N        # host ingress port (default 80) when 80 is taken
 #   scripts/dev-run.sh --postgres-port N     # host Postgres port (default 5432) when 5432 is taken
 #   scripts/dev-run.sh --firebase-project ID # api token audience (default peppercheck-dev)
+#
+# Interactive hot reload works only when you run this yourself in a terminal:
+# it execs `flutter run` in the foreground. An agent invoking it as a captured
+# command cannot relay keystrokes — let a human drive the app, or use
+# `scripts/dev-run.sh --build` for a compile check.
 #
 # --caddy-port is the single source of truth for the ingress: it publishes the
 # backend Caddy on that host port AND tells the app (via --dart-define) to use
@@ -28,7 +48,7 @@ FLUTTER_DIR="$REPO/peppercheck_flutter"
 BACKEND_DIR="$REPO/backend"
 FLUTTER_RUN_BASE="flutter run --flavor dev -t lib/main_dev.dart"
 
-RUN_IOS=0 RUN_ANDROID=0 EXPLICIT=0 START_BACKEND=1
+RUN_IOS=0 RUN_ANDROID=0 FORCE_BACKEND=0 DO_BUILD=0
 AVD="Medium_Phone_API_36.1"
 FIREBASE_PROJECT="peppercheck-dev"
 CADDY_PORT=80       # host ingress port (backend CADDY_HTTP_PORT + app DEV_API_PORT)
@@ -36,19 +56,30 @@ PG_PORT=5432        # host Postgres port (backend POSTGRES_HOST_PORT), host tool
 
 while [ $# -gt 0 ]; do
   case "$1" in
-    --ios)      RUN_IOS=1; EXPLICIT=1 ;;
-    --android)  RUN_ANDROID=1; EXPLICIT=1 ;;
-    --no-backend) START_BACKEND=0 ;;
+    --ios)      RUN_IOS=1 ;;
+    --android)  RUN_ANDROID=1 ;;
+    --backend)  FORCE_BACKEND=1 ;;
+    --build)    DO_BUILD=1 ;;
     --avd)      AVD="${2:?}"; shift ;;
     --caddy-port)    CADDY_PORT="${2:?}"; shift ;;
     --postgres-port) PG_PORT="${2:?}"; shift ;;
     --firebase-project) FIREBASE_PROJECT="${2:?}"; shift ;;
-    -h|--help)  sed -n '2,23p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+    -h|--help)  sed -n '2,42p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
     *) echo "unknown arg: $1" >&2; exit 2 ;;
   esac
   shift
 done
-[ "$EXPLICIT" -eq 1 ] || { RUN_IOS=1; RUN_ANDROID=1; }
+[ "$RUN_IOS" -eq 1 ] || [ "$RUN_ANDROID" -eq 1 ] || [ "$FORCE_BACKEND" -eq 1 ] || [ "$DO_BUILD" -eq 1 ] || {
+  echo "specify at least one of --backend, --ios, --android, --build" >&2; exit 2
+}
+if [ "$DO_BUILD" -eq 1 ] && { [ "$RUN_IOS" -eq 1 ] || [ "$RUN_ANDROID" -eq 1 ] || [ "$FORCE_BACKEND" -eq 1 ]; }; then
+  echo "--build is a standalone Android compile check; don't combine it with --backend/--ios/--android" >&2
+  exit 2
+fi
+if [ "$RUN_IOS" -eq 1 ] && [ "$RUN_ANDROID" -eq 1 ]; then
+  echo "run one platform at a time (--ios or --android): flutter run holds the terminal for hot reload" >&2
+  exit 2
+fi
 
 # The ingress port is the single source of truth: the backend publishes Caddy
 # on it and the app is told the same value, so they always agree.
@@ -56,6 +87,20 @@ API_HEALTH_URL="http://127.0.0.1:${CADDY_PORT}/api/v1/me"
 FLUTTER_RUN="$FLUTTER_RUN_BASE --dart-define=DEV_API_PORT=$CADDY_PORT"
 
 IOS_DEVICE="" ANDROID_DEVICE=""
+
+backend_healthy() { # true when something answers the ingress on this caddy port
+  local code
+  code="$(curl -s -o /dev/null -w '%{http_code}' "$API_HEALTH_URL" 2>/dev/null || true)"
+  [ -n "$code" ] && [ "$code" != "000" ]
+}
+
+ensure_backend() { # idempotent: start the backend only if it is not already up
+  if backend_healthy; then
+    echo "==> Backend already up on :$CADDY_PORT (skipping; pass --backend to rebuild/restart)"
+    return 0
+  fi
+  start_backend
+}
 
 start_backend() {
   echo "==> Starting backend (FIREBASE_PROJECT_ID=$FIREBASE_PROJECT, Caddy :$CADDY_PORT, Postgres :$PG_PORT)"
@@ -167,33 +212,33 @@ boot_android() {
   printf ' ready (%s)\n' "$ANDROID_DEVICE"
 }
 
-open_terminal() { # $1 = shell command to run in a new Terminal window
-  osascript >/dev/null <<OSA
-tell application "Terminal"
-  activate
-  do script "$1"
-end tell
-OSA
-}
-
-run_in_dir() { echo "cd '$FLUTTER_DIR' && $FLUTTER_RUN -d $1"; }
-
 # --- main ---
+# --build: JDK-pinned, flavored debug APK compile check. No backend, no emulator.
+if [ "$DO_BUILD" -eq 1 ]; then
+  ensure_android_jdk
+  cd "$FLUTTER_DIR"
+  exec flutter build apk --debug --flavor dev -t lib/main_dev.dart
+fi
+
+# Fail fast on the Android JDK before touching the backend or emulator.
 [ "$RUN_ANDROID" -eq 1 ] && ensure_android_jdk
-[ "$START_BACKEND" -eq 1 ] && start_backend
+
+# --backend forces a (re)build/restart; a bare platform run only ensures the
+# backend is up (leaving an already-running one — and its data — untouched).
+if [ "$FORCE_BACKEND" -eq 1 ]; then
+  start_backend
+elif [ "$RUN_IOS" -eq 1 ] || [ "$RUN_ANDROID" -eq 1 ]; then
+  ensure_backend
+fi
+
 [ "$RUN_IOS" -eq 1 ] && boot_ios
 [ "$RUN_ANDROID" -eq 1 ] && boot_android
 
-if [ "$RUN_IOS" -eq 1 ] && [ "$RUN_ANDROID" -eq 1 ]; then
-  echo "==> Launching both platforms in separate Terminal windows"
-  open_terminal "$(run_in_dir "$IOS_DEVICE")"
-  open_terminal "$(run_in_dir "$ANDROID_DEVICE")"
-  cat <<DONE
-Two Terminal windows opened (iOS + Android); press 'r' in each for hot reload.
-Backend stays up; stop it with:  (cd backend && make down)
-DONE
-elif [ "$RUN_IOS" -eq 1 ]; then
+# exec into the interactive foreground flutter run (hot reload: r / R / q).
+if [ "$RUN_IOS" -eq 1 ]; then
   cd "$FLUTTER_DIR"; exec $FLUTTER_RUN -d "$IOS_DEVICE"
-else
+elif [ "$RUN_ANDROID" -eq 1 ]; then
   cd "$FLUTTER_DIR"; exec $FLUTTER_RUN -d "$ANDROID_DEVICE"
+else
+  echo "==> Backend ready on :$CADDY_PORT. Run the app with: scripts/dev-run.sh --android | --ios"
 fi

--- a/scripts/dev-run.sh
+++ b/scripts/dev-run.sh
@@ -88,10 +88,12 @@ FLUTTER_RUN="$FLUTTER_RUN_BASE --dart-define=DEV_API_PORT=$CADDY_PORT"
 
 IOS_DEVICE="" ANDROID_DEVICE=""
 
-backend_healthy() { # true when something answers the ingress on this caddy port
-  local code
-  code="$(curl -s -o /dev/null -w '%{http_code}' "$API_HEALTH_URL" 2>/dev/null || true)"
-  [ -n "$code" ] && [ "$code" != "000" ]
+backend_healthy() { # true only for the PepperCheck API's expected unauthenticated 401
+  # A bare 2xx/3xx/4xx isn't enough: Caddy up but the api down returns 502, and
+  # an unrelated service on this port could return anything. Require the exact
+  # 401 that GET /api/v1/me gives without a token so we never skip startup for,
+  # or launch the app against, a broken or unrelated backend.
+  [ "$(curl -s -o /dev/null -w '%{http_code}' "$API_HEALTH_URL" 2>/dev/null || true)" = "401" ]
 }
 
 ensure_backend() { # idempotent: start the backend only if it is not already up
@@ -116,9 +118,8 @@ start_backend() {
   fi
   printf '==> Waiting for %s ' "$API_HEALTH_URL"
   for i in $(seq 1 60); do
-    code="$(curl -s -o /dev/null -w '%{http_code}' "$API_HEALTH_URL" || true)"
-    if [ -n "$code" ] && [ "$code" != "000" ]; then
-      printf ' ready (HTTP %s — 401 is expected)\n' "$code"; return 0
+    if backend_healthy; then
+      printf ' ready (HTTP 401 as expected)\n'; return 0
     fi
     printf '.'; sleep 2
   done


### PR DESCRIPTION
## Context

Local verification in this repo requires several non-obvious, repo-specific steps (start the Go backend with the right ports and a real `FIREBASE_PROJECT_ID`, wait for health, boot a simulator, run the correct flavored entry point). The knowledge was scattered, and while fixing #484 an agent reached for `docker compose` / `gradle` / bare `flutter` directly instead of the canonical paths.

This adds a repo-committed `run-and-verify` skill that routes to the canonical launch/verify paths and the SoT docs, and flags the traps — and streamlines `scripts/dev-run.sh` around that flow.

Closes #487. The strategy in `project_agent_skill_strategy_decision` (procedures → repo docs/rules; skills only for non-obvious, high-cost gotchas) is respected: the skill duplicates no procedure — it links `docs/getting-started.md` as SoT and carries only the routing + gotchas.

## dev-run.sh redesign

- **Remove** the two-terminal both-platform mode and `--no-backend`. Run one platform at a time (`flutter run` holds the terminal for hot reload).
- **Idempotent backend:** a bare `--ios`/`--android` ensures the backend is up (health-check on the caddy port; start only if down), leaving a running backend and its data untouched — so `--no-backend` is no longer needed.
- **`--backend`** forces `make up` (rebuild changed images, recreate changed containers). Combine as `--backend --android` to rebuild and run in one shot. Full reset stays `make reset`.
- **`--build`** (new): a JDK-pinned, `--flavor dev` debug APK compile check with no backend or emulator. Previously only the *run* path got the JDK-21 pin; a bare `flutter build apk` on a JDK-25/26 machine would hit #484. `.claude/rules/flutter.md` now points at `scripts/dev-run.sh --build`.

Parallel isolated backends across worktrees remain the job of `scripts/worktree/dev.sh` (unchanged); the skill and docs route there for that case.

## Docs

- `docs/getting-started.md`: updated to the new dev-run.sh model (`--backend`, `--build`, one platform at a time); removed the "omit to start both" / `--no-backend` guidance.
- `docs/development/bws-development.md`: added the `bws project list` lookup for the dev project id.
- `.claude/rules/flutter.md`: compile check now `scripts/dev-run.sh --build`.

## Out of scope

Automated checks (fmt/lint/analyze/test) are intentionally left to pre-commit and CI; auditing and closing that coverage is tracked in **#488**.

## Verification

- `scripts/dev-run.sh --build` → `✓ Built build/app/outputs/flutter-apk/app-dev-debug.apk` (JDK-21 pin + flavor applied via the new path).
- `bash -n` clean. Guards exercised: no args → error listing the four flags; `--ios --android` → "one platform at a time"; `--build --android` → "standalone compile check"; `--help` prints the full header (range verified).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DgmCsFDkNvWgeAXZbrGbSW
