### PR TITLE
feat(flutter): core/network — ApiClient write verbs + PresignedUploadClient (P3a-2a)

### DIFF
--- a/peppercheck_flutter/lib/core/network/api_client.dart
+++ b/peppercheck_flutter/lib/core/network/api_client.dart
@@ -84,6 +84,52 @@ class ApiClient {
     throw _mapErrorResponse(res);
   }
 
+  /// PATCH [path] with a JSON [body] and decode the JSON object response.
+  /// Never auto-retries on 401.
+  Future<Map<String, dynamic>> patchJson(String path, {Object? body}) =>
+      _sendJson('PATCH', path, body: body);
+
+  /// POST [path] with a JSON [body] and decode the JSON object response.
+  /// Never auto-retries on 401.
+  Future<Map<String, dynamic>> postJson(String path, {Object? body}) =>
+      _sendJson('POST', path, body: body);
+
+  /// PUT [path] with a JSON [body]; succeeds on any 2xx, including a body-less
+  /// 204. Never auto-retries on 401.
+  Future<void> putJson(String path, {Object? body}) =>
+      _sendVoid('PUT', path, body: body);
+
+  /// DELETE [path] with an optional JSON [body]; succeeds on any 2xx,
+  /// including a body-less 204. Never auto-retries on 401.
+  Future<void> deleteJson(String path, {Object? body}) =>
+      _sendVoid('DELETE', path, body: body);
+
+  Future<Map<String, dynamic>> _sendJson(
+    String method,
+    String path, {
+    Object? body,
+  }) async {
+    final res = await _sendBody(method, path, body: body, forceRefresh: false);
+    if (res.statusCode != null &&
+        res.statusCode! >= 200 &&
+        res.statusCode! < 300) {
+      final data = res.data;
+      if (data is Map<String, dynamic>) return data;
+      return <String, dynamic>{};
+    }
+    throw _mapErrorResponse(res);
+  }
+
+  Future<void> _sendVoid(String method, String path, {Object? body}) async {
+    final res = await _sendBody(method, path, body: body, forceRefresh: false);
+    if (res.statusCode != null &&
+        res.statusCode! >= 200 &&
+        res.statusCode! < 300) {
+      return;
+    }
+    throw _mapErrorResponse(res);
+  }
+
   Future<Response<dynamic>> _send(
     String path, {
     required bool authenticated,
@@ -103,6 +149,37 @@ class ApiClient {
       if (token != null) headers['Authorization'] = 'Bearer $token';
     }
     return _dio.get<dynamic>(path, options: Options(headers: headers));
+  }
+
+  /// Attaches the bearer + request-id headers and issues an authenticated
+  /// [method] request with a JSON [body]. Used by the write verbs, which
+  /// never retry on 401 (unlike [getJson]).
+  Future<Response<dynamic>> _sendBody(
+    String method,
+    String path, {
+    required Object? body,
+    required bool forceRefresh,
+  }) async {
+    final headers = <String, dynamic>{_requestIdHeader: _newRequestId()};
+    final String? token;
+    try {
+      token = await _idTokenProvider(forceRefresh: forceRefresh);
+    } catch (_, stackTrace) {
+      Error.throwWithStackTrace(
+        const ApiException.tokenUnavailable(),
+        stackTrace,
+      );
+    }
+    if (token != null) headers['Authorization'] = 'Bearer $token';
+    try {
+      return await _dio.request<dynamic>(
+        path,
+        data: body,
+        options: Options(method: method, headers: headers),
+      );
+    } on DioException catch (e) {
+      throw _mapDioException(e);
+    }
   }
 
   ApiException _mapErrorResponse(Response<dynamic> res) {

--- a/peppercheck_flutter/lib/core/network/presigned_upload_client.dart
+++ b/peppercheck_flutter/lib/core/network/presigned_upload_client.dart
@@ -1,0 +1,70 @@
+import 'package:dio/dio.dart';
+
+/// Uploads avatar bytes directly to Cloudflare R2 via a presigned URL. This is
+/// a bare Dio instance separate from [ApiClient]: no Firebase bearer, no API
+/// interceptors, and the [uploadUrl] (its query string is a credential) is
+/// never logged.
+class PresignedUploadClient {
+  PresignedUploadClient({Dio? dio})
+    : _dio =
+          dio ??
+          Dio(
+            BaseOptions(
+              connectTimeout: const Duration(seconds: 10),
+              sendTimeout: const Duration(seconds: 30),
+              receiveTimeout: const Duration(seconds: 30),
+              // We validate status ourselves and map non-2xx to UploadFailed.
+              validateStatus: (_) => true,
+            ),
+          ) {
+    if (dio != null) {
+      _dio.options
+        ..connectTimeout ??= const Duration(seconds: 10)
+        ..sendTimeout ??= const Duration(seconds: 30)
+        ..receiveTimeout ??= const Duration(seconds: 30)
+        ..validateStatus = (_) => true;
+    }
+  }
+
+  final Dio _dio;
+
+  /// PUTs [bytes] to [uploadUrl] with the given [contentType]. Throws
+  /// [UploadFailed] on any non-2xx response or transport failure.
+  Future<void> put({
+    required String uploadUrl,
+    required List<int> bytes,
+    required String contentType,
+  }) async {
+    final Response<dynamic> res;
+    try {
+      res = await _dio.putUri<dynamic>(
+        Uri.parse(uploadUrl),
+        data: Stream.fromIterable([bytes]),
+        options: Options(
+          headers: {
+            Headers.contentTypeHeader: contentType,
+            Headers.contentLengthHeader: bytes.length,
+          },
+        ),
+      );
+    } on DioException catch (e) {
+      throw UploadFailed(statusCode: e.response?.statusCode);
+    }
+    final status = res.statusCode;
+    if (status == null || status < 200 || status >= 300) {
+      throw UploadFailed(statusCode: status);
+    }
+  }
+}
+
+/// Thrown by [PresignedUploadClient.put] on a non-2xx response or transport
+/// failure. Deliberately not an [ApiException]: this client never touches the
+/// server error envelope.
+class UploadFailed implements Exception {
+  const UploadFailed({this.statusCode});
+
+  final int? statusCode;
+
+  @override
+  String toString() => 'UploadFailed(statusCode: $statusCode)';
+}

--- a/peppercheck_flutter/lib/core/network/presigned_upload_client_provider.dart
+++ b/peppercheck_flutter/lib/core/network/presigned_upload_client_provider.dart
@@ -1,0 +1,13 @@
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+import 'presigned_upload_client.dart';
+
+part 'presigned_upload_client_provider.g.dart';
+
+/// The app-wide [PresignedUploadClient] used to PUT avatar bytes directly to
+/// R2. Separate from the `apiClient` provider: no Firebase bearer, no
+/// interceptors.
+@Riverpod(keepAlive: true)
+PresignedUploadClient presignedUploadClient(Ref ref) {
+  return PresignedUploadClient();
+}

--- a/peppercheck_flutter/lib/core/network/presigned_upload_client_provider.g.dart
+++ b/peppercheck_flutter/lib/core/network/presigned_upload_client_provider.g.dart
@@ -1,0 +1,68 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'presigned_upload_client_provider.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+/// The app-wide [PresignedUploadClient] used to PUT avatar bytes directly to
+/// R2. Separate from the `apiClient` provider: no Firebase bearer, no
+/// interceptors.
+
+@ProviderFor(presignedUploadClient)
+const presignedUploadClientProvider = PresignedUploadClientProvider._();
+
+/// The app-wide [PresignedUploadClient] used to PUT avatar bytes directly to
+/// R2. Separate from the `apiClient` provider: no Firebase bearer, no
+/// interceptors.
+
+final class PresignedUploadClientProvider
+    extends
+        $FunctionalProvider<
+          PresignedUploadClient,
+          PresignedUploadClient,
+          PresignedUploadClient
+        >
+    with $Provider<PresignedUploadClient> {
+  /// The app-wide [PresignedUploadClient] used to PUT avatar bytes directly to
+  /// R2. Separate from the `apiClient` provider: no Firebase bearer, no
+  /// interceptors.
+  const PresignedUploadClientProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'presignedUploadClientProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$presignedUploadClientHash();
+
+  @$internal
+  @override
+  $ProviderElement<PresignedUploadClient> $createElement(
+    $ProviderPointer pointer,
+  ) => $ProviderElement(pointer);
+
+  @override
+  PresignedUploadClient create(Ref ref) {
+    return presignedUploadClient(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(PresignedUploadClient value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<PresignedUploadClient>(value),
+    );
+  }
+}
+
+String _$presignedUploadClientHash() =>
+    r'0d00fb718156deccf667b2be782848d502af8bf0';

--- a/peppercheck_flutter/test/core/network/api_client_test.dart
+++ b/peppercheck_flutter/test/core/network/api_client_test.dart
@@ -182,4 +182,150 @@ void main() {
     );
     expect(adapter.requests, isEmpty);
   });
+
+  test(
+    'patchJson sends PATCH with bearer + request-id and decodes the body',
+    () async {
+      final adapter = _FakeAdapter((o, _) => _json(200, {'username': 'alice'}));
+      final client = _client(adapter);
+
+      final body = await client.patchJson(
+        '/api/v1/me/profile',
+        body: {'username': 'alice'},
+      );
+
+      expect(adapter.requests.single.method, 'PATCH');
+      expect(adapter.requests.single.headers['Authorization'], 'Bearer tok-1');
+      expect(adapter.requests.single.headers['X-Request-Id'], isNotEmpty);
+      expect(adapter.requests.single.data, {'username': 'alice'});
+      expect(body['username'], 'alice');
+    },
+  );
+
+  test(
+    'patchJson maps a 409 envelope to ApiException(username_taken)',
+    () async {
+      final adapter = _FakeAdapter(
+        (o, _) => _json(409, {
+          'error': {
+            'code': 'username_taken',
+            'message': 'already taken',
+            'requestId': 'req-1',
+          },
+        }),
+      );
+      final client = _client(adapter);
+
+      expect(
+        () => client.patchJson('/api/v1/me/profile', body: {'username': 'x'}),
+        throwsA(
+          isA<ApiException>()
+              .having((e) => e.code, 'code', 'username_taken')
+              .having((e) => e.statusCode, 'statusCode', 409),
+        ),
+      );
+    },
+  );
+
+  test('patchJson does not retry on 401', () async {
+    final adapter = _FakeAdapter(
+      (o, _) => _json(401, {
+        'error': {'code': 'unauthenticated', 'message': 'x', 'requestId': 'r'},
+      }),
+    );
+    final client = _client(adapter);
+
+    await expectLater(
+      () => client.patchJson('/api/v1/me/profile', body: {'username': 'x'}),
+      throwsA(isA<ApiException>()),
+    );
+    expect(adapter.requests.length, 1, reason: 'no auto-retry on write verbs');
+  });
+
+  test(
+    'postJson sends POST with bearer + request-id and decodes the body',
+    () async {
+      final adapter = _FakeAdapter(
+        (o, _) => _json(200, {'uploadUrl': 'https://r2.example/put'}),
+      );
+      final client = _client(adapter);
+
+      final body = await client.postJson(
+        '/api/v1/me/profile/avatar-upload',
+        body: {'contentType': 'image/jpeg'},
+      );
+
+      expect(adapter.requests.single.method, 'POST');
+      expect(adapter.requests.single.headers['Authorization'], 'Bearer tok-1');
+      expect(adapter.requests.single.headers['X-Request-Id'], isNotEmpty);
+      expect(body['uploadUrl'], 'https://r2.example/put');
+    },
+  );
+
+  test('postJson does not retry on 401', () async {
+    final adapter = _FakeAdapter(
+      (o, _) => _json(401, {
+        'error': {'code': 'unauthenticated', 'message': 'x', 'requestId': 'r'},
+      }),
+    );
+    final client = _client(adapter);
+
+    await expectLater(
+      () => client.postJson('/api/v1/me/profile/avatar-upload'),
+      throwsA(isA<ApiException>()),
+    );
+    expect(adapter.requests.length, 1, reason: 'no auto-retry on write verbs');
+  });
+
+  test('putJson succeeds on 204 with no body', () async {
+    final adapter = _FakeAdapter((o, _) => ResponseBody.fromString('', 204));
+    final client = _client(adapter);
+
+    await client.putJson('/api/v1/me/fcm-tokens', body: {'token': 't1'});
+
+    expect(adapter.requests.single.method, 'PUT');
+    expect(adapter.requests.single.headers['Authorization'], 'Bearer tok-1');
+    expect(adapter.requests.single.headers['X-Request-Id'], isNotEmpty);
+  });
+
+  test('putJson does not retry on 401', () async {
+    final adapter = _FakeAdapter(
+      (o, _) => _json(401, {
+        'error': {'code': 'unauthenticated', 'message': 'x', 'requestId': 'r'},
+      }),
+    );
+    final client = _client(adapter);
+
+    await expectLater(
+      () => client.putJson('/api/v1/me/fcm-tokens', body: {'token': 't1'}),
+      throwsA(isA<ApiException>()),
+    );
+    expect(adapter.requests.length, 1, reason: 'no auto-retry on write verbs');
+  });
+
+  test('deleteJson succeeds on 204 with no body', () async {
+    final adapter = _FakeAdapter((o, _) => ResponseBody.fromString('', 204));
+    final client = _client(adapter);
+
+    await client.deleteJson('/api/v1/me/fcm-tokens', body: {'token': 't1'});
+
+    expect(adapter.requests.single.method, 'DELETE');
+    expect(adapter.requests.single.headers['Authorization'], 'Bearer tok-1');
+    expect(adapter.requests.single.headers['X-Request-Id'], isNotEmpty);
+  });
+
+  test('deleteJson does not retry on 401', () async {
+    final adapter = _FakeAdapter(
+      (o, _) => _json(401, {
+        'error': {'code': 'unauthenticated', 'message': 'x', 'requestId': 'r'},
+      }),
+    );
+    final client = _client(adapter);
+
+    await expectLater(
+      () => client.deleteJson('/api/v1/me/fcm-tokens', body: {'token': 't1'}),
+      throwsA(isA<ApiException>()),
+    );
+    expect(adapter.requests.length, 1, reason: 'no auto-retry on write verbs');
+  });
 }

--- a/peppercheck_flutter/test/core/network/api_client_test.dart
+++ b/peppercheck_flutter/test/core/network/api_client_test.dart
@@ -216,7 +216,7 @@ void main() {
       );
       final client = _client(adapter);
 
-      expect(
+      await expectLater(
         () => client.patchJson('/api/v1/me/profile', body: {'username': 'x'}),
         throwsA(
           isA<ApiException>()

--- a/peppercheck_flutter/test/core/network/presigned_upload_client_test.dart
+++ b/peppercheck_flutter/test/core/network/presigned_upload_client_test.dart
@@ -1,0 +1,104 @@
+import 'dart:typed_data';
+
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:peppercheck_flutter/core/network/presigned_upload_client.dart';
+
+/// Records the last request and returns a scripted response, mirroring the
+/// `_FakeAdapter` used in `api_client_test.dart`.
+class _FakeAdapter implements HttpClientAdapter {
+  _FakeAdapter(this.handler);
+
+  final ResponseBody Function(RequestOptions options) handler;
+  final List<RequestOptions> requests = [];
+
+  @override
+  void close({bool force = false}) {}
+
+  @override
+  Future<ResponseBody> fetch(
+    RequestOptions options,
+    Stream<Uint8List>? requestStream,
+    Future<void>? cancelFuture,
+  ) async {
+    requests.add(options);
+    return handler(options);
+  }
+}
+
+ResponseBody _empty(int status) => ResponseBody.fromString('', status);
+
+PresignedUploadClient _client(_FakeAdapter adapter) {
+  final dio = Dio()..httpClientAdapter = adapter;
+  return PresignedUploadClient(dio: dio);
+}
+
+void main() {
+  test(
+    'put issues a PUT to the exact uploadUrl with content headers and no Authorization',
+    () async {
+      final adapter = _FakeAdapter((o) => _empty(200));
+      final client = _client(adapter);
+      final bytes = List<int>.generate(10, (i) => i);
+      const uploadUrl =
+          'https://r2.example.com/bucket/key?X-Amz-Signature=secret';
+
+      await client.put(
+        uploadUrl: uploadUrl,
+        bytes: bytes,
+        contentType: 'image/jpeg',
+      );
+
+      final req = adapter.requests.single;
+      expect(req.method, 'PUT');
+      expect(req.uri.toString(), uploadUrl);
+      expect(req.headers[Headers.contentTypeHeader], 'image/jpeg');
+      expect(req.headers[Headers.contentLengthHeader], bytes.length);
+      expect(req.headers.containsKey('Authorization'), isFalse);
+    },
+  );
+
+  test('put succeeds on a 204 response', () async {
+    final adapter = _FakeAdapter((o) => _empty(204));
+    final client = _client(adapter);
+
+    await client.put(
+      uploadUrl: 'https://r2.example.com/bucket/key',
+      bytes: [1, 2, 3],
+      contentType: 'image/jpeg',
+    );
+  });
+
+  test('throws UploadFailed on a non-2xx response', () async {
+    final adapter = _FakeAdapter((o) => _empty(500));
+    final client = _client(adapter);
+
+    await expectLater(
+      () => client.put(
+        uploadUrl: 'https://r2.example.com/bucket/key',
+        bytes: [1, 2, 3],
+        contentType: 'image/jpeg',
+      ),
+      throwsA(isA<UploadFailed>()),
+    );
+  });
+
+  test('throws UploadFailed on a transport failure', () async {
+    final adapter = _FakeAdapter(
+      (o) => throw DioException.connectionTimeout(
+        timeout: const Duration(seconds: 1),
+        requestOptions: o,
+      ),
+    );
+    final client = _client(adapter);
+
+    await expectLater(
+      () => client.put(
+        uploadUrl: 'https://r2.example.com/bucket/key',
+        bytes: [1, 2, 3],
+        contentType: 'image/jpeg',
+      ),
+      throwsA(isA<UploadFailed>()),
+    );
+  });
+}


### PR DESCRIPTION
## Summary
- Add idempotent write verbs (`patchJson`/`postJson`/`putJson`/`deleteJson`) to `ApiClient`, matching `getJson`'s bearer/request-id/error-mapping but never auto-retrying on 401.
- Add `PresignedUploadClient` (`core/network`) for direct-to-R2 avatar byte uploads: bare Dio, no Firebase bearer, no interceptors, never logs the presigned URL, throws a distinct `UploadFailed` on non-2xx.

First of four sub-issues splitting Phase 3a Flutter (#491) into scoped PRs. Foundation for the `profile` (#493) and `notification` (#494) migrations.

Closes #492

## Test plan
- [x] `flutter test test/core/network/` — 22/22 pass
- [x] `flutter analyze` — clean
- [x] `flutter build apk --debug --flavor dev -t lib/main_dev.dart` — succeeds
- [x] Independent opus review of the full diff — no correctness/security findings; one low-severity test-assertion nit found and fixed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HdVukkt1tvf6HoL3yNec5y