### PR TITLE
chore(flutter): Phase 3a CI import checks + emulator verification (P3a-2d)

### DIFF
--- a/scripts/check-flutter-imports.sh
+++ b/scripts/check-flutter-imports.sh
@@ -1,11 +1,13 @@
 #!/usr/bin/env bash
 # Enforces import boundaries in the Flutter app:
 #   1. firebase_auth may only be imported under lib/features/auth/.
-#   2. the authenticated-user path (features/auth, core/network) must not
-#      import supabase_flutter.
-# The "Dio construction only in core/network" rule from the design (spec §8) is
-# deliberately NOT enforced yet: evidence/profile still build Dio for R2 uploads
-# until their own migration phase. Add that check when those features move.
+#   2. supabase_flutter must not be imported by the features already migrated
+#      off it: features/auth, features/profile, features/notification, or by
+#      core/network.
+#   3. Dio is only constructed in core/network — features must go through
+#      ApiClient/PresignedUploadClient, never build their own Dio instance.
+# evidence still builds Dio directly for R2 uploads until its own migration
+# phase (Phase 4b); it is deliberately excluded from rule 3 until then.
 set -euo pipefail
 cd "$(dirname "$0")/.."
 lib=peppercheck_flutter/lib
@@ -20,10 +22,19 @@ if [ -n "$bad_fb" ]; then
 fi
 
 bad_sb=$(grep -rl "package:supabase_flutter/" \
-  "$lib/features/auth" "$lib/core/network" || true)
+  "$lib/features/auth" "$lib/features/profile" "$lib/features/notification" \
+  "$lib/core/network" || true)
 if [ -n "$bad_sb" ]; then
-  echo "ERROR: supabase_flutter imported on the auth path (features/auth, core/network):"
+  echo "ERROR: supabase_flutter imported on a migrated path (features/auth, features/profile, features/notification, core/network):"
   echo "$bad_sb"
+  fail=1
+fi
+
+bad_dio=$(grep -rl "Dio(" "$lib/features" \
+  | grep -v "^$lib/features/evidence/" || true)
+if [ -n "$bad_dio" ]; then
+  echo "ERROR: Dio constructed outside core/network (features must use ApiClient/PresignedUploadClient):"
+  echo "$bad_dio"
   fail=1
 fi
 

--- a/scripts/check-flutter-imports.sh
+++ b/scripts/check-flutter-imports.sh
@@ -30,7 +30,8 @@ if [ -n "$bad_sb" ]; then
   fail=1
 fi
 
-bad_dio=$(grep -rl "Dio(" "$lib/features" \
+bad_dio=$(grep -rl "Dio(" "$lib" \
+  | grep -v "^$lib/core/network/" \
   | grep -v "^$lib/features/evidence/" || true)
 if [ -n "$bad_dio" ]; then
   echo "ERROR: Dio constructed outside core/network (features must use ApiClient/PresignedUploadClient):"

--- a/scripts/check-flutter-imports.sh
+++ b/scripts/check-flutter-imports.sh
@@ -30,7 +30,7 @@ if [ -n "$bad_sb" ]; then
   fail=1
 fi
 
-bad_dio=$(grep -rl "Dio(" "$lib" \
+bad_dio=$(grep -rlE "Dio\(|Dio\.new" "$lib" \
   | grep -v "^$lib/core/network/" \
   | grep -v "^$lib/features/evidence/" || true)
 if [ -n "$bad_dio" ]; then


### PR DESCRIPTION
## Summary
- Extend `scripts/check-flutter-imports.sh`: `supabase_flutter` must not be imported by `features/profile` or `features/notification` (both now migrated onto the Go API), on top of the existing `features/auth`/`core/network` rule.
- Add the Dio-construction-only-in-`core/network` check the script's original comment deferred until profile moved off Supabase — profile has now moved (`evidence` stays excluded until its own Phase 4b migration).
- Full verification pass on the fully-integrated branch (#496 + #498 + #499 all merged): `dart format`, `flutter analyze`, full `flutter test` suite, flavored debug build — all green, no code changes needed.

Closes #495, and closes out the P3a-2 parent (#491).

## Test plan
- [x] `bash scripts/check-flutter-imports.sh` — passes on the fully-integrated branch
- [x] `dart format --set-exit-if-changed lib test` — no changes needed
- [x] `flutter analyze` — clean (5 pre-existing unrelated infos in `evidence`/`report`, untouched by Phase 3a)
- [x] `flutter test` — full suite passes
- [x] `scripts/dev-run.sh --build` (flavored dev debug APK) — succeeds
- [ ] Single emulator verification pass (profile view/edit/avatar upload, notification token registration, sign-out token deregistration) — pending, see comment below

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HdVukkt1tvf6HoL3yNec5y