### PR TITLE
chore(backend,flutter): auto-resolve bws project + opt-in dev-run.sh --bws

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -30,6 +30,11 @@ FIREBASE_PROJECT_ID=peppercheck-local
 # R2_ACCOUNT_ID / R2_BUCKET / R2_PUBLIC_DOMAIN are non-secret (see
 # internal/core/config/config.go) — to test against a real dev bucket, just
 # replace these three with real values in your own .env.
+# R2_PUBLIC_DOMAIN must be a bare hostname with NO https:// prefix (it's
+# combined as fmt.Sprintf("https://%s/...", publicDomain) in
+# internal/profile/service.go and matched against the parsed avatarUrl's
+# u.Host on PATCH) — including the scheme makes every avatar PATCH fail
+# with 400 invalid_argument.
 R2_ACCOUNT_ID=r2-local-account
 R2_BUCKET=peppercheck-avatars-local
 R2_PUBLIC_DOMAIN=cdn.local.example.com

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -15,12 +15,14 @@ TEST_POSTGRES_PORT ?= 55432
 help: ## Show available targets
 	grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN{FS=":.*?## "}{printf "  %-9s %s\n", $$1, $$2}'
 
-up: ## Start the core stack (creates .env if missing). Add BWS_PROJECT_ID=<id> to inject real dev secrets via Bitwarden Secrets Manager (see docs/development/bws-development.md)
+up: ## Start the core stack (creates .env if missing). Off by default (plain .env dummies) so a fresh clone with no Bitwarden access always works. Add BWS_PROJECT_ID=auto to inject real dev secrets via the shared 'development' project (auto-resolved by name — see docs/development/bws-development.md), or BWS_PROJECT_ID=<id> for a specific project.
 	[ -f .env ] || cp .env.example .env
-	@if [ -n "$(BWS_PROJECT_ID)" ]; then \
-		scripts/bws-dev-up.sh "$(BWS_PROJECT_ID)"; \
-	else \
+	@if [ -z "$(BWS_PROJECT_ID)" ]; then \
 		docker compose up -d --build; \
+	elif [ "$(BWS_PROJECT_ID)" = "auto" ]; then \
+		scripts/bws-dev-up.sh; \
+	else \
+		scripts/bws-dev-up.sh "$(BWS_PROJECT_ID)"; \
 	fi
 
 down: ## Stop the stack (keep volumes)

--- a/backend/compose.yaml
+++ b/backend/compose.yaml
@@ -93,7 +93,7 @@ services:
       # dummy values below the api still constructs an R2 client (r2.New only
       # rejects empty fields, not placeholder ones — see #483) that presigns
       # against a nonexistent account, so a real upload attempt fails at the
-      # client PUT step rather than at the api. `make up BWS_PROJECT_ID=<id>`
+      # client PUT step rather than at the api. `make up BWS_PROJECT_ID=auto`
       # overrides these two with the real dev credential via Bitwarden Secrets
       # Manager (see docs/development/bws-development.md) — Compose gives that
       # injected process-environment value precedence over the .env dummy

--- a/backend/scripts/bws-dev-up.sh
+++ b/backend/scripts/bws-dev-up.sh
@@ -14,11 +14,6 @@ if ! command -v bws >/dev/null 2>&1; then
   exit 127
 fi
 
-if ! command -v jq >/dev/null 2>&1; then
-  echo "jq is not installed; required to resolve the bws project (brew install jq)" >&2
-  exit 127
-fi
-
 if [ -z "${BWS_ACCESS_TOKEN:-}" ] && command -v security >/dev/null 2>&1; then
   # This machine account's token is shared across repos that read the same
   # BWS `development` project (see docs/development/bws-development.md). The
@@ -37,7 +32,12 @@ if [ -z "$PROJECT_ID" ]; then
   # The project ID is not secret, and this machine account can only ever see
   # the one shared 'development' project (see docs/development/bws-development.md)
   # — resolve it by name instead of requiring every operator to look it up
-  # and pass it on every invocation.
+  # and pass it on every invocation. jq is only needed for this lookup, not
+  # for the explicit-project-ID path below, so check for it here.
+  if ! command -v jq >/dev/null 2>&1; then
+    echo "jq is not installed; required to resolve the bws project by name (brew install jq), or pass one explicitly: $0 <project-id>" >&2
+    exit 127
+  fi
   PROJECT_ID="$(bws project list | jq -r '
     [.[] | select(.name == "development")] as $matches
     | if ($matches | length) == 1 then $matches[0].id

--- a/backend/scripts/bws-dev-up.sh
+++ b/backend/scripts/bws-dev-up.sh
@@ -3,13 +3,19 @@
 # Secrets Manager (bws). See docs/development/bws-development.md.
 set -euo pipefail
 
-if [ "$#" -ne 1 ]; then
-  echo "usage: $0 <BWS development project ID>" >&2
+if [ "$#" -gt 1 ]; then
+  echo "usage: $0 [BWS project ID]" >&2
+  echo "  (with no argument, auto-resolves the shared 'development' project)" >&2
   exit 2
 fi
 
 if ! command -v bws >/dev/null 2>&1; then
   echo "bws is not installed; install the Bitwarden Secrets Manager CLI first (see docs/development/bws-development.md)" >&2
+  exit 127
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "jq is not installed; required to resolve the bws project (brew install jq)" >&2
   exit 127
 fi
 
@@ -26,12 +32,34 @@ if [ -z "${BWS_ACCESS_TOKEN:-}" ]; then
   exit 2
 fi
 
-# The project ID is not secret. bws injects only this project's secret values
-# (e.g. R2_ACCESS_KEY_ID, R2_SECRET_ACCESS_KEY) into Compose's process
-# environment; BWS_ACCESS_TOKEN itself is never listed in compose.yaml or
-# passed to a container. .env is still loaded as normal -- Compose gives
-# process-environment variables precedence over .env, so the bws-injected
-# values override the .env dummies for the keys bws actually provides, while
-# every other variable (non-secret config and required-but-non-secret
-# variables such as POSTGRES_PASSWORD and API_PORT) keeps coming from .env.
-exec bws run --project-id "$1" -- docker compose up -d --build
+PROJECT_ID="${1:-}"
+if [ -z "$PROJECT_ID" ]; then
+  # The project ID is not secret, and this machine account can only ever see
+  # the one shared 'development' project (see docs/development/bws-development.md)
+  # — resolve it by name instead of requiring every operator to look it up
+  # and pass it on every invocation.
+  PROJECT_ID="$(bws project list | jq -r '
+    [.[] | select(.name == "development")] as $matches
+    | if ($matches | length) == 1 then $matches[0].id
+      elif ($matches | length) == 0 then "MISSING"
+      else "AMBIGUOUS" end
+  ')"
+  case "$PROJECT_ID" in
+    MISSING)
+      echo "no bws project named 'development' visible to this access token" >&2
+      exit 2 ;;
+    AMBIGUOUS)
+      echo "multiple bws projects named 'development' are visible; pass one explicitly: $0 <project-id>" >&2
+      exit 2 ;;
+  esac
+fi
+
+# bws injects only this project's secret values (e.g. R2_ACCESS_KEY_ID,
+# R2_SECRET_ACCESS_KEY) into Compose's process environment; BWS_ACCESS_TOKEN
+# itself is never listed in compose.yaml or passed to a container. .env is
+# still loaded as normal -- Compose gives process-environment variables
+# precedence over .env, so the bws-injected values override the .env
+# dummies for the keys bws actually provides, while every other variable
+# (non-secret config and required-but-non-secret variables such as
+# POSTGRES_PASSWORD and API_PORT) keeps coming from .env.
+exec bws run --project-id "$PROJECT_ID" -- docker compose up -d --build

--- a/docs/development/bws-development.md
+++ b/docs/development/bws-development.md
@@ -79,7 +79,10 @@ evidence, Phase 5 Stripe/RevenueCat, ...) introduce real dev-side credentials.
    `development` project — there is only one token, not one per repository.
 4. Set real, non-secret values for `R2_ACCOUNT_ID`, `R2_BUCKET`, and
    `R2_PUBLIC_DOMAIN` in `backend/.env` (see above — these don't go through
-   bws).
+   bws). `R2_PUBLIC_DOMAIN` must be a **bare hostname with no `https://`
+   prefix** — the api prepends it itself when building/validating the avatar
+   URL, so an included scheme makes every avatar `PATCH` fail with `400
+   invalid_argument` no matter how correct the credentials are.
 5. Run:
 
    ```bash

--- a/docs/development/bws-development.md
+++ b/docs/development/bws-development.md
@@ -7,13 +7,16 @@ Local development normally boots on non-sensitive dummy values in
 and exercise most flows, but not ones that call a real external service —
 today that's the Cloudflare R2 avatar upload/finalize flow.
 
-`make up BWS_PROJECT_ID=<id>` injects real credential values from Bitwarden
-Secrets Manager (`bws`) into the Compose stack for the duration of that one
-run. This is optional: plain `make up` (no `BWS_PROJECT_ID`) keeps working
-without it, exercising the avatar upload/finalize code path against a
-nonexistent R2 account rather than a real bucket (see [#483][] — the shipped
-dummy values don't currently make the api fail closed the way earlier docs in
-this area assumed).
+`make up BWS_PROJECT_ID=auto` (or `scripts/dev-run.sh --backend --bws`)
+injects real credential values from Bitwarden Secrets Manager (`bws`) into
+the Compose stack for the duration of that one run. This is optional and off
+by default — plain `make up` (no `BWS_PROJECT_ID`) keeps working without it,
+exercising the avatar upload/finalize code path against a nonexistent R2
+account rather than a real bucket (see [#483][] — the shipped dummy values
+don't currently make the api fail closed the way earlier docs in this area
+assumed). Off-by-default is deliberate: this repository intends to build in
+the open, and a contributor without Bitwarden access should never need it to
+get a working local stack.
 
 [#483]: https://github.com/cloveclovedev/peppercheck/issues/483
 
@@ -81,27 +84,35 @@ evidence, Phase 5 Stripe/RevenueCat, ...) introduce real dev-side credentials.
 
    ```bash
    cd backend
-   make up BWS_PROJECT_ID=<development-project-id>
+   make up BWS_PROJECT_ID=auto
    ```
 
-   Find the `development` project's id with `bws project list` (it reads the
-   same `BWS_ACCESS_TOKEN` described below):
+   or from the repo root: `scripts/dev-run.sh --backend --bws` (also works
+   combined with `--android`/`--ios`, and forces a backend restart even if
+   one is already running, since secrets are injected only at `docker
+   compose up` time).
 
-   ```bash
-   bws project list
-   ```
+   `auto` resolves the shared `development` project by name — this machine
+   account only ever has access to that one project, so there's normally
+   nothing to look up. Pass a specific `BWS_PROJECT_ID=<id>` instead if you
+   ever need to point at a different project; find candidates with
+   `bws project list` (it reads the same `BWS_ACCESS_TOKEN` described below).
 
 ## How it works
 
-`make up BWS_PROJECT_ID=<id>` still creates `backend/.env` from the template
-if missing, then runs `backend/scripts/bws-dev-up.sh <id>` instead of a plain
-`docker compose up`. The script:
+`make up BWS_PROJECT_ID=auto` (or `=<id>`) still creates `backend/.env` from
+the template if missing, then runs `backend/scripts/bws-dev-up.sh` (with or
+without an explicit project ID) instead of a plain `docker compose up`.
+`BWS_PROJECT_ID` unset or empty skips bws entirely — that's the default. The
+script:
 
-- Fails closed if `bws` isn't installed.
+- Fails closed if `bws` or `jq` isn't installed.
 - Reads `BWS_ACCESS_TOKEN` from the `bws-local-access-token` Keychain item
   into its own process tree (falling back to an already-exported
   `BWS_ACCESS_TOKEN`, e.g. for a one-shot override), and fails closed if
   neither is available.
+- With no project ID argument, resolves the `development` project by name via
+  `bws project list | jq`, failing closed if none or more than one match.
 - Runs `bws run --project-id <id> -- docker compose up -d --build`. Only the
   selected project's secret values reach that one process tree; the BWS
   access token itself is never listed in Compose or passed to a container.

--- a/docs/development/bws-development.md
+++ b/docs/development/bws-development.md
@@ -109,13 +109,15 @@ without an explicit project ID) instead of a plain `docker compose up`.
 `BWS_PROJECT_ID` unset or empty skips bws entirely — that's the default. The
 script:
 
-- Fails closed if `bws` or `jq` isn't installed.
+- Fails closed if `bws` isn't installed.
 - Reads `BWS_ACCESS_TOKEN` from the `bws-local-access-token` Keychain item
   into its own process tree (falling back to an already-exported
   `BWS_ACCESS_TOKEN`, e.g. for a one-shot override), and fails closed if
   neither is available.
-- With no project ID argument, resolves the `development` project by name via
-  `bws project list | jq`, failing closed if none or more than one match.
+- With no project ID argument (`BWS_PROJECT_ID=auto`), resolves the
+  `development` project by name via `bws project list | jq` — `jq` is only
+  required for this path, not for an explicit `BWS_PROJECT_ID=<id>` — failing
+  closed if none or more than one match.
 - Runs `bws run --project-id <id> -- docker compose up -d --build`. Only the
   selected project's secret values reach that one process tree; the BWS
   access token itself is never listed in Compose or passed to a container.

--- a/scripts/dev-run.sh
+++ b/scripts/dev-run.sh
@@ -16,6 +16,14 @@
 #                          changed containers) — use after editing backend code
 #   --backend --android    rebuild/restart the backend AND run the app, one shot
 #   --backend              (alone) bring the backend up without running an app
+#   --bws                  inject real dev secrets (currently R2 credentials)
+#                          from Bitwarden Secrets Manager instead of the .env
+#                          dummies — see docs/development/bws-development.md.
+#                          Off by default: most flows don't need it, and a
+#                          fresh clone with no Bitwarden access should always
+#                          work. Forces a backend restart even if one is
+#                          already running, since secrets are injected only
+#                          at `docker compose up` time.
 # For a full reset incl. the local DB, use `cd backend && make reset` instead.
 #
 # --build compiles a debug Android APK (JDK pin + --flavor dev) as a
@@ -27,6 +35,7 @@
 #   scripts/dev-run.sh --ios                 # ensure backend, run iOS
 #   scripts/dev-run.sh --backend             # (re)build/restart backend only
 #   scripts/dev-run.sh --backend --android   # rebuild backend, then run Android
+#   scripts/dev-run.sh --backend --bws       # restart backend with real bws dev secrets
 #   scripts/dev-run.sh --build               # Android debug APK compile check
 #   scripts/dev-run.sh --avd NAME            # Android AVD (default below; see: flutter emulators)
 #   scripts/dev-run.sh --caddy-port N        # host ingress port (default 80) when 80 is taken
@@ -48,7 +57,7 @@ FLUTTER_DIR="$REPO/peppercheck_flutter"
 BACKEND_DIR="$REPO/backend"
 FLUTTER_RUN_BASE="flutter run --flavor dev -t lib/main_dev.dart"
 
-RUN_IOS=0 RUN_ANDROID=0 FORCE_BACKEND=0 DO_BUILD=0
+RUN_IOS=0 RUN_ANDROID=0 FORCE_BACKEND=0 DO_BUILD=0 USE_BWS=0
 AVD="Medium_Phone_API_36.1"
 FIREBASE_PROJECT="peppercheck-dev"
 CADDY_PORT=80       # host ingress port (backend CADDY_HTTP_PORT + app DEV_API_PORT)
@@ -59,12 +68,13 @@ while [ $# -gt 0 ]; do
     --ios)      RUN_IOS=1 ;;
     --android)  RUN_ANDROID=1 ;;
     --backend)  FORCE_BACKEND=1 ;;
+    --bws)      USE_BWS=1 ;;
     --build)    DO_BUILD=1 ;;
     --avd)      AVD="${2:?}"; shift ;;
     --caddy-port)    CADDY_PORT="${2:?}"; shift ;;
     --postgres-port) PG_PORT="${2:?}"; shift ;;
     --firebase-project) FIREBASE_PROJECT="${2:?}"; shift ;;
-    -h|--help)  sed -n '2,42p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+    -h|--help)  sed -n '2,56p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
     *) echo "unknown arg: $1" >&2; exit 2 ;;
   esac
   shift
@@ -96,8 +106,11 @@ backend_healthy() { # true only for the PepperCheck API's expected unauthenticat
   [ "$(curl -s -o /dev/null -w '%{http_code}' "$API_HEALTH_URL" 2>/dev/null || true)" = "401" ]
 }
 
-ensure_backend() { # idempotent: start the backend only if it is not already up
-  if backend_healthy; then
+ensure_backend() { # idempotent: start the backend only if it is not already up.
+  # --bws always restarts even if a backend is already up: bws secrets are
+  # injected only at `docker compose up` time, so an already-running backend
+  # (started without --bws) would otherwise silently keep the .env dummies.
+  if [ "$USE_BWS" -eq 0 ] && backend_healthy; then
     echo "==> Backend already up on :$CADDY_PORT (skipping; pass --backend to rebuild/restart)"
     return 0
   fi
@@ -105,10 +118,16 @@ ensure_backend() { # idempotent: start the backend only if it is not already up
 }
 
 start_backend() {
-  echo "==> Starting backend (FIREBASE_PROJECT_ID=$FIREBASE_PROJECT, Caddy :$CADDY_PORT, Postgres :$PG_PORT)"
+  local bws_project_id="" bws_note=""
+  if [ "$USE_BWS" -eq 1 ]; then
+    bws_project_id="auto"
+    bws_note=", bws dev secrets"
+  fi
+  echo "==> Starting backend (FIREBASE_PROJECT_ID=$FIREBASE_PROJECT, Caddy :$CADDY_PORT, Postgres :$PG_PORT$bws_note)"
   if ! ( cd "$BACKEND_DIR" \
       && FIREBASE_PROJECT_ID="$FIREBASE_PROJECT" \
-         CADDY_HTTP_PORT="$CADDY_PORT" POSTGRES_HOST_PORT="$PG_PORT" make up ); then
+         CADDY_HTTP_PORT="$CADDY_PORT" POSTGRES_HOST_PORT="$PG_PORT" \
+         BWS_PROJECT_ID="$bws_project_id" make up ); then
     echo
     echo "backend failed to start. If compose reported a missing variable"
     echo "(e.g. API_PORT), your backend/.env predates a template change and"


### PR DESCRIPTION
## Summary
While verifying Phase 3a Flutter's avatar upload locally, confirmed the operator's hypothesis: `dev-run.sh`/`make up` never injected real R2 credentials via bws, so the avatar upload's real-R2-PUT step was guaranteed to fail (backend generates a presigned URL fine — signing doesn't need real credentials — but the URL points at a nonexistent account, matching known issue #483).

- `backend/scripts/bws-dev-up.sh` now resolves the shared `development` bws project by name (`bws project list | jq`) when no project ID is given, instead of requiring the operator to look up and paste the UUID every time. Fails closed on zero or multiple matches.
- `make up BWS_PROJECT_ID=auto` uses this. Plain `make up` (no `BWS_PROJECT_ID`) is **unchanged** — still off by default, so a fresh clone with no Bitwarden access always works (this repo intends to build in the open).
- `scripts/dev-run.sh` gains a `--bws` flag (off by default) that threads `BWS_PROJECT_ID=auto` through and forces a backend restart even if one is already running, since bws secrets are only injected at `docker compose up` time — an already-running backend started without `--bws` would otherwise silently keep serving the `.env` dummies.
- Updated `docs/development/bws-development.md` and a `compose.yaml` comment to match the new `BWS_PROJECT_ID=auto` invocation.

Considered making bws injection the default for every `make up`/`dev-run.sh --backend`, but reverted after discussion: this project intends to build in the open, and most external contributors won't have Bitwarden access — the local dev stack must always work without it.

## Test plan
- [x] `bash -n scripts/dev-run.sh`, `bash -n backend/scripts/bws-dev-up.sh` — syntax OK
- [x] `make -n up` and `make -n up BWS_PROJECT_ID=auto` — dry-run confirms the right branch is selected in both cases
- [x] Ran `scripts/dev-run.sh --backend --bws` for real against the live dev stack: `bws project list` correctly resolved the single `development` project, `api` container recreated with real credentials
- [x] Ran `scripts/dev-run.sh --backend` (no `--bws`) immediately after — confirmed default-off path still works and doesn't touch bws
- [x] Backend health check passes (`HTTP 401 as expected`) after both

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HdVukkt1tvf6HoL3yNec5y