### PR TITLE
feat(backend): Phase 3b web feature skeleton, locale routing, home page (P3b-1)

### DIFF
--- a/backend/cmd/peppercheck/main.go
+++ b/backend/cmd/peppercheck/main.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cloveclovedev/peppercheck/backend/internal/platform/auth"
 	"github.com/cloveclovedev/peppercheck/backend/internal/platform/r2"
 	"github.com/cloveclovedev/peppercheck/backend/internal/profile"
+	"github.com/cloveclovedev/peppercheck/backend/internal/web"
 	"github.com/cloveclovedev/peppercheck/backend/internal/worker"
 )
 
@@ -96,6 +97,7 @@ func main() {
 			Profile:      profile.NewHandler(profileSvc),
 			Notification: notification.NewHandler(notifSvc),
 			ResolveUser:  identity.NewMiddleware(idSvc, logger),
+			Web:          web.NewHandler(web.Deps{Logger: logger}),
 		}); err != nil {
 			logger.Error("api exited with error", "error", err)
 			os.Exit(1)

--- a/backend/internal/api/api.go
+++ b/backend/internal/api/api.go
@@ -69,9 +69,21 @@ func buildHandler(deps Deps) http.Handler {
 		}
 	}
 
+	// Methodless /api/ fallback: without this, a request that hits a
+	// registered path with the wrong method (e.g. POST /api/v1/me, which only
+	// registers GET) is NOT rejected by the specific pattern -- ServeMux falls
+	// through to the least-specific matching pattern instead, which would be
+	// the web catch-all below, silently serving an HTML page for an API path.
+	// Registering this JSON fallback for the whole /api/ prefix keeps every
+	// /api/* response API-shaped regardless of Web being mounted.
+	mux.Handle("/api/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		httpserver.WriteError(w, r, http.StatusNotFound, httpserver.CodeNotFound, "not found")
+	}))
+
 	if deps.Web != nil {
-		// Catch-all: anything not matched by a more specific pattern above
-		// (ServeMux prioritizes specificity, so /api/v1/* routes still win).
+		// Catch-all for everything else not matched by a more specific
+		// pattern above (/api/ never reaches here; see the fallback registered
+		// just above).
 		mux.Handle("/", deps.Web)
 	}
 	return mux

--- a/backend/internal/api/api.go
+++ b/backend/internal/api/api.go
@@ -25,6 +25,7 @@ type Deps struct {
 	Notification *notification.Handler
 	ResolveUser  func(http.Handler) http.Handler // identity.NewMiddleware: verified Identity -> internal User in ctx
 	Logger       *slog.Logger                    // used by the auth middleware; Run injects the run logger when nil
+	Web          http.Handler                    // server-rendered public web (internal/web); mounted as the catch-all
 }
 
 // buildHandler wires routes and middleware. deps.Ready is the readiness probe;
@@ -66,6 +67,12 @@ func buildHandler(deps Deps) http.Handler {
 			mux.Handle("PUT /api/v1/me/device-push-tokens", chain(deps.Notification.PutToken))
 			mux.Handle("DELETE /api/v1/me/device-push-tokens", chain(deps.Notification.DeleteToken))
 		}
+	}
+
+	if deps.Web != nil {
+		// Catch-all: anything not matched by a more specific pattern above
+		// (ServeMux prioritizes specificity, so /api/v1/* routes still win).
+		mux.Handle("/", deps.Web)
 	}
 	return mux
 }

--- a/backend/internal/api/web_test.go
+++ b/backend/internal/api/web_test.go
@@ -46,6 +46,29 @@ func TestWebCatchAllServesRootAndDoesNotShadowMountedAPIRoutes(t *testing.T) {
 	}
 }
 
+func TestAPIPrefixFallbackStaysJSONOnMethodMismatch(t *testing.T) {
+	// Regression: stdlib ServeMux does NOT return 405 for a wrong-method
+	// request against a registered path when a less-specific catch-all ("/")
+	// also matches -- it silently dispatches to the catch-all instead. Without
+	// the /api/ prefix fallback, POST /api/v1/me (only GET is registered)
+	// would be served by the web handler as an HTML 404 page.
+	h := buildHandler(Deps{Web: web.NewHandler(web.Deps{})})
+
+	for _, tc := range []struct{ method, path string }{
+		{http.MethodPost, "/api/v1/me"},            // registered path, wrong method
+		{http.MethodGet, "/api/v1/does-not-exist"}, // unregistered path
+	} {
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, httptest.NewRequest(tc.method, tc.path, nil))
+		if rec.Code != http.StatusNotFound {
+			t.Fatalf("%s %s = %d, want 404", tc.method, tc.path, rec.Code)
+		}
+		if ct := rec.Header().Get("Content-Type"); ct != "application/json" {
+			t.Fatalf("%s %s Content-Type = %q, want application/json (leaked to the web handler?)", tc.method, tc.path, ct)
+		}
+	}
+}
+
 func TestBuildHandlerWithoutWebHasNoCatchAll(t *testing.T) {
 	h := buildHandler(Deps{})
 	rec := httptest.NewRecorder()

--- a/backend/internal/api/web_test.go
+++ b/backend/internal/api/web_test.go
@@ -1,0 +1,56 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/cloveclovedev/peppercheck/backend/internal/identity"
+	"github.com/cloveclovedev/peppercheck/backend/internal/platform/auth"
+	"github.com/cloveclovedev/peppercheck/backend/internal/testsupport"
+	"github.com/cloveclovedev/peppercheck/backend/internal/web"
+)
+
+func TestWebCatchAllServesRootAndDoesNotShadowMountedAPIRoutes(t *testing.T) {
+	db := testsupport.DB(t)
+	if _, err := db.Exec("TRUNCATE public.users CASCADE"); err != nil {
+		t.Fatalf("truncate: %v", err)
+	}
+	svc := identity.NewService(identity.NewStore(db), nil)
+	h := buildHandler(Deps{
+		Verifier:    &auth.FakeVerifier{Identity: auth.Identity{Issuer: "iss", Subject: "sub-A"}},
+		Identity:    identity.NewHandler(svc, nil),
+		ResolveUser: identity.NewMiddleware(svc, nil),
+		Web:         web.NewHandler(web.Deps{}),
+	})
+
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/", nil))
+	if rec.Code != http.StatusMovedPermanently || rec.Header().Get("Location") != "/en" {
+		t.Fatalf("GET / = %d %q, want 301 to /en", rec.Code, rec.Header().Get("Location"))
+	}
+
+	// The identity route is mounted (Verifier/Identity/ResolveUser are all
+	// set), so it must win over the web catch-all's "/" pattern -- stdlib
+	// ServeMux picks the more specific pattern, but this asserts the actual
+	// wiring, not just the stdlib guarantee.
+	rec = httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/me", nil)
+	req.Header.Set("Authorization", "Bearer t")
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET /api/v1/me = %d, want 200 from the identity route; body=%s", rec.Code, rec.Body.String())
+	}
+	if ct := rec.Header().Get("Content-Type"); ct != "application/json" {
+		t.Fatalf("GET /api/v1/me Content-Type = %q, want application/json (was it served by the web handler instead?)", ct)
+	}
+}
+
+func TestBuildHandlerWithoutWebHasNoCatchAll(t *testing.T) {
+	h := buildHandler(Deps{})
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/", nil))
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("GET / without Web = %d, want 404 (stdlib ServeMux default, no catch-all registered)", rec.Code)
+	}
+}

--- a/backend/internal/core/httpserver/errors.go
+++ b/backend/internal/core/httpserver/errors.go
@@ -14,6 +14,7 @@ const (
 	CodeUsernameTaken   = "username_taken"   // 409: username already in use
 	CodeInvalidTimezone = "invalid_timezone" // 400: not a valid IANA timezone
 	CodeRateLimited     = "rate_limited"     // 429: per-user rate limit exceeded
+	CodeNotFound        = "not_found"        // 404: no route matches this API path/method
 )
 
 type errorEnvelope struct {

--- a/backend/internal/web/i18n.go
+++ b/backend/internal/web/i18n.go
@@ -1,0 +1,59 @@
+package web
+
+import (
+	"embed"
+	"encoding/json"
+	"strings"
+)
+
+//go:embed messages/en.json messages/ja.json
+var messagesFS embed.FS
+
+const defaultLocale = "en"
+
+var supportedLocales = []string{"en", "ja"}
+
+// catalog maps locale -> nested message tree.
+type catalog map[string]map[string]any
+
+var cat = loadCatalog()
+
+func loadCatalog() catalog {
+	c := catalog{}
+	for _, loc := range supportedLocales {
+		b, err := messagesFS.ReadFile("messages/" + loc + ".json")
+		if err != nil {
+			panic("web: missing messages for " + loc + ": " + err.Error())
+		}
+		var tree map[string]any
+		if err := json.Unmarshal(b, &tree); err != nil {
+			panic("web: bad messages json for " + loc + ": " + err.Error())
+		}
+		c[loc] = tree
+	}
+	return c
+}
+
+// T resolves a dotted key (e.g. "HomePage.title"); a missing key echoes the
+// key so gaps are visible in tests and dev instead of rendering blank.
+func (c catalog) T(locale, key string) string {
+	tree, ok := c[locale]
+	if !ok {
+		return key
+	}
+	var cur any = map[string]any(tree)
+	for _, seg := range strings.Split(key, ".") {
+		m, ok := cur.(map[string]any)
+		if !ok {
+			return key
+		}
+		cur, ok = m[seg]
+		if !ok {
+			return key
+		}
+	}
+	if s, ok := cur.(string); ok {
+		return s
+	}
+	return key
+}

--- a/backend/internal/web/i18n_test.go
+++ b/backend/internal/web/i18n_test.go
@@ -1,0 +1,15 @@
+package web
+
+import "testing"
+
+func TestCatalogT(t *testing.T) {
+	if got := cat.T("en", "HomePage.title"); got != "Peer Referee Platform for Tasks" {
+		t.Fatalf("en HomePage.title = %q", got)
+	}
+	if got := cat.T("ja", "HomePage.subtitle"); got != "あなたのタスクを第三者がチェック。習慣化を支え、質を高めるレフリーマッチングサービス。" {
+		t.Fatalf("ja HomePage.subtitle = %q", got)
+	}
+	if got := cat.T("en", "Missing.key"); got != "Missing.key" {
+		t.Fatalf("missing key should echo the key, got %q", got)
+	}
+}

--- a/backend/internal/web/locale.go
+++ b/backend/internal/web/locale.go
@@ -1,0 +1,27 @@
+package web
+
+// alt is one hreflang (or language-switcher) alternate.
+type alt struct {
+	Lang string
+	Href string
+}
+
+func isSupported(loc string) bool {
+	for _, l := range supportedLocales {
+		if l == loc {
+			return true
+		}
+	}
+	return false
+}
+
+// hreflangAlternates returns alternates for a locale-relative path (e.g.
+// "/legal/privacy", or "" for home), one per supported locale plus x-default.
+func hreflangAlternates(relPath string) []alt {
+	out := make([]alt, 0, len(supportedLocales)+1)
+	for _, l := range supportedLocales {
+		out = append(out, alt{Lang: l, Href: "/" + l + relPath})
+	}
+	out = append(out, alt{Lang: "x-default", Href: "/" + defaultLocale + relPath})
+	return out
+}

--- a/backend/internal/web/messages/en.json
+++ b/backend/internal/web/messages/en.json
@@ -1,0 +1,34 @@
+{
+  "Meta": {
+    "siteName": "peppercheck",
+    "defaultTitle": "Peppercheck"
+  },
+  "Footer": {
+    "terms": "Terms of Service",
+    "privacy": "Privacy Policy",
+    "tokushoho": "Specified Commercial Transactions Act",
+    "refund": "Refund & Cancellation Policy",
+    "copyright": "© 2024 CloveClove"
+  },
+  "HomePage": {
+    "title": "Peer Referee Platform for Tasks",
+    "subtitle": "Get your tasks reviewed by real people. Stay accountable, improve quality, and build better habits.",
+    "features": {
+      "create": {
+        "heading": "Create Tasks",
+        "body": "Define your tasks with clear criteria and deadlines."
+      },
+      "review": {
+        "heading": "Peer Review",
+        "body": "Get matched with a referee who reviews your evidence and provides feedback."
+      },
+      "reward": {
+        "heading": "Earn Rewards",
+        "body": "Serve as a referee for others and earn reward points redeemable for payouts."
+      }
+    }
+  },
+  "NotFound": {
+    "title": "Page not found"
+  }
+}

--- a/backend/internal/web/messages/ja.json
+++ b/backend/internal/web/messages/ja.json
@@ -1,0 +1,34 @@
+{
+  "Meta": {
+    "siteName": "peppercheck",
+    "defaultTitle": "Peppercheck"
+  },
+  "Footer": {
+    "terms": "利用規約",
+    "privacy": "プライバシーポリシー",
+    "tokushoho": "特定商取引法に基づく表記",
+    "refund": "返金・キャンセルポリシー",
+    "copyright": "© 2024 CloveClove"
+  },
+  "HomePage": {
+    "title": "タスクのためのピア・レフリー プラットフォーム",
+    "subtitle": "あなたのタスクを第三者がチェック。習慣化を支え、質を高めるレフリーマッチングサービス。",
+    "features": {
+      "create": {
+        "heading": "タスクを作成",
+        "body": "明確な基準と期限を設定してタスクを作成します。"
+      },
+      "review": {
+        "heading": "ピアレビュー",
+        "body": "レフリーとマッチングし、エビデンスを審査してフィードバックを受けられます。"
+      },
+      "reward": {
+        "heading": "リワードを獲得",
+        "body": "他のユーザーのレフリーを務めてリワードポイントを獲得し、報酬として受け取れます。"
+      }
+    }
+  },
+  "NotFound": {
+    "title": "ページが見つかりません"
+  }
+}

--- a/backend/internal/web/render.go
+++ b/backend/internal/web/render.go
@@ -1,0 +1,80 @@
+package web
+
+import (
+	"bytes"
+	"embed"
+	"html/template"
+	"io/fs"
+	"log/slog"
+	"net/http"
+	"path"
+	"strings"
+)
+
+//go:embed templates/*.gohtml
+var templatesFS embed.FS
+
+// pageData is the data every template receives. Later Phase 3b sub-issues
+// (legal pages, tokushoho price, account-deletion form) extend this struct
+// as they add pages that need it.
+type pageData struct {
+	Locale     string
+	Title      string
+	Hreflang   []alt
+	LangSwitch []alt
+}
+
+// langLabel is the language-switcher display label for a locale code, e.g.
+// "ja" -> "JP" (matches the current site's EN/JP switcher; ISO code and
+// display label differ for Japanese).
+func langLabel(locale string) string {
+	switch locale {
+	case "ja":
+		return "JP"
+	default:
+		return strings.ToUpper(locale)
+	}
+}
+
+// pages holds one parsed template set per page: layout + that page's content
+// block. Every templates/<name>.gohtml auto-registers as page <name>.
+var pages = parsePages()
+
+func parsePages() map[string]*template.Template {
+	fm := template.FuncMap{"t": cat.T, "langLabel": langLabel}
+	entries, err := fs.Glob(templatesFS, "templates/*.gohtml")
+	if err != nil {
+		panic("web: glob templates: " + err.Error())
+	}
+	m := map[string]*template.Template{}
+	for _, e := range entries {
+		base := strings.TrimSuffix(path.Base(e), ".gohtml")
+		if base == "layout" {
+			continue
+		}
+		m[base] = template.Must(
+			template.New("layout").Funcs(fm).ParseFS(templatesFS, "templates/layout.gohtml", e),
+		)
+	}
+	return m
+}
+
+// render executes the named page to a buffer first, so a template error
+// yields a clean 500 instead of a half-written body.
+func (h *Handler) render(w http.ResponseWriter, status int, name string, data pageData) {
+	t, ok := pages[name]
+	if !ok {
+		h.logger.Error("web_render_unknown_template", slog.String("template", name))
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+	var buf bytes.Buffer
+	if err := t.ExecuteTemplate(&buf, "layout", data); err != nil {
+		h.logger.Error("web_render_exec_failed", slog.String("template", name), slog.Any("error", err))
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	w.WriteHeader(status)
+	_, _ = buf.WriteTo(w)
+}

--- a/backend/internal/web/templates/home.gohtml
+++ b/backend/internal/web/templates/home.gohtml
@@ -1,0 +1,20 @@
+{{define "content"}}
+<section class="hero">
+  <h1>{{t .Locale "HomePage.title"}}</h1>
+  <p class="subtitle">{{t .Locale "HomePage.subtitle"}}</p>
+</section>
+<section class="features">
+  <div class="feature">
+    <h2>{{t .Locale "HomePage.features.create.heading"}}</h2>
+    <p>{{t .Locale "HomePage.features.create.body"}}</p>
+  </div>
+  <div class="feature">
+    <h2>{{t .Locale "HomePage.features.review.heading"}}</h2>
+    <p>{{t .Locale "HomePage.features.review.body"}}</p>
+  </div>
+  <div class="feature">
+    <h2>{{t .Locale "HomePage.features.reward.heading"}}</h2>
+    <p>{{t .Locale "HomePage.features.reward.body"}}</p>
+  </div>
+</section>
+{{end}}

--- a/backend/internal/web/templates/layout.gohtml
+++ b/backend/internal/web/templates/layout.gohtml
@@ -4,7 +4,8 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>{{.Title}}</title>
-<link rel="stylesheet" href="/static/styles.css">
+{{/* Self-hosted CSS/fonts land in a follow-up sub-issue (Phase 3b Task 6);
+     no /static/ handler is mounted yet, so no stylesheet link here until then. */}}
 {{range .Hreflang}}<link rel="alternate" hreflang="{{.Lang}}" href="{{.Href}}">
 {{end}}</head>
 <body>

--- a/backend/internal/web/templates/layout.gohtml
+++ b/backend/internal/web/templates/layout.gohtml
@@ -1,0 +1,28 @@
+{{define "layout"}}<!doctype html>
+<html lang="{{.Locale}}">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>{{.Title}}</title>
+<link rel="stylesheet" href="/static/styles.css">
+{{range .Hreflang}}<link rel="alternate" hreflang="{{.Lang}}" href="{{.Href}}">
+{{end}}</head>
+<body>
+<header class="site-header">
+<a href="/{{.Locale}}" class="brand">{{t .Locale "Meta.siteName"}}</a>
+<nav class="lang-switch">{{range $i, $a := .LangSwitch}}{{if $i}} | {{end}}<a href="{{$a.Href}}">{{langLabel $a.Lang}}</a>{{end}}</nav>
+</header>
+<main>{{template "content" .}}</main>
+<footer class="site-footer">
+<nav class="legal-links">
+<a href="/{{.Locale}}/legal/terms">{{t .Locale "Footer.terms"}}</a>
+<a href="/{{.Locale}}/legal/privacy">{{t .Locale "Footer.privacy"}}</a>
+<a href="/{{.Locale}}/legal/tokushoho">{{t .Locale "Footer.tokushoho"}}</a>
+<a href="/{{.Locale}}/legal/refund">{{t .Locale "Footer.refund"}}</a>
+</nav>
+<a href="https://x.com/peppercheck_app" target="_blank" rel="noopener noreferrer" class="x-link" aria-label="X">
+<svg viewBox="0 0 24 24" aria-hidden="true" class="x-icon"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg>
+</a>
+<p class="copyright">{{t .Locale "Footer.copyright"}}</p>
+</footer>
+</body></html>{{end}}

--- a/backend/internal/web/templates/notfound.gohtml
+++ b/backend/internal/web/templates/notfound.gohtml
@@ -1,0 +1,1 @@
+{{define "content"}}<h1>{{t .Locale "NotFound.title"}}</h1>{{end}}

--- a/backend/internal/web/web.go
+++ b/backend/internal/web/web.go
@@ -1,0 +1,85 @@
+// Package web serves the server-rendered public web (marketing home, legal
+// pages, Stripe Connect landing pages, and the account-deletion request
+// resource) same-origin alongside the JSON API. See
+// docs/designs/2026-07-26-phase3b-go-web-design.md.
+package web
+
+import (
+	"log/slog"
+	"net/http"
+	"strings"
+)
+
+// Deps are the web handler's dependencies. Later Phase 3b sub-issues add
+// fields (e.g. the account-deletion service).
+type Deps struct {
+	Logger *slog.Logger
+}
+
+// Handler serves the server-rendered public web on every path not owned by
+// the JSON API. It is mounted as the ServeMux catch-all ("/").
+type Handler struct {
+	logger *slog.Logger
+}
+
+// NewHandler builds the web Handler. A nil logger falls back to slog.Default().
+func NewHandler(d Deps) *Handler {
+	l := d.Logger
+	if l == nil {
+		l = slog.Default()
+	}
+	return &Handler{logger: l}
+}
+
+// contentSecurityPolicy locks the pages to their own self-contained origin.
+// The site ships no JavaScript and no external hosts (CSS/fonts are embedded
+// and served same-origin), so this is strict: no scripts, no framing, forms
+// only to self. data: is allowed for images (favicons/inline SVG) only.
+const contentSecurityPolicy = "default-src 'self'; script-src 'none'; style-src 'self'; font-src 'self'; img-src 'self' data:; form-action 'self'; base-uri 'self'; frame-ancestors 'none'; object-src 'none'"
+
+func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	// Security headers on every web response (set before any body/redirect write).
+	w.Header().Set("Content-Security-Policy", contentSecurityPolicy)
+	w.Header().Set("X-Content-Type-Options", "nosniff")
+	w.Header().Set("Referrer-Policy", "strict-origin-when-cross-origin")
+
+	p := r.URL.Path
+	if p == "/" {
+		http.Redirect(w, r, "/"+defaultLocale, http.StatusMovedPermanently)
+		return
+	}
+	segs := strings.Split(strings.Trim(p, "/"), "/")
+	if !isSupported(segs[0]) {
+		// Bare (locale-less) path with no locale prefix: the legacy
+		// auth/subscription routes are dropped entirely (P3b-D15, no
+		// redirect); everything else is a plain 404 too. Stripe Connect's
+		// bare-path handling is added when that page lands.
+		h.renderNotFound(w, defaultLocale)
+		return
+	}
+	locale := segs[0]
+	rest := segs[1:]
+
+	switch {
+	case len(rest) == 0: // localized home
+		h.render(w, http.StatusOK, "home", h.page(locale, "Meta.defaultTitle", ""))
+	default:
+		h.renderNotFound(w, locale)
+	}
+}
+
+func (h *Handler) renderNotFound(w http.ResponseWriter, locale string) {
+	h.render(w, http.StatusNotFound, "notfound", h.page(locale, "NotFound.title", ""))
+}
+
+// page builds pageData for a locale, a title message key, and the
+// locale-relative path (used for hreflang + the language switcher).
+func (h *Handler) page(locale, titleKey, relPath string) pageData {
+	alts := hreflangAlternates(relPath)
+	return pageData{
+		Locale:     locale,
+		Title:      cat.T(locale, titleKey),
+		Hreflang:   alts,
+		LangSwitch: alts[:len(supportedLocales)],
+	}
+}

--- a/backend/internal/web/web_test.go
+++ b/backend/internal/web/web_test.go
@@ -1,0 +1,90 @@
+package web
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func newTestHandler() *Handler { return NewHandler(Deps{}) }
+
+func TestRootRedirectsToDefaultLocale(t *testing.T) {
+	rec := httptest.NewRecorder()
+	newTestHandler().ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/", nil))
+	if rec.Code != http.StatusMovedPermanently {
+		t.Fatalf("status = %d", rec.Code)
+	}
+	if loc := rec.Header().Get("Location"); loc != "/en" {
+		t.Fatalf("Location = %q", loc)
+	}
+}
+
+func TestLocalizedHomeRenders(t *testing.T) {
+	for _, tc := range []struct{ loc, want string }{
+		{"en", "Peer Referee Platform for Tasks"},
+		{"ja", "ピア・レフリー"},
+	} {
+		rec := httptest.NewRecorder()
+		newTestHandler().ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/"+tc.loc, nil))
+		if rec.Code != http.StatusOK {
+			t.Fatalf("%s home status = %d", tc.loc, rec.Code)
+		}
+		body := rec.Body.String()
+		if !strings.Contains(body, tc.want) {
+			t.Fatalf("%s home missing %q in body", tc.loc, tc.want)
+		}
+		if !strings.Contains(body, `<title>Peppercheck</title>`) {
+			t.Fatalf("%s home missing expected <title>", tc.loc)
+		}
+		if !strings.Contains(body, `hreflang="ja"`) || !strings.Contains(body, `hreflang="x-default"`) {
+			t.Fatalf("%s home missing hreflang tags", tc.loc)
+		}
+		if !strings.Contains(body, `lang="`+tc.loc+`"`) {
+			t.Fatalf("%s home missing <html lang>", tc.loc)
+		}
+	}
+}
+
+func TestUnknownPathIs404(t *testing.T) {
+	rec := httptest.NewRecorder()
+	newTestHandler().ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/en/nope", nil))
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status = %d", rec.Code)
+	}
+}
+
+func TestLegacyRoutesAre404NotRedirect(t *testing.T) {
+	// P3b-D15: the public web has never gone to production, so the legacy
+	// auth/subscription routes carry no external indexing/backlinks to
+	// preserve. No route is registered for them; they 404 like any other
+	// unknown path, with no redirect.
+	for _, p := range []string{"/auth/callback", "/login", "/dashboard", "/pricing", "/en/login", "/ja/pricing"} {
+		rec := httptest.NewRecorder()
+		newTestHandler().ServeHTTP(rec, httptest.NewRequest(http.MethodGet, p, nil))
+		if rec.Code != http.StatusNotFound {
+			t.Fatalf("%s status = %d, want 404", p, rec.Code)
+		}
+		if loc := rec.Header().Get("Location"); loc != "" {
+			t.Fatalf("%s unexpectedly redirected to %q", p, loc)
+		}
+	}
+}
+
+func TestSecurityHeadersOnEveryResponse(t *testing.T) {
+	rec := httptest.NewRecorder()
+	newTestHandler().ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/en", nil))
+	csp := rec.Header().Get("Content-Security-Policy")
+	if csp == "" {
+		t.Fatal("missing Content-Security-Policy header")
+	}
+	if !strings.Contains(csp, "default-src 'self'") || !strings.Contains(csp, "frame-ancestors 'none'") {
+		t.Fatalf("unexpected CSP: %q", csp)
+	}
+	if rec.Header().Get("X-Content-Type-Options") != "nosniff" {
+		t.Fatal("missing X-Content-Type-Options: nosniff")
+	}
+	if rec.Header().Get("Referrer-Policy") == "" {
+		t.Fatal("missing Referrer-Policy")
+	}
+}


### PR DESCRIPTION
## Summary
- New `internal/web` inbound feature: embedded i18n catalog (`en`/`ja`), locale-prefixed routing (`/{locale}/...`), CSP + security headers on every response, and the marketing home page (hero + feature cards, header brand + EN/JP switcher, footer legal links + X link + copyright) ported from `peppercheck-webapp`.
- The 4 legacy auth/subscription routes (`auth/callback`, `login`, `dashboard`, `pricing`) have no registered route and 404 by default — per P3b-D15, the site has never gone to production so there's nothing to preserve with a redirect.
- Content decision: the home page's former "View Plans" CTA (→ `/pricing`) is dropped rather than repointed. Subscription is IAP-only and no replacement web destination exists; keeping a dead-linking button would be worse than removing it. Not a structural design change, just a content call made while porting.
- Wires `web.Handler` into `internal/api` as the `ServeMux` catch-all. Added a DB-backed integration test proving the catch-all does not shadow the mounted `/api/v1/me` route.

## Test plan
- [x] `make test` — full suite green, incl. new `internal/web` and `internal/api` tests, no regressions elsewhere.
- [x] `gofmt`/`go vet` clean.
- [x] Verified end-to-end against the running dev stack (`scripts/dev-run.sh --backend`, through Caddy):
  - `GET /` → 301 `/en` with CSP/security headers
  - `GET /en` / `GET /ja` → 200, correct hero title per locale, `hreflang` tags present
  - `GET /en/login`, `GET /login` → 404 (no redirect)
  - `GET /api/v1/me` (unauth) → 401 JSON error envelope, not the web 404 HTML page

Closes #506.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EHqJCdKVqvWMuBPRcbUHXn