### PR TITLE
fix(backend): preserve query strings and emit absolute hreflang URLs

### DIFF
--- a/backend/internal/web/locale.go
+++ b/backend/internal/web/locale.go
@@ -17,11 +17,15 @@ func isSupported(loc string) bool {
 
 // hreflangAlternates returns alternates for a locale-relative path (e.g.
 // "/legal/privacy", or "" for home), one per supported locale plus x-default.
-func hreflangAlternates(relPath string) []alt {
+// origin is prepended to every href ("" for relative links, e.g. the
+// language switcher; a scheme+host for <link rel="alternate" hreflang>
+// tags, which Google requires to be fully qualified -- see
+// https://developers.google.com/search/docs/specialty/international/localized-versions#all-method-guidelines).
+func hreflangAlternates(origin, relPath string) []alt {
 	out := make([]alt, 0, len(supportedLocales)+1)
 	for _, l := range supportedLocales {
-		out = append(out, alt{Lang: l, Href: "/" + l + relPath})
+		out = append(out, alt{Lang: l, Href: origin + "/" + l + relPath})
 	}
-	out = append(out, alt{Lang: "x-default", Href: "/" + defaultLocale + relPath})
+	out = append(out, alt{Lang: "x-default", Href: origin + "/" + defaultLocale + relPath})
 	return out
 }

--- a/backend/internal/web/web.go
+++ b/backend/internal/web/web.go
@@ -45,7 +45,13 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	p := r.URL.Path
 	if p == "/" {
-		http.Redirect(w, r, "/"+defaultLocale, http.StatusMovedPermanently)
+		target := "/" + defaultLocale
+		if r.URL.RawQuery != "" {
+			// Preserve campaign/attribution query params (e.g. utm_source)
+			// through the locale redirect instead of dropping them.
+			target += "?" + r.URL.RawQuery
+		}
+		http.Redirect(w, r, target, http.StatusMovedPermanently)
 		return
 	}
 	segs := strings.Split(strings.Trim(p, "/"), "/")
@@ -54,7 +60,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		// auth/subscription routes are dropped entirely (P3b-D15, no
 		// redirect); everything else is a plain 404 too. Stripe Connect's
 		// bare-path handling is added when that page lands.
-		h.renderNotFound(w, defaultLocale)
+		h.renderNotFound(w, r, defaultLocale)
 		return
 	}
 	locale := segs[0]
@@ -62,24 +68,38 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	switch {
 	case len(rest) == 0: // localized home
-		h.render(w, http.StatusOK, "home", h.page(locale, "Meta.defaultTitle", ""))
+		h.render(w, http.StatusOK, "home", h.page(r, locale, "Meta.defaultTitle", ""))
 	default:
-		h.renderNotFound(w, locale)
+		h.renderNotFound(w, r, locale)
 	}
 }
 
-func (h *Handler) renderNotFound(w http.ResponseWriter, locale string) {
-	h.render(w, http.StatusNotFound, "notfound", h.page(locale, "NotFound.title", ""))
+func (h *Handler) renderNotFound(w http.ResponseWriter, r *http.Request, locale string) {
+	h.render(w, http.StatusNotFound, "notfound", h.page(r, locale, "NotFound.title", ""))
+}
+
+// requestOrigin returns the scheme+host the current request arrived on, for
+// building fully-qualified URLs (Google requires hreflang alternates to be
+// absolute). Caddy sets X-Forwarded-Proto when reverse-proxying; https is the
+// correct default for every real deployment (this is a public site, never
+// served over plain http in staging/production).
+func requestOrigin(r *http.Request) string {
+	scheme := "https"
+	if proto := r.Header.Get("X-Forwarded-Proto"); proto != "" {
+		scheme = proto
+	}
+	return scheme + "://" + r.Host
 }
 
 // page builds pageData for a locale, a title message key, and the
 // locale-relative path (used for hreflang + the language switcher).
-func (h *Handler) page(locale, titleKey, relPath string) pageData {
-	alts := hreflangAlternates(relPath)
+// Hreflang tags get absolute URLs (requestOrigin); the language switcher's
+// nav links stay relative, matching every other in-page link.
+func (h *Handler) page(r *http.Request, locale, titleKey, relPath string) pageData {
 	return pageData{
 		Locale:     locale,
 		Title:      cat.T(locale, titleKey),
-		Hreflang:   alts,
-		LangSwitch: alts[:len(supportedLocales)],
+		Hreflang:   hreflangAlternates(requestOrigin(r), relPath),
+		LangSwitch: hreflangAlternates("", relPath)[:len(supportedLocales)],
 	}
 }

--- a/backend/internal/web/web_test.go
+++ b/backend/internal/web/web_test.go
@@ -20,6 +20,19 @@ func TestRootRedirectsToDefaultLocale(t *testing.T) {
 	}
 }
 
+func TestRootRedirectPreservesQueryString(t *testing.T) {
+	// Campaign/attribution params (utm_source, etc.) must survive the locale
+	// redirect instead of being dropped at the root.
+	rec := httptest.NewRecorder()
+	newTestHandler().ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/?utm_source=ad&utm_campaign=x", nil))
+	if rec.Code != http.StatusMovedPermanently {
+		t.Fatalf("status = %d", rec.Code)
+	}
+	if loc := rec.Header().Get("Location"); loc != "/en?utm_source=ad&utm_campaign=x" {
+		t.Fatalf("Location = %q, want query string preserved", loc)
+	}
+}
+
 func TestLocalizedHomeRenders(t *testing.T) {
 	for _, tc := range []struct{ loc, want string }{
 		{"en", "Peer Referee Platform for Tasks"},
@@ -39,6 +52,16 @@ func TestLocalizedHomeRenders(t *testing.T) {
 		}
 		if !strings.Contains(body, `hreflang="ja"`) || !strings.Contains(body, `hreflang="x-default"`) {
 			t.Fatalf("%s home missing hreflang tags", tc.loc)
+		}
+		// Google requires hreflang alternates to be fully qualified (scheme +
+		// host), not relative paths.
+		if !strings.Contains(body, `hreflang="en" href="https://example.com/en"`) {
+			t.Fatalf("%s home hreflang href is not absolute; body=%s", tc.loc, body)
+		}
+		// The language switcher's visible nav links stay relative, unlike the
+		// hreflang tags -- distinct hrefs to the same locale in the same page.
+		if !strings.Contains(body, `<a href="/en">EN</a>`) {
+			t.Fatalf("%s home language switcher missing relative EN link", tc.loc)
 		}
 		if !strings.Contains(body, `lang="`+tc.loc+`"`) {
 			t.Fatalf("%s home missing <html lang>", tc.loc)


### PR DESCRIPTION
## Summary

Two P2 Codex findings on #511 that I missed before merging (only checked the review's top-level summary comment, not the full set of inline findings on the re-review — corrected here, see #511 review threads for the full history):

- `GET /?utm_source=...` redirected to `/en` unconditionally, dropping the query string. Campaign/attribution params now survive the locale redirect.
- `hreflang` alternates were relative (`href="/ja"`); [Google requires them fully qualified](https://developers.google.com/search/docs/specialty/international/localized-versions#all-method-guidelines). Now built from the request's origin (`X-Forwarded-Proto`/`Host`, `https` default). The language switcher's visible nav links deliberately stay relative — same helper, different callers.

## Test plan
- [x] `make test` — full suite green.
- [x] `gofmt`/`go vet` clean.
- [x] Verified against the running dev stack:
  - `GET /?utm_source=ad&utm_campaign=x` → `301` to `/en?utm_source=ad&utm_campaign=x`
  - `GET /en` hreflang tags: `href="http://127.0.0.1/en"` (absolute)
  - Language switcher: `<a href="/en">EN</a>` (still relative)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EHqJCdKVqvWMuBPRcbUHXn