### PR TITLE
docs(designs): local object storage strategy — Garage as zero-flag local + CI backend

### DIFF
--- a/docs/designs/2026-08-05-local-object-storage-garage-design.md
+++ b/docs/designs/2026-08-05-local-object-storage-garage-design.md
@@ -93,20 +93,45 @@ Presigned URLs sign the host, so they must be signed with the host the client
 host the API container uses. Introduce two endpoints:
 
 - **internal** — server-side Head/Delete/List (`http://garage:3900` locally)
-- **external** — presigned PUT/GET (emulator-reachable, e.g. Android
-  `http://10.0.2.2:3900`, iOS sim `http://localhost:3900`)
+- **external** — presigned PUT/GET, and public-read URL composition
+  (client-reachable)
 
-In production both collapse to the single R2 endpoint. This seam is the one
-genuinely new design element; it reuses the **same host mapping the Flutter dev
-app already uses to reach the local Go API**, so it introduces no new
-per-platform axis.
+In production both collapse to the single R2 endpoint / Cloudflare custom
+domain.
+
+**The external base must be request-derived, not a single static value.**
+Storage URLs (presigned PUT/GET and the public avatar URL) are composed and
+**signed by the Go server**, and SigV4 covers the host — so the client cannot
+rewrite it after the fact. The Flutter dev app applies `10.0.2.2` (Android) vs
+`127.0.0.1` (iOS) only when *it* builds the API base URL; that per-platform
+choice does **not** carry over to a server-emitted host. A single configured
+external endpoint would therefore hand one of the two emulators an unreachable
+or wrongly-signed URL.
+
+Resolve it by deriving the external base from the **incoming request's host**
+(the `Host` / `X-Forwarded-Host` that Caddy forwards): a request that arrived
+via `10.0.2.2` gets `10.0.2.2`-based storage URLs, one via `127.0.0.1` gets
+`127.0.0.1`-based ones, and the SigV4 signature matches because the presign is
+computed against that same host. Caddy fronts both the API and Garage on that
+host, so the URL routes back to Garage. (An alternative — binding a single host
+LAN IP both emulators can reach — is more fragile and network-specific;
+request-derived is preferred.) In CI there is no emulator, so the request host
+is stable and this collapses to a single value. This corrects an earlier draft
+that claimed "no new per-platform axis": there is one, but it is satisfied by
+request-derived hosts rather than static per-platform config.
 
 ### 4. Garage is the default; real R2 is operator opt-in
 
-The local Compose stack ships a Garage service plus a bucket/key/CORS bootstrap
-as the **default** backend (zero flags). Real R2 is an operator opt-in override
-(mirrors the BWS secret-injection opt-in default, #480/#482). CI uses Garage
-with internal == external (no emulator, no host split).
+The local Compose stack ships a Garage service plus a bootstrap as the
+**default** backend (zero flags). The bootstrap must create: both buckets
+(public + private), an access key granting both, CORS rules on both (browser
+presigned upload/download), and — critically — **website exposure on the public
+bucket** (`garage bucket website --allow`, i.e. `PutBucketWebsite`), without
+which Garage's web port (3902) will not serve the bucket anonymously even though
+the bucket exists. Omitting this is a silent trap: presigned PUT/Head/List can
+all pass while the stable avatar URL still 404s. Real R2 is an operator opt-in
+override (mirrors the BWS secret-injection opt-in default, #480/#482). CI uses
+Garage with internal == external (no emulator, no host split).
 
 Local reproduction per class:
 
@@ -133,17 +158,20 @@ pointing `R2_PUBLIC_DOMAIN` at `garage:3902`. Three facts collide:
 Naively repointing `R2_PUBLIC_DOMAIN` therefore yields a stable URL the emulator
 cannot actually fetch. Resolve it by **fronting Garage's web port with the
 stack's existing Caddy reverse proxy** (the Compose stack already runs Caddy):
-Caddy owns the `Host`-header → public-bucket routing and exposes one stable
-public host that the emulator reaches through the **same host mapping already
-used for the Go API** (`10.0.2.2` / `127.0.0.1`), so no `Host`-header handling
-or per-platform axis leaks into app config. Because local serving is http on a
-non-443 port, the public-base config must carry a **scheme (and port)** locally
-— either widen the avatar public-URL config from a bare hostname to a full base
-URL, or terminate TLS at Caddy so the existing `https://…/<key>` composition
-still holds. Production is unaffected: the Cloudflare custom domain already
-provides scheme + a stable host, so both collapse to today's behavior. The
-implementation issue (#523) must not treat this as a config-only change; it
-carries the small `PublicURL`/config widening described here.
+Caddy owns the `Host`-header → public-bucket routing so no `Host`-header
+handling leaks into app config. The public host itself is **request-derived**
+per §3 — the server composes the avatar URL from the host the request arrived
+on, so Android (`10.0.2.2`) and iOS (`127.0.0.1`) each get a fetchable URL
+without static per-platform config. Because local serving is http on a non-443
+port, the public-base composition must carry a **scheme (and port)** — either
+widen the avatar public-URL config/logic from a bare hostname to a full,
+request-derived base URL, or terminate TLS at Caddy so the existing
+`https://…/<key>` composition still holds. Production is unaffected: the
+Cloudflare custom domain already provides scheme + a stable host, so the
+request-derived base collapses to today's single value. The implementation issue
+(#523) must not treat this as a config-only change; it carries the
+request-derived `PublicURL` widening described here, and the public-bucket
+website-allow bootstrap step above.
 
 ### 5. Sequencing — land within Phase 4b
 
@@ -178,9 +206,14 @@ path that works for avatars but breaks at evidence is not actually "done."
 
 ## Consequences
 
-- One config axis is added — the operator opt-in R2 override — and the
-  internal/external endpoint seam. No new per-platform axis (rides the existing
-  API host mapping).
+- Config axes added: the operator opt-in R2 override, and the internal/external
+  endpoint seam whose **external base is request-derived** (from the
+  Caddy-forwarded host) so it stays per-platform-safe without static
+  Android/iOS config. This is a real mechanism, not a no-op — the Go server must
+  compose/sign storage URLs from the request host, not a fixed env value.
+- The Garage bootstrap must include **website-allow on the public bucket**
+  (`PutBucketWebsite`); without it the anonymous avatar URL 404s even though
+  presigned PUT/Head/List pass.
 - Fidelity gaps to verify against real R2 before shipping (operator opt-in):
   Cloudflare custom-domain CDN serving/cache/public-access toggle, R2's actual
   CORS enforcement, R2 not enforcing Content-Length (already backstopped by the
@@ -226,3 +259,11 @@ path that works for avatars but breaks at evidence is not actually "done."
   iOS `127.0.0.1`). Resolution: front Garage's web port with the existing Caddy
   proxy and widen the avatar public-URL config to a scheme-carrying base URL;
   prod unchanged.
+- **2026-08-06** — Second Codex round on PR #526. (1) **Corrected** the
+  overstated "no new per-platform axis" claim in §3: server-emitted, SigV4-signed
+  storage URLs cannot be client-rewritten, so a single static external endpoint
+  breaks one of Android/iOS. The external base is now specified as
+  **request-derived** (Caddy-forwarded host), which is per-platform-safe without
+  static config. (2) Added **public-bucket website-allow** (`PutBucketWebsite`)
+  to the Garage bootstrap contract, without which the anonymous avatar URL 404s
+  despite passing presigned PUT/Head/List.

--- a/docs/designs/2026-08-05-local-object-storage-garage-design.md
+++ b/docs/designs/2026-08-05-local-object-storage-garage-design.md
@@ -1,0 +1,187 @@
+# Local Object Storage — Garage as the Zero-Flag Local + CI Backend
+
+**Date:** 2026-08-05
+**Issues:** #523 (this feature), #522 (parent — OSS local dev profile), #483 (dummy R2 config doesn't fail closed), #477 (Supabase → Go API + VPS refactor; Phase 4b evidence + private R2)
+**Status:** Approved
+
+## Context
+
+Object storage in the Go backend goes through `internal/platform/r2` — a thin,
+S3-compatible adapter over Cloudflare R2 (aws-sdk-go-v2, path-style). Phase 3a
+uses it for avatar uploads (presigned PUT + finalize Head + inline Delete).
+Phase 4b (designed ahead, uncommitted) extends it with `PresignGet` + `List`
+for private evidence downloads and retention sweeps, and adds a **separate
+private bucket** alongside the existing public avatar bucket.
+
+Today the local dev stack points `platform/r2` at real Cloudflare R2 dev
+credentials, or at non-working dummy values. The dummy path is broken rather
+than functional (#483: `r2.New()` only rejects *empty* fields, so shipped
+placeholders produce a non-nil uploader that signs presigned URLs against a
+nonexistent account — `request-upload-url` returns 200 with an unreachable URL
+instead of the documented 503). This blocks the goal, tracked under parent
+#522, of running the full stack with **zero external accounts**.
+
+### The key observation
+
+`platform/r2` is almost entirely provider-neutral. Decomposing it:
+
+| Surface | Nature | Provider dependency |
+|---|---|---|
+| presigned PUT (upload) | SigV4, `UsePathStyle` | neutral (endpoint + creds only) |
+| presigned GET (private DL, 4b) | local HMAC, no R2 round-trip | neutral |
+| Head / Delete / List | standard S3 | neutral |
+| CORS (browser presigned) | `PutBucketCors` | neutral |
+| **public read URL (avatar)** | `https://cdn.peppercheck.dev/<key>` — Cloudflare custom domain CDN | **the only Cloudflare-specific piece** |
+
+Everything except public-read URL composition is a generic S3 contract that any
+S3-compatible server can satisfy. [Garage](https://garagehq.deuxfleurs.fr) is
+S3-compatible with verified support for SigV4 presigned PUT/GET, `HeadObject`,
+`DeleteObject`, `ListObjectsV2`, `Get/PutBucketCors`, and path-style addressing
+(website serving is only partially implemented — index/error doc + no redirects
+— which does not affect serving an object by exact key).
+
+## Goals
+
+- A clean `git clone` runs avatar (and, post-4b, evidence) upload/download
+  end-to-end **with zero external accounts and zero flags**.
+- CI exercises the object-storage contract (presign round-trip, Head/Delete/
+  List, CORS) against a **local** backend, never a real shared bucket — a hard
+  requirement for Phase 4b private evidence (retention sweeps, object purge).
+- Fix #483: the default local path actually works instead of failing late.
+- Keep the production R2 code path unchanged and swappable via config alone.
+
+## Non-goals
+
+- Reproducing Cloudflare-specific behavior locally (custom-domain CDN, cache,
+  public-access toggles, R2's exact CORS/error semantics). These are verified
+  against real R2 as an operator opt-in before shipping.
+- Auth and push local backends — separate legs of #522 (#524 Firebase Auth
+  Emulator, #525 FCM stub).
+- Changing the two-sweep design or evidence lifecycle from Phase 4b.
+
+## Decision
+
+### 1. Two-class media model (durable principle)
+
+Classify every media type into exactly one class; the class fixes the bucket
+and the URL model. New media picks a class first.
+
+| Class | Examples | Bucket | URL model | Criterion |
+|---|---|---|---|---|
+| **public** | avatars, future public images | public bucket + public domain | **stable, anonymous, cacheable URL** (never presigned) | "anyone may view it" |
+| **private** | evidence, future sensitive media | private bucket | **short-lived presigned GET** (after authz, TTL 900s) | "requires authorization / limited to owner + related parties" |
+
+Avatars stay public because they are shown in bulk (profile lists, and future
+rankings / referee pickers). Presigning them would defeat CDN/browser/image
+caching (URL churns every TTL) and cost one signature per image per list — so
+public media must resolve to a durable URL, and `PublicURL(key)` stays a pure
+string composition with no S3 client call.
+
+### 2. `core/objectstore` promotion
+
+Promote the provider-neutral S3 client out of `platform/r2` into
+`core/objectstore` (the neutrality test: swapping providers changes only config
+— endpoint, creds, bucket — so it belongs in `core`; `core/objectstore` is
+named as a `core` example in the engineering policy). The only piece that stays
+provider-specific is public-domain URL composition. Phase 4b's `PresignGet` +
+`List` land on this new home rather than on `platform/r2`.
+
+### 3. Internal / external endpoint seam
+
+Presigned URLs sign the host, so they must be signed with the host the client
+(Flutter emulator / browser) actually reaches — which locally differs from the
+host the API container uses. Introduce two endpoints:
+
+- **internal** — server-side Head/Delete/List (`http://garage:3900` locally)
+- **external** — presigned PUT/GET (emulator-reachable, e.g. Android
+  `http://10.0.2.2:3900`, iOS sim `http://localhost:3900`)
+
+In production both collapse to the single R2 endpoint. This seam is the one
+genuinely new design element; it reuses the **same host mapping the Flutter dev
+app already uses to reach the local Go API**, so it introduces no new
+per-platform axis.
+
+### 4. Garage is the default; real R2 is operator opt-in
+
+The local Compose stack ships a Garage service plus a bucket/key/CORS bootstrap
+as the **default** backend (zero flags). Real R2 is an operator opt-in override
+(mirrors the BWS secret-injection opt-in default, #480/#482). CI uses Garage
+with internal == external (no emulator, no host split).
+
+Local reproduction per class:
+
+- **public bucket (avatar)** — served anonymously via Garage's web port,
+  yielding a stable URL that matches prod's CDN model (`R2_PUBLIC_DOMAIN` points
+  at the local web endpoint). No presigning of public media, locally or in prod.
+- **private bucket (evidence)** — presigned GET via the S3 API port.
+
+### 5. Sequencing — land within Phase 4b
+
+Do this with / just before Phase 4b, which already adds `PresignGet` + `List`
+and the private bucket. Doing it earlier for avatars alone would build the
+public-bucket seam once and rework it for the private bucket at 4b, and an OSS
+path that works for avatars but breaks at evidence is not actually "done."
+
+## Alternatives considered
+
+- **Keep real R2 dev locally (status quo).** Works, but requires
+  operator-provisioned Cloudflare credentials (blocks OSS zero-account
+  onboarding), pollutes/depends on a shared bucket for tests, and cannot safely
+  host Phase 4b evidence retention/purge tests. Rejected as the default; kept as
+  operator opt-in.
+- **Make dummy R2 config fail closed (#483's literal framing).** Produces a
+  working *disabled* state, not a working *storage* path — OSS contributors
+  still can't exercise uploads. Superseded: a real Garage backend makes the
+  default path work, resolving #483's root concern.
+- **Presign avatars locally too (avoids Garage's partial website serving).**
+  Diverges the public URL model between environments and tempts presigning of
+  public media, which the two-class principle rejects. Rejected in favor of
+  Garage's web port for anonymous public serving.
+- **MinIO instead of Garage.** MinIO's open-source server is archived / marked
+  no longer maintained; the engineering policy already prefers Garage for
+  S3-compatible local/CI testing. (The existing `compose.test.yaml` MinIO for
+  pgBackRest is a separate concern; converging it on Garage is optional
+  follow-up.)
+- **Garage for CI only, keep emulator on real R2.** Considered, but the OSS
+  onboarding goal (#522) requires the *emulator* path to work with zero
+  accounts, so Garage must be the emulator-loop default, not CI-only.
+
+## Consequences
+
+- One config axis is added — the operator opt-in R2 override — and the
+  internal/external endpoint seam. No new per-platform axis (rides the existing
+  API host mapping).
+- Fidelity gaps to verify against real R2 before shipping (operator opt-in):
+  Cloudflare custom-domain CDN serving/cache/public-access toggle, R2's actual
+  CORS enforcement, R2 not enforcing Content-Length (already backstopped by the
+  finalize Head), and any R2-specific error shapes.
+- #483 is resolved by construction (a real working backend), not by a separate
+  fail-closed change.
+- `platform/r2` shrinks to public-domain URL strategy; the S3 client moves to
+  `core/objectstore`, tidying the architecture boundary.
+
+## Deferred / related work
+
+- #524 Firebase Auth Emulator, #525 FCM stub — the auth and push legs of the
+  same zero-account local profile (#522), following the same
+  zero-flag-default / operator-opt-in pattern.
+- #436 dev-only client mock layer — complementary: client-side simulated flows
+  for services with **no** local emulator (Stripe / IAP purchase, payout). This
+  design deliberately prefers a real local backend over client bypass wherever
+  an emulator exists.
+
+## References
+
+- Garage S3 compatibility: https://garagehq.deuxfleurs.fr/documentation/reference-manual/s3-compatibility/
+- `internal/platform/r2/r2.go` (current adapter)
+- Phase 4b design: `docs/designs/2026-07-26-phase4b-evidence-private-r2-design.md`
+- Engineering policy (Option E layout; `core/objectstore` example) — global AGENTS.md
+
+## Decision log
+
+- **2026-08-05** — Initial design. Established the two-class media model,
+  `core/objectstore` promotion, internal/external endpoint seam, Garage as the
+  zero-flag local + CI default with real R2 as operator opt-in, and 4b
+  sequencing. Filed under parent #522 (OSS local dev profile) with siblings
+  #524 (auth emulator) and #525 (FCM stub); supersedes the fail-closed framing
+  of #483.

--- a/docs/designs/2026-08-05-local-object-storage-garage-design.md
+++ b/docs/designs/2026-08-05-local-object-storage-garage-design.md
@@ -111,9 +111,39 @@ with internal == external (no emulator, no host split).
 Local reproduction per class:
 
 - **public bucket (avatar)** — served anonymously via Garage's web port,
-  yielding a stable URL that matches prod's CDN model (`R2_PUBLIC_DOMAIN` points
-  at the local web endpoint). No presigning of public media, locally or in prod.
+  yielding a stable URL that matches prod's CDN model. No presigning of public
+  media, locally or in prod. See the routing note below — this is more than
+  repointing `R2_PUBLIC_DOMAIN`.
 - **private bucket (evidence)** — presigned GET via the S3 API port.
+
+#### Local public-read routing (Garage web port)
+
+Reproducing anonymous public avatar reads locally is **not** as simple as
+pointing `R2_PUBLIC_DOMAIN` at `garage:3902`. Three facts collide:
+
+1. Garage's web endpoint selects the bucket from the HTTP **`Host` header** and
+   serves over **http**, on a **separate port** from the S3 API.
+2. `PublicURL` composes `https://<R2_PUBLIC_DOMAIN>/<key>` from a
+   **bare-hostname, no-scheme** config (the `R2_PUBLIC_DOMAIN`-no-scheme
+   gotcha from #503) — it hardcodes `https` and cannot express http or a
+   custom port cleanly.
+3. The Flutter dev app reaches local containers as **`10.0.2.2` (Android)** vs
+   **`127.0.0.1` (iOS)**.
+
+Naively repointing `R2_PUBLIC_DOMAIN` therefore yields a stable URL the emulator
+cannot actually fetch. Resolve it by **fronting Garage's web port with the
+stack's existing Caddy reverse proxy** (the Compose stack already runs Caddy):
+Caddy owns the `Host`-header → public-bucket routing and exposes one stable
+public host that the emulator reaches through the **same host mapping already
+used for the Go API** (`10.0.2.2` / `127.0.0.1`), so no `Host`-header handling
+or per-platform axis leaks into app config. Because local serving is http on a
+non-443 port, the public-base config must carry a **scheme (and port)** locally
+— either widen the avatar public-URL config from a bare hostname to a full base
+URL, or terminate TLS at Caddy so the existing `https://…/<key>` composition
+still holds. Production is unaffected: the Cloudflare custom domain already
+provides scheme + a stable host, so both collapse to today's behavior. The
+implementation issue (#523) must not treat this as a config-only change; it
+carries the small `PublicURL`/config widening described here.
 
 ### 5. Sequencing — land within Phase 4b
 
@@ -159,6 +189,10 @@ path that works for avatars but breaks at evidence is not actually "done."
   fail-closed change.
 - `platform/r2` shrinks to public-domain URL strategy; the S3 client moves to
   `core/objectstore`, tidying the architecture boundary.
+- The avatar public-URL composition needs a small widening (scheme + port, i.e.
+  a base URL instead of a bare hostname) plus a Caddy route in front of Garage's
+  web port for local serving — see "Local public-read routing." Prod behavior is
+  unchanged.
 
 ## Deferred / related work
 
@@ -185,3 +219,10 @@ path that works for avatars but breaks at evidence is not actually "done."
   sequencing. Filed under parent #522 (OSS local dev profile) with siblings
   #524 (auth emulator) and #525 (FCM stub); supersedes the fail-closed framing
   of #483.
+- **2026-08-06** — Added the "Local public-read routing" note after a Codex
+  review of PR #526 flagged that repointing `R2_PUBLIC_DOMAIN` at Garage's web
+  port cannot serve avatars to the emulator (Host-header bucket selection, http
+  on a non-443 port, bare-hostname/no-scheme config, and Android `10.0.2.2` vs
+  iOS `127.0.0.1`). Resolution: front Garage's web port with the existing Caddy
+  proxy and widen the avatar public-URL config to a scheme-carrying base URL;
+  prod unchanged.

--- a/docs/designs/2026-08-05-local-object-storage-garage-design.md
+++ b/docs/designs/2026-08-05-local-object-storage-garage-design.md
@@ -92,6 +92,15 @@ carries a 3a-touching change — `profiles.avatar_url` semantics, the profile
 service, and the Flutter avatar PATCH/read path move from persisting a URL to
 persisting a key + composing on read.
 
+**Existing rows need a migration, not just a semantics switch.** Phase 3a rows
+already hold absolute `https://…` values in `avatar_url`. Composing a public URL
+on read over an already-absolute value would double-prefix it, and Head/Delete
+would receive a URL where they now expect a key. #523 must **backfill existing
+`avatar_url` values to bare object keys** (strip the known public-domain prefix)
+before switching read semantics — or dual-read (treat a value containing `://`
+as already-absolute) during a transition window — rather than flipping the
+contract in place.
+
 ### 2. `core/objectstore` promotion
 
 Promote the provider-neutral S3 client out of `platform/r2` into
@@ -123,26 +132,39 @@ there), breaking one media class. In production the two S3 roles collapse to the
 R2 account endpoint and public-read stays the Cloudflare custom domain — the
 same split as today.
 
-**Both external bases must be request-derived, not static values.** Storage URLs
-(presigned PUT/GET and the public avatar URL) are composed and **signed by the
-Go server**, and SigV4 covers the host — so the client cannot rewrite it after
-the fact. The Flutter dev app applies `10.0.2.2` (Android) vs `127.0.0.1` (iOS)
-only when *it* builds the API base URL; that per-platform choice does **not**
-carry over to a server-emitted host. A single static external endpoint would
-therefore hand one of the two emulators an unreachable or wrongly-signed URL.
+**Request-derivation is a local-Garage-only mechanism; real R2 always uses
+configured static bases.** Storage URLs (presigned PUT/GET and the public avatar
+URL) are composed and **signed by the Go server**, and SigV4 covers the host —
+so the client cannot rewrite it after the fact. Locally the Flutter dev app
+applies `10.0.2.2` (Android) vs `127.0.0.1` (iOS) only when *it* builds the API
+base URL; that per-platform choice does **not** carry over to a server-emitted
+host, so a single static external endpoint would hand one of the two emulators
+an unreachable or wrongly-signed URL.
 
-Resolve it by deriving both the external S3-API and external public-read bases
-from the **incoming request's host** (the `Host` / `X-Forwarded-Host` that Caddy
-forwards), each routed to its own Garage port: a request that arrived via
-`10.0.2.2` gets `10.0.2.2`-based storage URLs, one via `127.0.0.1` gets
-`127.0.0.1`-based ones, and the SigV4 signature matches because the presign is
-computed against that same host. Caddy fronts both the API and Garage on that
-host, so the URLs route back to Garage. (An alternative — binding a single host
-LAN IP both emulators can reach — is more fragile and network-specific;
-request-derived is preferred.) In CI there is no emulator, so the request host
-is stable and this collapses to a single value. This corrects an earlier draft
-that claimed "no new per-platform axis": there is one, but it is satisfied by
-request-derived hosts rather than static per-platform config.
+For the **local Garage + Caddy** backend, resolve this by deriving both the
+external S3-API and external public-read bases from the **incoming request's
+host** (the `Host` / `X-Forwarded-Host` that Caddy forwards), each routed to its
+own Garage port: a request via `10.0.2.2` gets `10.0.2.2`-based URLs, one via
+`127.0.0.1` gets `127.0.0.1`-based ones, and the SigV4 signature matches because
+the presign is computed against that same host. Caddy fronts both the API and
+Garage on that host, so the URLs route back to Garage. (An alternative — binding
+a single host LAN IP both emulators can reach — is more fragile and
+network-specific; request-derived is preferred.)
+
+**This request-derivation must be gated to the Garage path only.** On the real
+R2 backend (production, and the operator opt-in override even when run locally),
+the S3-API base is the fixed `https://<account>.r2.cloudflarestorage.com` and
+public-read is the fixed `R2_PUBLIC_DOMAIN`; R2 presigns against its account
+endpoint and the production Caddyfile proxies only the app API, not R2. Deriving
+those bases from the request host there would sign uploads for
+`peppercheck.dev` / `staging.peppercheck.dev` and break real uploads. So #523
+must select the base source by backend (Garage → request-derived; R2 →
+configured static), not apply request-derivation universally — this is what
+keeps the "prod code path unchanged" goal true. In CI (Garage, no emulator) the
+request host is stable, so the local mechanism collapses to a single value
+anyway. This also corrects an earlier draft that claimed "no new per-platform
+axis": there is one for local Garage, satisfied by request-derived hosts rather
+than static per-platform config.
 
 ### 4. Garage is the default; real R2 is operator opt-in
 
@@ -245,7 +267,12 @@ path that works for avatars but breaks at evidence is not actually "done."
   `avatar_url`, and the public URL is composed on read from the request-local
   base. This touches existing 3a code (`profiles.avatar_url` semantics, the
   profile service, the Flutter avatar PATCH/read path) and converges avatars
-  onto the Phase 4b evidence `object_key`-only model.
+  onto the Phase 4b evidence `object_key`-only model. It also requires a
+  **one-time backfill** of existing absolute `avatar_url` rows to keys (or a
+  dual-read transition) — not an in-place semantics flip.
+- Request-derivation is **local-Garage-only**: #523 selects the base source by
+  backend (Garage → request-derived; real R2 → configured static account/
+  public-read endpoints), so the prod/opt-in-R2 code path is genuinely unchanged.
 - Fidelity gaps to verify against real R2 before shipping (operator opt-in):
   Cloudflare custom-domain CDN serving/cache/public-access toggle, R2's actual
   CORS enforcement, R2 not enforcing Content-Length (already backstopped by the
@@ -313,3 +340,12 @@ path that works for avatars but breaks at evidence is not actually "done."
   matches the split that already exists in prod (`r2.go` composes the public URL
   from `R2_PUBLIC_DOMAIN`, separate from the S3 endpoint), which the round-2
   request-derived fix had over-collapsed.
+- **2026-08-06** — Fifth Codex round (operator-requested). (1) **Scoped**
+  request-derivation to the local Garage/Caddy backend only: real R2 (prod and
+  the opt-in override) uses the fixed account S3 endpoint + `R2_PUBLIC_DOMAIN`,
+  and deriving from the request host there would sign uploads for
+  `peppercheck.dev`/`staging.peppercheck.dev` and break prod. #523 selects base
+  source by backend. (2) Added a **backfill** requirement: existing absolute
+  `avatar_url` rows must be normalized to object keys (or dual-read) before the
+  key + compose-on-read switch, to avoid double-prefixing and Head/Delete
+  receiving a URL instead of a key.

--- a/docs/designs/2026-08-05-local-object-storage-garage-design.md
+++ b/docs/designs/2026-08-05-local-object-storage-garage-design.md
@@ -77,6 +77,21 @@ caching (URL churns every TTL) and cost one signature per image per list — so
 public media must resolve to a durable URL, and `PublicURL(key)` stays a pure
 string composition with no S3 client call.
 
+**Persist the object key, not a host-bearing URL; compose the public URL on
+read.** Because the external base is request-derived (§3), a full URL is only
+valid for the host it was built on. The existing 3a flow persists a full
+`profiles.avatar_url` (Flutter PATCHes back the server-returned `publicUrl`,
+which `profile/service.go` validates and stores), so locally an Android upload
+would persist a `10.0.2.2` URL that iOS / a browser later cannot fetch, and even
+in prod a persisted absolute URL rots if the CDN domain ever changes. The fix
+is host-neutral persistence: store the **object key** (or path) as the canonical
+value and derive the fetchable public URL from the request-local base on every
+read. This aligns avatars with the Phase 4b evidence decision (which already
+drops `public_url`/`file_url` for an `object_key`-only column). #523 therefore
+carries a 3a-touching change — `profiles.avatar_url` semantics, the profile
+service, and the Flutter avatar PATCH/read path move from persisting a URL to
+persisting a key + composing on read.
+
 ### 2. `core/objectstore` promotion
 
 Promote the provider-neutral S3 client out of `platform/r2` into
@@ -214,6 +229,11 @@ path that works for avatars but breaks at evidence is not actually "done."
 - The Garage bootstrap must include **website-allow on the public bucket**
   (`PutBucketWebsite`); without it the anonymous avatar URL 404s even though
   presigned PUT/Head/List pass.
+- Avatar persistence changes: the DB stores the **object key**, not a full
+  `avatar_url`, and the public URL is composed on read from the request-local
+  base. This touches existing 3a code (`profiles.avatar_url` semantics, the
+  profile service, the Flutter avatar PATCH/read path) and converges avatars
+  onto the Phase 4b evidence `object_key`-only model.
 - Fidelity gaps to verify against real R2 before shipping (operator opt-in):
   Cloudflare custom-domain CDN serving/cache/public-access toggle, R2's actual
   CORS enforcement, R2 not enforcing Content-Length (already backstopped by the
@@ -267,3 +287,10 @@ path that works for avatars but breaks at evidence is not actually "done."
   static config. (2) Added **public-bucket website-allow** (`PutBucketWebsite`)
   to the Garage bootstrap contract, without which the anonymous avatar URL 404s
   despite passing presigned PUT/Head/List.
+- **2026-08-06** — Third Codex round on PR #526 caught that a request-derived
+  URL must not be **persisted**: the 3a flow stores the returned `avatar_url`, so
+  an Android upload would save a `10.0.2.2` URL iOS/a browser cannot later fetch.
+  Adopted host-neutral persistence — store the object key, compose the public URL
+  on read from the request-local base — converging avatars onto Phase 4b's
+  `object_key`-only model. Noted the 3a-touching scope in #523. Per the review
+  cap, this third-round fix was not sent for a fourth independent review.

--- a/docs/designs/2026-08-05-local-object-storage-garage-design.md
+++ b/docs/designs/2026-08-05-local-object-storage-garage-design.md
@@ -105,30 +105,39 @@ provider-specific is public-domain URL composition. Phase 4b's `PresignGet` +
 
 Presigned URLs sign the host, so they must be signed with the host the client
 (Flutter emulator / browser) actually reaches — which locally differs from the
-host the API container uses. Introduce two endpoints:
+host the API container uses. **Model three endpoint roles, not two**, because
+presigned traffic and anonymous public reads hit different surfaces (the S3 API
+vs the CDN/website host — different ports locally):
 
-- **internal** — server-side Head/Delete/List (`http://garage:3900` locally)
-- **external** — presigned PUT/GET, and public-read URL composition
-  (client-reachable)
+- **internal S3** — server-side Head/Delete/List (`http://garage:3900` locally)
+- **external S3-API** — presigned PUT/GET, signed against the S3 API host the
+  client reaches (Garage port 3900 via Caddy; the R2 account endpoint in prod)
+- **external public-read** — anonymous public-URL composition, against the
+  web/CDN host (Garage web port 3902 via Caddy; `R2_PUBLIC_DOMAIN` in prod)
 
-In production both collapse to the single R2 endpoint / Cloudflare custom
-domain.
+The public-read base is already distinct from the S3 endpoint today — `r2.go`
+composes the avatar URL from `R2_PUBLIC_DOMAIN`, separate from the S3 endpoint
+it presigns against. Collapsing them would sign presigned URLs for the CDN host
+(no S3 there) or compose avatar URLs for the S3-API host (no anonymous serving
+there), breaking one media class. In production the two S3 roles collapse to the
+R2 account endpoint and public-read stays the Cloudflare custom domain — the
+same split as today.
 
-**The external base must be request-derived, not a single static value.**
-Storage URLs (presigned PUT/GET and the public avatar URL) are composed and
-**signed by the Go server**, and SigV4 covers the host — so the client cannot
-rewrite it after the fact. The Flutter dev app applies `10.0.2.2` (Android) vs
-`127.0.0.1` (iOS) only when *it* builds the API base URL; that per-platform
-choice does **not** carry over to a server-emitted host. A single configured
-external endpoint would therefore hand one of the two emulators an unreachable
-or wrongly-signed URL.
+**Both external bases must be request-derived, not static values.** Storage URLs
+(presigned PUT/GET and the public avatar URL) are composed and **signed by the
+Go server**, and SigV4 covers the host — so the client cannot rewrite it after
+the fact. The Flutter dev app applies `10.0.2.2` (Android) vs `127.0.0.1` (iOS)
+only when *it* builds the API base URL; that per-platform choice does **not**
+carry over to a server-emitted host. A single static external endpoint would
+therefore hand one of the two emulators an unreachable or wrongly-signed URL.
 
-Resolve it by deriving the external base from the **incoming request's host**
-(the `Host` / `X-Forwarded-Host` that Caddy forwards): a request that arrived
-via `10.0.2.2` gets `10.0.2.2`-based storage URLs, one via `127.0.0.1` gets
+Resolve it by deriving both the external S3-API and external public-read bases
+from the **incoming request's host** (the `Host` / `X-Forwarded-Host` that Caddy
+forwards), each routed to its own Garage port: a request that arrived via
+`10.0.2.2` gets `10.0.2.2`-based storage URLs, one via `127.0.0.1` gets
 `127.0.0.1`-based ones, and the SigV4 signature matches because the presign is
 computed against that same host. Caddy fronts both the API and Garage on that
-host, so the URL routes back to Garage. (An alternative — binding a single host
+host, so the URLs route back to Garage. (An alternative — binding a single host
 LAN IP both emulators can reach — is more fragile and network-specific;
 request-derived is preferred.) In CI there is no emulator, so the request host
 is stable and this collapses to a single value. This corrects an earlier draft
@@ -221,11 +230,14 @@ path that works for avatars but breaks at evidence is not actually "done."
 
 ## Consequences
 
-- Config axes added: the operator opt-in R2 override, and the internal/external
-  endpoint seam whose **external base is request-derived** (from the
-  Caddy-forwarded host) so it stays per-platform-safe without static
-  Android/iOS config. This is a real mechanism, not a no-op — the Go server must
-  compose/sign storage URLs from the request host, not a fixed env value.
+- Config axes added: the operator opt-in R2 override, and a **three-role**
+  endpoint seam — internal S3 (server ops), external S3-API (presigned), and
+  external public-read (anonymous CDN/web) — whose two external bases are
+  **request-derived** (from the Caddy-forwarded host) so they stay
+  per-platform-safe without static Android/iOS config. This is a real mechanism,
+  not a no-op — the Go server must compose/sign storage URLs from the request
+  host per surface, not a fixed env value. Public-read is already a base distinct
+  from the S3 endpoint today (`R2_PUBLIC_DOMAIN`).
 - The Garage bootstrap must include **website-allow on the public bucket**
   (`PutBucketWebsite`); without it the anonymous avatar URL 404s even though
   presigned PUT/Head/List pass.
@@ -292,5 +304,12 @@ path that works for avatars but breaks at evidence is not actually "done."
   an Android upload would save a `10.0.2.2` URL iOS/a browser cannot later fetch.
   Adopted host-neutral persistence — store the object key, compose the public URL
   on read from the request-local base — converging avatars onto Phase 4b's
-  `object_key`-only model. Noted the 3a-touching scope in #523. Per the review
-  cap, this third-round fix was not sent for a fourth independent review.
+  `object_key`-only model. Noted the 3a-touching scope in #523.
+- **2026-08-06** — Fourth Codex round (operator-authorized beyond the 3-round
+  cap) caught that §3 conflated two serving surfaces into one external base.
+  Split the seam into **three roles**: internal S3, external S3-API (presigned,
+  Garage 3900 / R2 endpoint), and external public-read (anonymous, Garage web
+  3902 / `R2_PUBLIC_DOMAIN`). Both external bases are request-derived. This
+  matches the split that already exists in prod (`r2.go` composes the public URL
+  from `R2_PUBLIC_DOMAIN`, separate from the S3 endpoint), which the round-2
+  request-derived fix had over-collapsed.


### PR DESCRIPTION
## Summary

Adds the design doc for local + CI object storage on **Garage** (S3-compatible)
with zero external accounts, keeping real Cloudflare R2 as an operator opt-in.

Key decisions captured:

- **Two-class media model** — public media (avatars) = stable anonymous URL
  (never presigned); private media (evidence) = short-lived presigned GET. This
  is the durable rule for classifying all future media.
- **`core/objectstore` promotion** — the provider-neutral S3 client moves out of
  `platform/r2` (neutrality test); only public-domain URL composition stays
  provider-specific. Phase 4b's `PresignGet` + `List` land on the new home.
- **Internal / external endpoint seam** — presigned URLs sign the host, so they
  are signed with the external (emulator-reachable) endpoint while server-side
  Head/Delete/List use the internal endpoint. Prod collapses both to R2. Reuses
  the same host mapping the Flutter dev app already uses for the local Go API.
- **Garage is the zero-flag default; real R2 is operator opt-in** (mirrors the
  BWS injection opt-in default). Resolves #483 by making the default local path
  actually work.
- **Sequenced within Phase 4b**, which already adds the private bucket +
  `PresignGet`/`List`.

## Scope

Design doc only — no code changes. Implementation is tracked in #523.

## Documentation

This PR *is* the documentation change (a new `docs/designs/` living doc). No
other docs need updating for this design-only PR.

## Related

- Feature: #523
- Parent (OSS local dev profile): #522, siblings #524 (Firebase Auth Emulator),
  #525 (FCM stub)
- #483 (dummy R2 config doesn't fail closed — resolved by the Garage backend)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LLRGuGgsjidD7fTymVPJAS
