### PR TITLE
feat(backend): Phase 4a matching engine — store, match & sweep workers (T7–T9)

### DIFF
--- a/backend/internal/matching/domain.go
+++ b/backend/internal/matching/domain.go
@@ -8,16 +8,6 @@ import "errors"
 // transaction — the request stays pending and the sweep retries it.
 var ErrRefereeTaken = errors.New("matching: referee already accepted on this task")
 
-// Referee-request statuses the matching engine reads and writes. The full set
-// lives in the referee_request_status enum; these are the ones this package
-// transitions between.
-const (
-	statusPending   = "pending"
-	statusAccepted  = "accepted"
-	statusExpired   = "expired"
-	statusCancelled = "cancelled"
-)
-
 // Config is the typed matching configuration singleton (matching_config, one
 // row id = true). The ordering invariant open > rematch > cancel is enforced in
 // the schema; the service only reads these values.

--- a/backend/internal/matching/domain.go
+++ b/backend/internal/matching/domain.go
@@ -29,6 +29,18 @@ type Config struct {
 	PointCostPerRequest int
 }
 
+// RequestContext carries the task facts the match handler needs to notify: the
+// task id/title, the tasker (empty when the task's author was deleted), and
+// whether the task already has a cancelled request. HasCancelledSibling marks a
+// re-match after a referee cancelled, which selects the reassigned/
+// cancelled-pending notification variants over the first-match ones.
+type RequestContext struct {
+	TaskID              string
+	TaskerID            string // "" when the task's tasker was deleted
+	Title               string
+	HasCancelledSibling bool
+}
+
 // ExpiredCandidate is a pending request that has passed the rematch cutoff and
 // is a candidate for expiry by the sweep. TaskerID/Title come from the joined
 // task so the sweep can refund and notify without a second round-trip; both may

--- a/backend/internal/matching/domain.go
+++ b/backend/internal/matching/domain.go
@@ -1,0 +1,41 @@
+package matching
+
+import "errors"
+
+// ErrRefereeTaken signals that a referee already holds an accepted seat on the
+// task: the partial unique index uq_referee_requests_task_accepted_referee
+// tripped (P4a-D16). The match handler maps it to success OUTSIDE the
+// transaction — the request stays pending and the sweep retries it.
+var ErrRefereeTaken = errors.New("matching: referee already accepted on this task")
+
+// Referee-request statuses the matching engine reads and writes. The full set
+// lives in the referee_request_status enum; these are the ones this package
+// transitions between.
+const (
+	statusPending   = "pending"
+	statusAccepted  = "accepted"
+	statusExpired   = "expired"
+	statusCancelled = "cancelled"
+)
+
+// Config is the typed matching configuration singleton (matching_config, one
+// row id = true). The ordering invariant open > rematch > cancel is enforced in
+// the schema; the service only reads these values.
+type Config struct {
+	OpenDeadlineHours   int
+	CancelDeadlineHours int
+	RematchCutoffHours  int
+	MaxRefereesPerTask  int
+	PointCostPerRequest int
+}
+
+// ExpiredCandidate is a pending request that has passed the rematch cutoff and
+// is a candidate for expiry by the sweep. TaskerID/Title come from the joined
+// task so the sweep can refund and notify without a second round-trip; both may
+// be zero-valued for a task whose tasker was deleted (ON DELETE SET NULL).
+type ExpiredCandidate struct {
+	ID       string
+	TaskID   string
+	TaskerID string // "" when the task's tasker was deleted
+	Title    string
+}

--- a/backend/internal/matching/service.go
+++ b/backend/internal/matching/service.go
@@ -153,6 +153,65 @@ func (s *Service) maybeNotifyCancelledPending(ctx context.Context, tx database.Q
 		"cancelled_pending:"+requestID)
 }
 
+// HandleSweep is the recurring worker pass. It first reschedules itself (so a
+// mid-run failure never stops the chain — the bucketed key makes a duplicate
+// schedule on retry a no-op), then expires every pending request past the
+// rematch cutoff (refund + notify, each in its own transaction) and re-enqueues
+// a match for the pendings still inside the window.
+func (s *Service) HandleSweep(ctx context.Context, _ *jobs.Job) error {
+	if err := s.scheduleNextSweep(ctx); err != nil {
+		return err
+	}
+	cfg, err := s.store.LoadConfig(ctx)
+	if err != nil {
+		return err
+	}
+
+	// Expire past-cutoff pendings. The expire CAS shares the transaction with the
+	// refund + notify, so a request a concurrent match already accepted is neither
+	// expired nor refunded.
+	expiring, err := s.store.PastCutoffPendingIDs(ctx, cfg.RematchCutoffHours)
+	if err != nil {
+		return err
+	}
+	for _, e := range expiring {
+		if err := database.WithTx(ctx, s.db, func(tx database.Querier) error {
+			expired, err := s.store.ExpireIfPendingInTx(ctx, tx, e.ID)
+			if err != nil {
+				return err
+			}
+			if !expired {
+				return nil // a concurrent match accepted it; leave it be
+			}
+			if err := s.points.RefundForRequestInTx(ctx, tx, e.ID, "matching expired: no referee found"); err != nil {
+				return err
+			}
+			if e.TaskerID == "" {
+				return nil // tasker was deleted; nothing to notify
+			}
+			return s.notifier.EnqueueInTx(ctx, tx, e.TaskerID,
+				"notification_matching_expired_refunded_tasker", []string{e.Title},
+				map[string]string{"route": "/tasks/" + e.TaskID})
+		}); err != nil {
+			return err
+		}
+	}
+
+	// Re-enqueue a match for the pendings still inside the window.
+	remaining, err := s.store.PendingWithinWindow(ctx, cfg.RematchCutoffHours)
+	if err != nil {
+		return err
+	}
+	for _, id := range remaining {
+		if err := database.WithTx(ctx, s.db, func(tx database.Querier) error {
+			return s.EnqueueMatchInTx(ctx, tx, id)
+		}); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // pickIndex derives a stable index into the least-workload candidate set from
 // the request id, so the choice is deterministic and idempotent (no math/rand
 // inside the transaction). Faithful randomness is not required — any stable pick

--- a/backend/internal/matching/service.go
+++ b/backend/internal/matching/service.go
@@ -1,0 +1,164 @@
+package matching
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"hash/fnv"
+
+	"github.com/cloveclovedev/peppercheck/backend/internal/core/database"
+	"github.com/cloveclovedev/peppercheck/backend/internal/core/jobs"
+	"github.com/cloveclovedev/peppercheck/backend/internal/judgement"
+)
+
+// notifier is the subset of the notification sender the matching engine uses.
+// It is defined here (not imported from notification) so matching stays
+// independent of that feature; the composition root passes the real
+// notification.Sender, tests pass a fake.
+type notifier interface {
+	EnqueueInTx(ctx context.Context, tx database.Querier, userID, keyBase string, args []string, data map[string]string) error
+	EnqueueIdempotentInTx(ctx context.Context, tx database.Querier, userID, keyBase string, args []string, data map[string]string, idempotencyKey string) error
+}
+
+// Service is the matching use case: it turns a match job into (at most) one
+// accepted referee, provisions the judgement, and notifies both parties, all in
+// one transaction. It also owns the sweep that expires past-cutoff pendings.
+type Service struct {
+	db          *database.Handle
+	store       *Store
+	points      PointLocker
+	obligations ObligationChecker
+	judgements  *judgement.Provisioner
+	notifier    notifier
+	jobs        *jobs.Store
+}
+
+// NewService wires the matching use case. points/obligations are the Phase 5
+// seams (no-ops in 4a); judgements provisions the awaiting_evidence row; the
+// notifier and jobs store back the notification outbox and worker enqueues.
+func NewService(db *database.Handle, store *Store, points PointLocker, obligations ObligationChecker, judgements *judgement.Provisioner, notifier notifier, jobsStore *jobs.Store) *Service {
+	return &Service{
+		db:          db,
+		store:       store,
+		points:      points,
+		obligations: obligations,
+		judgements:  judgements,
+		notifier:    notifier,
+		jobs:        jobsStore,
+	}
+}
+
+// HandleMatch is the idempotent worker handler for one match job: pick a
+// least-workload eligible referee, accept them (CAS), provision the judgement,
+// and notify. A redelivery whose request is already accepted is a no-op. A
+// same-task double-assignment (23505) MUST propagate out of the transaction to
+// force a rollback — treating it as success inside the callback would make
+// Commit fail (P4a-D16) — so the sentinel is mapped to success OUTSIDE the tx.
+func (s *Service) HandleMatch(ctx context.Context, j *jobs.Job) error {
+	var p struct {
+		RequestID string `json:"requestId"`
+	}
+	if err := json.Unmarshal(j.Payload, &p); err != nil {
+		return fmt.Errorf("unmarshal match payload: %w", err)
+	}
+	if p.RequestID == "" {
+		return fmt.Errorf("match payload: empty requestId")
+	}
+	requestID := p.RequestID
+
+	err := database.WithTx(ctx, s.db, func(tx database.Querier) error {
+		candidates, err := s.store.CandidateReferees(ctx, tx, requestID)
+		if err != nil {
+			return err
+		}
+		if len(candidates) == 0 {
+			// No eligible referee right now; leave the request pending for the
+			// sweep to retry. If it is a re-match after a cancel, tell the tasker
+			// once (idempotent).
+			return s.maybeNotifyCancelledPending(ctx, tx, requestID)
+		}
+
+		// Obligation priority (Phase 5 seam; 4a returns none, so pick == candidates).
+		pick := candidates
+		obligated, err := s.obligations.FilterObligated(ctx, candidates)
+		if err != nil {
+			return err
+		}
+		if len(obligated) > 0 {
+			pick = obligated
+		}
+		isObligation := len(pick) < len(candidates) // narrowed only by obligation
+		referee := pick[pickIndex(requestID, len(pick))]
+
+		won, err := s.store.MarkAcceptedInTx(ctx, tx, requestID, referee, isObligation)
+		if err != nil {
+			return err // ErrRefereeTaken propagates -> WithTx rolls back
+		}
+		if !won {
+			// Another worker already matched it, or the request slipped past the
+			// rematch cutoff; either way the sweep owns the outcome.
+			return nil
+		}
+		if err := s.judgements.CreateAwaitingEvidenceInTx(ctx, tx, requestID); err != nil {
+			return err
+		}
+		return s.notifyMatch(ctx, tx, requestID, referee)
+	})
+	if errors.Is(err, ErrRefereeTaken) {
+		return nil // a concurrent match took this referee on the task; sweep retries
+	}
+	return err
+}
+
+// notifyMatch tells the assigned referee they have a new task and the tasker
+// their request matched (or was reassigned, if a prior request on the task was
+// cancelled). A deleted tasker (nil id) is skipped.
+func (s *Service) notifyMatch(ctx context.Context, tx database.Querier, requestID, refereeID string) error {
+	rc, err := s.store.RequestContext(ctx, tx, requestID)
+	if err != nil {
+		return err
+	}
+	data := map[string]string{"route": "/tasks/" + rc.TaskID}
+	if err := s.notifier.EnqueueInTx(ctx, tx, refereeID,
+		"notification_task_assigned_referee", []string{rc.Title}, data); err != nil {
+		return err
+	}
+	if rc.TaskerID == "" {
+		return nil
+	}
+	taskerKey := "notification_request_matched_tasker"
+	if rc.HasCancelledSibling {
+		taskerKey = "notification_matching_reassigned_tasker"
+	}
+	return s.notifier.EnqueueInTx(ctx, tx, rc.TaskerID, taskerKey, []string{rc.Title}, data)
+}
+
+// maybeNotifyCancelledPending tells the tasker their re-match is still searching,
+// but only for a cancel-originated request (its task has a prior cancelled
+// request) with a live tasker, and only once — the idempotency key survives the
+// sweep's repeated re-matches (P4a-D19). A first-time (non-cancel) pending is a
+// silent no-op; the sweep keeps retrying.
+func (s *Service) maybeNotifyCancelledPending(ctx context.Context, tx database.Querier, requestID string) error {
+	rc, err := s.store.RequestContext(ctx, tx, requestID)
+	if err != nil {
+		return err
+	}
+	if !rc.HasCancelledSibling || rc.TaskerID == "" {
+		return nil
+	}
+	return s.notifier.EnqueueIdempotentInTx(ctx, tx, rc.TaskerID,
+		"notification_matching_cancelled_pending_tasker", []string{rc.Title},
+		map[string]string{"route": "/tasks/" + rc.TaskID},
+		"cancelled_pending:"+requestID)
+}
+
+// pickIndex derives a stable index into the least-workload candidate set from
+// the request id, so the choice is deterministic and idempotent (no math/rand
+// inside the transaction). Faithful randomness is not required — any stable pick
+// within the least-workload set preserves the balancing intent.
+func pickIndex(requestID string, n int) int {
+	h := fnv.New64a()
+	_, _ = h.Write([]byte(requestID))
+	return int(h.Sum64() % uint64(n))
+}

--- a/backend/internal/matching/service.go
+++ b/backend/internal/matching/service.go
@@ -2,6 +2,7 @@ package matching
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -141,6 +142,9 @@ func (s *Service) notifyMatch(ctx context.Context, tx database.Querier, requestI
 // silent no-op; the sweep keeps retrying.
 func (s *Service) maybeNotifyCancelledPending(ctx context.Context, tx database.Querier, requestID string) error {
 	rc, err := s.store.RequestContext(ctx, tx, requestID)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil // request vanished (e.g. its task was deleted); nothing to notify (#464)
+	}
 	if err != nil {
 		return err
 	}

--- a/backend/internal/matching/service_test.go
+++ b/backend/internal/matching/service_test.go
@@ -269,6 +269,16 @@ func TestHandleMatchCancelOriginatedNoCandidateNotifiesTasker(t *testing.T) {
 	}
 }
 
+func TestHandleMatchMissingRequestIsNoop(t *testing.T) {
+	db := testsupport.DB(t)
+	svc, _ := newTestMatchingService(t, db)
+	// A well-formed uuid that maps to no request row (e.g. its task was deleted):
+	// the handler must succeed as a no-op, not error and burn retries (#464).
+	if err := svc.HandleMatch(context.Background(), matchJob("00000000-0000-0000-0000-000000000000")); err != nil {
+		t.Fatalf("want no-op for a missing request, got %v", err)
+	}
+}
+
 func TestHandleMatchPastCutoffLeavesPending(t *testing.T) {
 	db := testsupport.DB(t)
 	svc, _ := newTestMatchingService(t, db)

--- a/backend/internal/matching/service_test.go
+++ b/backend/internal/matching/service_test.go
@@ -1,0 +1,295 @@
+package matching_test
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"sync"
+	"testing"
+
+	"github.com/cloveclovedev/peppercheck/backend/internal/core/database"
+	"github.com/cloveclovedev/peppercheck/backend/internal/core/jobs"
+	"github.com/cloveclovedev/peppercheck/backend/internal/judgement"
+	"github.com/cloveclovedev/peppercheck/backend/internal/matching"
+	"github.com/cloveclovedev/peppercheck/backend/internal/testsupport"
+)
+
+// fakeNotifier records the notifications the matching service enqueues so tests
+// can assert on them without a device-token round-trip. It satisfies matching's
+// unexported notifier interface structurally.
+type fakeNotifier struct {
+	mu    sync.Mutex
+	calls []notifyCall
+}
+
+type notifyCall struct {
+	userID  string
+	keyBase string
+}
+
+func (f *fakeNotifier) EnqueueInTx(_ context.Context, _ database.Querier, userID, keyBase string, _ []string, _ map[string]string) error {
+	f.record(userID, keyBase)
+	return nil
+}
+
+func (f *fakeNotifier) EnqueueIdempotentInTx(_ context.Context, _ database.Querier, userID, keyBase string, _ []string, _ map[string]string, _ string) error {
+	f.record(userID, keyBase)
+	return nil
+}
+
+func (f *fakeNotifier) record(userID, keyBase string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.calls = append(f.calls, notifyCall{userID, keyBase})
+}
+
+func (f *fakeNotifier) keysFor(userID string) []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	var out []string
+	for _, c := range f.calls {
+		if c.userID == userID {
+			out = append(out, c.keyBase)
+		}
+	}
+	return out
+}
+
+func newTestMatchingService(t *testing.T, db *sql.DB) (*matching.Service, *fakeNotifier) {
+	t.Helper()
+	fn := &fakeNotifier{}
+	svc := matching.NewService(
+		db,
+		matching.NewStore(db),
+		matching.NewNoopPointLocker(),
+		matching.NewNoObligations(),
+		judgement.NewProvisioner(),
+		fn,
+		jobs.NewStore(db),
+	)
+	return svc, fn
+}
+
+// seedSingleCandidate creates a pending request whose only eligible referee is A.
+func seedSingleCandidate(t *testing.T, db *sql.DB) (requestID, refereeA string) {
+	t.Helper()
+	tasker := newUser(t, db)
+	taskID := newTask(t, db, tasker)
+	a := newReferee(t, db)
+	addAllDaySlot(t, db, a, taskID)
+	return newPendingRequest(t, db, taskID), a
+}
+
+func matchJob(reqID string) *jobs.Job {
+	payload, _ := json.Marshal(map[string]string{"requestId": reqID})
+	return &jobs.Job{Kind: matching.JobKindMatch, Payload: payload}
+}
+
+func requestStatus(t *testing.T, db *sql.DB, reqID string) (status string, matched sql.NullString) {
+	t.Helper()
+	if err := db.QueryRow(`SELECT status, matched_referee_id FROM public.referee_requests WHERE id=$1`, reqID).
+		Scan(&status, &matched); err != nil {
+		t.Fatalf("read request %s: %v", reqID, err)
+	}
+	return status, matched
+}
+
+func judgementCount(t *testing.T, db *sql.DB, reqID string) int {
+	t.Helper()
+	var n int
+	if err := db.QueryRow(`SELECT count(*) FROM public.judgements WHERE id=$1`, reqID).Scan(&n); err != nil {
+		t.Fatalf("count judgements %s: %v", reqID, err)
+	}
+	return n
+}
+
+func TestHandleMatchAssignsAndIsIdempotent(t *testing.T) {
+	db := testsupport.DB(t)
+	svc, fn := newTestMatchingService(t, db)
+	reqID, refA := seedSingleCandidate(t, db)
+	ctx := context.Background()
+
+	if err := svc.HandleMatch(ctx, matchJob(reqID)); err != nil {
+		t.Fatalf("match #1: %v", err)
+	}
+	if err := svc.HandleMatch(ctx, matchJob(reqID)); err != nil {
+		t.Fatalf("match #2 (idempotent): %v", err)
+	}
+
+	status, matched := requestStatus(t, db, reqID)
+	if status != "accepted" || matched.String != refA {
+		t.Fatalf("want accepted->A(%s), got %s/%s", refA, status, matched.String)
+	}
+	if n := judgementCount(t, db, reqID); n != 1 {
+		t.Fatalf("want exactly 1 judgement, got %d", n)
+	}
+	if keys := fn.keysFor(refA); len(keys) != 1 || keys[0] != "notification_task_assigned_referee" {
+		t.Fatalf("want referee assigned once, got %v", keys)
+	}
+}
+
+func TestHandleMatchConcurrentSameRequestAcceptsOnce(t *testing.T) {
+	db := testsupport.DB(t)
+	svc, _ := newTestMatchingService(t, db)
+	reqID, refA := seedSingleCandidate(t, db)
+	ctx := context.Background()
+
+	var wg sync.WaitGroup
+	errs := make([]error, 2)
+	for i := range errs {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			errs[i] = svc.HandleMatch(ctx, matchJob(reqID))
+		}(i)
+	}
+	wg.Wait()
+	for i, err := range errs {
+		if err != nil {
+			t.Fatalf("goroutine %d: %v", i, err)
+		}
+	}
+
+	status, matched := requestStatus(t, db, reqID)
+	if status != "accepted" || matched.String != refA {
+		t.Fatalf("want accepted->A, got %s/%s", status, matched.String)
+	}
+	if n := judgementCount(t, db, reqID); n != 1 {
+		t.Fatalf("want exactly 1 judgement after concurrent match, got %d", n)
+	}
+}
+
+func TestHandleMatchConcurrentSameTaskAssignsOneSeat(t *testing.T) {
+	db := testsupport.DB(t)
+	svc, _ := newTestMatchingService(t, db)
+	ctx := context.Background()
+
+	// Two seats on one task whose only eligible referee is A: exactly one seat
+	// can accept A (the partial unique index trips ErrRefereeTaken on the other,
+	// which rolls back and leaves that seat pending).
+	tasker := newUser(t, db)
+	taskID := newTask(t, db, tasker)
+	a := newReferee(t, db)
+	addAllDaySlot(t, db, a, taskID)
+	req1 := newPendingRequest(t, db, taskID)
+	req2 := newPendingRequest(t, db, taskID)
+
+	var wg sync.WaitGroup
+	for _, r := range []string{req1, req2} {
+		wg.Add(1)
+		go func(r string) {
+			defer wg.Done()
+			if err := svc.HandleMatch(ctx, matchJob(r)); err != nil {
+				t.Errorf("match %s: %v", r, err)
+			}
+		}(r)
+	}
+	wg.Wait()
+
+	s1, m1 := requestStatus(t, db, req1)
+	s2, m2 := requestStatus(t, db, req2)
+	accepted := 0
+	pending := 0
+	for _, pair := range []struct {
+		s string
+		m sql.NullString
+	}{{s1, m1}, {s2, m2}} {
+		switch pair.s {
+		case "accepted":
+			accepted++
+			if pair.m.String != a {
+				t.Fatalf("accepted seat matched to %s, want A(%s)", pair.m.String, a)
+			}
+		case "pending":
+			pending++
+		default:
+			t.Fatalf("unexpected status %s", pair.s)
+		}
+	}
+	if accepted != 1 || pending != 1 {
+		t.Fatalf("want exactly one accepted + one pending, got accepted=%d pending=%d", accepted, pending)
+	}
+}
+
+// addCancelledSibling inserts a cancelled referee_request on the task so it
+// reads as a re-match (a referee previously cancelled their assignment).
+func addCancelledSibling(t *testing.T, db *sql.DB, taskID, refereeID string) {
+	t.Helper()
+	if _, err := db.Exec(
+		`INSERT INTO public.referee_requests (task_id, status, matched_referee_id)
+		 VALUES ($1, 'cancelled', $2)`, taskID, refereeID); err != nil {
+		t.Fatalf("seed cancelled sibling: %v", err)
+	}
+}
+
+func TestHandleMatchReassignNotifiesTasker(t *testing.T) {
+	db := testsupport.DB(t)
+	svc, fn := newTestMatchingService(t, db)
+	ctx := context.Background()
+
+	tasker := newUser(t, db)
+	taskID := newTask(t, db, tasker)
+	gone := newReferee(t, db)
+	addCancelledSibling(t, db, taskID, gone) // prior referee cancelled -> re-match
+	a := newReferee(t, db)
+	addAllDaySlot(t, db, a, taskID)
+	reqID := newPendingRequest(t, db, taskID)
+
+	if err := svc.HandleMatch(ctx, matchJob(reqID)); err != nil {
+		t.Fatalf("match: %v", err)
+	}
+	status, matched := requestStatus(t, db, reqID)
+	if status != "accepted" || matched.String != a {
+		t.Fatalf("want accepted->A, got %s/%s", status, matched.String)
+	}
+	if keys := fn.keysFor(tasker); len(keys) != 1 || keys[0] != "notification_matching_reassigned_tasker" {
+		t.Fatalf("want tasker reassigned once, got %v", keys)
+	}
+}
+
+func TestHandleMatchCancelOriginatedNoCandidateNotifiesTasker(t *testing.T) {
+	db := testsupport.DB(t)
+	svc, fn := newTestMatchingService(t, db)
+	ctx := context.Background()
+
+	tasker := newUser(t, db)
+	taskID := newTask(t, db, tasker)
+	gone := newReferee(t, db)
+	addCancelledSibling(t, db, taskID, gone)
+	reqID := newPendingRequest(t, db, taskID) // no eligible referee seeded
+
+	if err := svc.HandleMatch(ctx, matchJob(reqID)); err != nil {
+		t.Fatalf("match: %v", err)
+	}
+	if status, _ := requestStatus(t, db, reqID); status != "pending" {
+		t.Fatalf("want request left pending, got %s", status)
+	}
+	if keys := fn.keysFor(tasker); len(keys) != 1 || keys[0] != "notification_matching_cancelled_pending_tasker" {
+		t.Fatalf("want tasker told the re-match is searching, got %v", keys)
+	}
+}
+
+func TestHandleMatchPastCutoffLeavesPending(t *testing.T) {
+	db := testsupport.DB(t)
+	svc, _ := newTestMatchingService(t, db)
+	ctx := context.Background()
+
+	// Task due inside the 14h rematch cutoff, with an otherwise-eligible referee:
+	// the accept CAS embeds the cutoff guard, so no referee is assigned.
+	tasker := newUser(t, db)
+	taskID := newTaskDueIn(t, db, tasker, "5 hours")
+	a := newReferee(t, db)
+	addAllDaySlot(t, db, a, taskID)
+	reqID := newPendingRequest(t, db, taskID)
+
+	if err := svc.HandleMatch(ctx, matchJob(reqID)); err != nil {
+		t.Fatalf("match: %v", err)
+	}
+	status, _ := requestStatus(t, db, reqID)
+	if status != "pending" {
+		t.Fatalf("want request left pending past cutoff, got %s", status)
+	}
+	if n := judgementCount(t, db, reqID); n != 0 {
+		t.Fatalf("want no judgement past cutoff, got %d", n)
+	}
+}

--- a/backend/internal/matching/store.go
+++ b/backend/internal/matching/store.go
@@ -2,6 +2,7 @@ package matching
 
 import (
 	"context"
+	"database/sql"
 	"errors"
 	"fmt"
 
@@ -119,6 +120,27 @@ WHERE wl = (SELECT MIN(wl) FROM workloads)`, requestID)
 		out = append(out, id)
 	}
 	return out, rows.Err()
+}
+
+// RequestContext loads the task facts the match handler notifies with: the task
+// id/title, the tasker (NULL when the author was deleted), and whether the task
+// already has a cancelled request (the re-match signal).
+func (s *Store) RequestContext(ctx context.Context, q database.Querier, requestID string) (RequestContext, error) {
+	var rc RequestContext
+	var tasker sql.NullString
+	err := q.QueryRowContext(ctx, `
+		SELECT rr.task_id, t.tasker_id, t.title,
+		       EXISTS (SELECT 1 FROM public.referee_requests c
+		               WHERE c.task_id = rr.task_id AND c.status = 'cancelled') AS has_cancelled
+		FROM public.referee_requests rr
+		JOIN public.tasks t ON t.id = rr.task_id
+		WHERE rr.id = $1`, requestID).
+		Scan(&rc.TaskID, &tasker, &rc.Title, &rc.HasCancelledSibling)
+	if err != nil {
+		return RequestContext{}, fmt.Errorf("load request context: %w", err)
+	}
+	rc.TaskerID = tasker.String
+	return rc, nil
 }
 
 // MarkAcceptedInTx transitions a request pending->accepted only if it is still

--- a/backend/internal/matching/store.go
+++ b/backend/internal/matching/store.go
@@ -143,6 +143,76 @@ func (s *Store) RequestContext(ctx context.Context, q database.Querier, requestI
 	return rc, nil
 }
 
+// PastCutoffPendingIDs lists pending requests whose task is within
+// rematchCutoffHours of its due date (or already past it) — matching can no
+// longer place them, so the sweep expires them. Rows carry the task facts the
+// sweep refunds and notifies with. A NULL due date is skipped (an unpublished
+// task has no requests; a defensively-NULL one can neither match nor expire).
+func (s *Store) PastCutoffPendingIDs(ctx context.Context, rematchCutoffHours int) ([]ExpiredCandidate, error) {
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT rr.id, rr.task_id, t.tasker_id, t.title
+		FROM public.referee_requests rr
+		JOIN public.tasks t ON t.id = rr.task_id
+		WHERE rr.status = 'pending'
+		  AND t.due_date IS NOT NULL
+		  AND t.due_date <= now() + make_interval(hours => $1)`, rematchCutoffHours)
+	if err != nil {
+		return nil, fmt.Errorf("past-cutoff pendings: %w", err)
+	}
+	defer rows.Close()
+	var out []ExpiredCandidate
+	for rows.Next() {
+		var e ExpiredCandidate
+		var tasker sql.NullString
+		if err := rows.Scan(&e.ID, &e.TaskID, &tasker, &e.Title); err != nil {
+			return nil, err
+		}
+		e.TaskerID = tasker.String
+		out = append(out, e)
+	}
+	return out, rows.Err()
+}
+
+// ExpireIfPendingInTx flips a request pending->expired only while it is still
+// pending, returning whether it changed. The CAS is the concurrency guard: a
+// request a concurrent match already accepted is left untouched (0 rows), so the
+// sweep never refunds/notifies a request that was in fact matched.
+func (s *Store) ExpireIfPendingInTx(ctx context.Context, q database.Querier, requestID string) (bool, error) {
+	res, err := q.ExecContext(ctx,
+		`UPDATE public.referee_requests SET status = 'expired', updated_at = now()
+		 WHERE id = $1 AND status = 'pending'`, requestID)
+	if err != nil {
+		return false, fmt.Errorf("expire request: %w", err)
+	}
+	n, _ := res.RowsAffected()
+	return n > 0, nil
+}
+
+// PendingWithinWindow lists pending requests whose task is still more than
+// rematchCutoffHours from its due date — matching can still place them, so the
+// sweep re-enqueues a match.
+func (s *Store) PendingWithinWindow(ctx context.Context, rematchCutoffHours int) ([]string, error) {
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT rr.id
+		FROM public.referee_requests rr
+		JOIN public.tasks t ON t.id = rr.task_id
+		WHERE rr.status = 'pending'
+		  AND t.due_date > now() + make_interval(hours => $1)`, rematchCutoffHours)
+	if err != nil {
+		return nil, fmt.Errorf("in-window pendings: %w", err)
+	}
+	defer rows.Close()
+	var out []string
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			return nil, err
+		}
+		out = append(out, id)
+	}
+	return out, rows.Err()
+}
+
 // MarkAcceptedInTx transitions a request pending->accepted only if it is still
 // pending AND its task is still within the matching window (due_date is more
 // than rematch_cutoff_hours away). The cutoff guard is in the UPDATE itself so a

--- a/backend/internal/matching/store.go
+++ b/backend/internal/matching/store.go
@@ -1,0 +1,152 @@
+package matching
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/jackc/pgx/v5/pgconn"
+
+	"github.com/cloveclovedev/peppercheck/backend/internal/core/database"
+)
+
+// Store issues the SQL backing referee matching: the typed config, request
+// insertion, candidate selection, and the accept CAS. IDs are strings to match
+// the codebase's internal identifier convention; the columns are uuid.
+type Store struct {
+	db *database.Handle
+}
+
+// NewStore builds a Store over an open database handle.
+func NewStore(db *database.Handle) *Store { return &Store{db: db} }
+
+// LoadConfig reads the singleton matching configuration.
+func (s *Store) LoadConfig(ctx context.Context) (Config, error) {
+	var c Config
+	err := s.db.QueryRowContext(ctx, `
+		SELECT open_deadline_hours, cancel_deadline_hours, rematch_cutoff_hours,
+		       max_referees_per_task, point_cost_per_request
+		FROM public.matching_config WHERE id = true`).
+		Scan(&c.OpenDeadlineHours, &c.CancelDeadlineHours, &c.RematchCutoffHours,
+			&c.MaxRefereesPerTask, &c.PointCostPerRequest)
+	if err != nil {
+		return Config{}, fmt.Errorf("load matching config: %w", err)
+	}
+	return c, nil
+}
+
+// InsertRequestInTx creates one pending referee_request seat on a task using the
+// caller's transaction, returning its id. Publishing a task inserts N of these
+// (N = the tasker's chosen referee count), each matched asynchronously.
+func (s *Store) InsertRequestInTx(ctx context.Context, q database.Querier, taskID string) (string, error) {
+	var id string
+	err := q.QueryRowContext(ctx,
+		`INSERT INTO public.referee_requests (task_id) VALUES ($1) RETURNING id`, taskID).Scan(&id)
+	if err != nil {
+		return "", fmt.Errorf("insert request: %w", err)
+	}
+	return id, nil
+}
+
+// CandidateReferees runs the full exclusion + least-workload query for a pending
+// request and returns the least-workload candidate set (obligation priority is
+// applied by the service using ObligationChecker). A referee qualifies when they
+// have an active time slot covering the task's due instant in their local
+// timezone, are accepting, are not the tasker, are not blocked on the due date,
+// never previously cancelled on this task, are not already active on it, and are
+// under their concurrent-assignment cap. The returned set is those qualifying
+// referees whose current workload equals the minimum across all qualifying
+// referees.
+func (s *Store) CandidateReferees(ctx context.Context, q database.Querier, requestID string) ([]string, error) {
+	rows, err := q.QueryContext(ctx, `
+WITH req AS (
+  SELECT rr.id, rr.task_id, t.tasker_id, t.due_date
+  FROM public.referee_requests rr
+  JOIN public.tasks t ON t.id = rr.task_id
+  WHERE rr.id = $1
+),
+available AS (
+  SELECT DISTINCT s.user_id AS referee_id
+  FROM public.referee_available_time_slots s
+  JOIN req ON true
+  JOIN public.profiles p ON p.id = s.user_id
+  LEFT JOIN public.referee_availability ra ON ra.user_id = s.user_id
+  WHERE s.is_active
+    AND s.user_id <> req.tasker_id
+    AND COALESCE(ra.is_accepting, true)
+    -- due instant in the referee's timezone: matching dow + minute window
+    AND EXTRACT(DOW FROM (req.due_date AT TIME ZONE COALESCE(p.timezone, 'UTC'))) = s.dow
+    AND (EXTRACT(HOUR FROM (req.due_date AT TIME ZONE COALESCE(p.timezone, 'UTC'))) * 60
+       + EXTRACT(MINUTE FROM (req.due_date AT TIME ZONE COALESCE(p.timezone, 'UTC')))) BETWEEN s.start_min AND s.end_min
+    -- not blocked on the due date
+    AND NOT EXISTS (
+      SELECT 1 FROM public.referee_blocked_dates b
+      WHERE b.user_id = s.user_id
+        AND (req.due_date AT TIME ZONE COALESCE(p.timezone, 'UTC'))::date BETWEEN b.start_date AND b.end_date)
+    -- did not previously cancel on this task
+    AND NOT EXISTS (
+      SELECT 1 FROM public.referee_requests c
+      WHERE c.task_id = req.task_id AND c.status = 'cancelled' AND c.matched_referee_id = s.user_id)
+    -- not already active on this task (multi-referee)
+    AND NOT EXISTS (
+      SELECT 1 FROM public.referee_requests a
+      WHERE a.task_id = req.task_id AND a.status IN ('pending','accepted')
+        AND a.matched_referee_id = s.user_id)
+),
+workloads AS (
+  SELECT a.referee_id,
+         COUNT(j.id) FILTER (WHERE j.status IN ('awaiting_evidence','in_review','rejected','review_timeout')) AS wl
+  FROM available a
+  LEFT JOIN public.referee_requests rr2 ON rr2.matched_referee_id = a.referee_id AND rr2.status = 'accepted'
+  LEFT JOIN public.judgements j ON j.id = rr2.id
+  LEFT JOIN public.referee_availability ra ON ra.user_id = a.referee_id
+  GROUP BY a.referee_id, ra.max_concurrent_assignments
+  HAVING ra.max_concurrent_assignments IS NULL
+      OR COUNT(j.id) FILTER (WHERE j.status IN ('awaiting_evidence','in_review','rejected','review_timeout')) < ra.max_concurrent_assignments
+)
+SELECT referee_id FROM workloads
+WHERE wl = (SELECT MIN(wl) FROM workloads)`, requestID)
+	if err != nil {
+		return nil, fmt.Errorf("candidate query: %w", err)
+	}
+	defer rows.Close()
+	var out []string
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			return nil, err
+		}
+		out = append(out, id)
+	}
+	return out, rows.Err()
+}
+
+// MarkAcceptedInTx transitions a request pending->accepted only if it is still
+// pending AND its task is still within the matching window (due_date is more
+// than rematch_cutoff_hours away). The cutoff guard is in the UPDATE itself so a
+// match job that runs late — e.g. after a worker outage crossed the cutoff —
+// cannot assign a referee to a request the sweep should expire; when it affects
+// 0 rows the caller leaves the request pending and the sweep expires + refunds
+// it. This UPDATE also sets updated_at = now(). A same-task double-assignment
+// (two requests, same referee) trips the partial unique index (P4a-D16); the
+// caller distinguishes ErrRefereeTaken.
+func (s *Store) MarkAcceptedInTx(ctx context.Context, q database.Querier, requestID, refereeID string, isObligation bool) (bool, error) {
+	res, err := q.ExecContext(ctx, `
+		UPDATE public.referee_requests r
+		SET status = 'accepted', matched_referee_id = $2, is_obligation = $3,
+		    responded_at = now(), updated_at = now()
+		FROM public.tasks t, public.matching_config c
+		WHERE r.id = $1 AND r.status = 'pending'
+		  AND t.id = r.task_id AND c.id = true
+		  AND t.due_date > now() + make_interval(hours => c.rematch_cutoff_hours)`,
+		requestID, refereeID, isObligation)
+	if err != nil {
+		var pgErr *pgconn.PgError
+		if errors.As(err, &pgErr) && pgErr.Code == "23505" { // same-task accepted unique index
+			return false, ErrRefereeTaken
+		}
+		return false, fmt.Errorf("mark accepted: %w", err)
+	}
+	n, _ := res.RowsAffected()
+	return n == 1, nil
+}

--- a/backend/internal/matching/store_test.go
+++ b/backend/internal/matching/store_test.go
@@ -139,12 +139,12 @@ func setAvailability(t *testing.T, db *sql.DB, refereeID string, accepting bool,
 	}
 }
 
-// newPendingRequest inserts a pending referee_request for a task, returning its id.
+// newPendingRequest inserts a pending referee_request for a task via the store's
+// InsertRequestInTx (exercising it), returning its id.
 func newPendingRequest(t *testing.T, db *sql.DB, taskID string) string {
 	t.Helper()
-	var id string
-	if err := db.QueryRow(
-		`INSERT INTO public.referee_requests (task_id) VALUES ($1) RETURNING id`, taskID).Scan(&id); err != nil {
+	id, err := matching.NewStore(db).InsertRequestInTx(context.Background(), db, taskID)
+	if err != nil {
 		t.Fatalf("seed request: %v", err)
 	}
 	return id

--- a/backend/internal/matching/store_test.go
+++ b/backend/internal/matching/store_test.go
@@ -1,0 +1,327 @@
+package matching_test
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"os"
+	"testing"
+
+	"github.com/cloveclovedev/peppercheck/backend/internal/core/database"
+	"github.com/cloveclovedev/peppercheck/backend/internal/matching"
+	"github.com/cloveclovedev/peppercheck/backend/internal/testsupport"
+)
+
+// The integration DB is shared across every test in the package and rows
+// persist (no per-test cleanup). Candidate selection is global by design — any
+// referee available at a task's due instant qualifies — so two tasks whose due
+// instants share a weekday+minute would cross-contaminate each other's results.
+// TestMain gives each seeded task a globally-unique due instant by advancing a
+// persistent sequence (unique across runs of the shared iteration DB too), and
+// the seed helpers cut each referee a one-minute slot around exactly that
+// instant. Distinct tasks therefore never see each other's referees.
+func TestMain(m *testing.M) {
+	if dsn := os.Getenv("DATABASE_URL"); dsn != "" {
+		db, err := database.Connect(context.Background(), dsn)
+		if err == nil {
+			_, _ = db.Exec(`CREATE SEQUENCE IF NOT EXISTS test_matching_bucket`)
+			_ = db.Close()
+		}
+	}
+	os.Exit(m.Run())
+}
+
+// --- seed helpers (shared by store/service/sweep tests) -------------------
+//
+// The integration DB is shared across tests and rows persist, so every helper
+// mints fresh users (new uuids) and derives globally-unique usernames from the
+// user id. Candidate selection is scoped by request id and workload by referee
+// id, so freshly-minted rows never collide with another test's data.
+
+// newUser inserts a bare identity anchor and returns its id.
+func newUser(t *testing.T, db *sql.DB) string {
+	t.Helper()
+	var id string
+	if err := db.QueryRow(`INSERT INTO public.users DEFAULT VALUES RETURNING id`).Scan(&id); err != nil {
+		t.Fatalf("seed user: %v", err)
+	}
+	return id
+}
+
+// newReferee inserts a user + profile (timezone UTC), returning the user id. A
+// profile is required because candidate selection joins profiles for timezone.
+func newReferee(t *testing.T, db *sql.DB) string {
+	t.Helper()
+	id := newUser(t, db)
+	if _, err := db.Exec(
+		`INSERT INTO public.profiles (id, username, timezone)
+		 VALUES ($1, left(replace($2, '-', ''), 16), 'UTC')`, id, id); err != nil {
+		t.Fatalf("seed profile: %v", err)
+	}
+	return id
+}
+
+// newTask inserts an open task authored by taskerID whose due_date is a fixed
+// far-future instant (well within the matching window) offset by a
+// globally-unique number of minutes. Anchoring to a constant base — not now() —
+// makes each task's UTC minute-of-day deterministic and unique, so its
+// referees' one-minute slots never overlap another task's due instant.
+func newTask(t *testing.T, db *sql.DB, taskerID string) string {
+	t.Helper()
+	var id string
+	if err := db.QueryRow(
+		`INSERT INTO public.tasks (tasker_id, title, status, due_date)
+		 VALUES ($1, 'seed', 'open',
+		         timestamptz '2027-06-01 00:00:00+00' + (nextval('test_matching_bucket') * interval '2 minutes'))
+		 RETURNING id`, taskerID).Scan(&id); err != nil {
+		t.Fatalf("seed task: %v", err)
+	}
+	return id
+}
+
+// newTaskDueIn inserts an open task whose due_date is `dueInterval` from now
+// (e.g. '5 hours' to sit inside the rematch cutoff). Used by accept-window tests
+// where candidate selection is not exercised, so no unique-minute slot is needed.
+func newTaskDueIn(t *testing.T, db *sql.DB, taskerID, dueInterval string) string {
+	t.Helper()
+	var id string
+	if err := db.QueryRow(
+		`INSERT INTO public.tasks (tasker_id, title, status, due_date)
+		 VALUES ($1, 'seed', 'open', now() + $2::interval) RETURNING id`, taskerID, dueInterval).Scan(&id); err != nil {
+		t.Fatalf("seed task: %v", err)
+	}
+	return id
+}
+
+// addAllDaySlot gives a referee an active slot covering exactly the one-minute
+// window around the task's due instant (in UTC). A narrow window keeps the seed
+// isolated: only referees seeded for this task match its due minute.
+func addAllDaySlot(t *testing.T, db *sql.DB, refereeID, taskID string) {
+	t.Helper()
+	if _, err := db.Exec(
+		`INSERT INTO public.referee_available_time_slots (user_id, dow, start_min, end_min)
+		 SELECT $1,
+		        EXTRACT(DOW FROM (due_date AT TIME ZONE 'UTC'))::int,
+		        (EXTRACT(HOUR FROM (due_date AT TIME ZONE 'UTC')) * 60
+		           + EXTRACT(MINUTE FROM (due_date AT TIME ZONE 'UTC')))::int,
+		        (EXTRACT(HOUR FROM (due_date AT TIME ZONE 'UTC')) * 60
+		           + EXTRACT(MINUTE FROM (due_date AT TIME ZONE 'UTC')))::int + 1
+		 FROM public.tasks WHERE id = $2`, refereeID, taskID); err != nil {
+		t.Fatalf("seed time slot: %v", err)
+	}
+}
+
+// blockOnDueDate marks the referee unavailable on the task's due date.
+func blockOnDueDate(t *testing.T, db *sql.DB, refereeID, taskID string) {
+	t.Helper()
+	if _, err := db.Exec(
+		`INSERT INTO public.referee_blocked_dates (user_id, start_date, end_date)
+		 SELECT $1, (due_date AT TIME ZONE 'UTC')::date, (due_date AT TIME ZONE 'UTC')::date
+		 FROM public.tasks WHERE id = $2`, refereeID, taskID); err != nil {
+		t.Fatalf("seed blocked date: %v", err)
+	}
+}
+
+// setAvailability upserts the referee's availability knobs. maxConcurrent < 0
+// means "no cap" (stored as NULL).
+func setAvailability(t *testing.T, db *sql.DB, refereeID string, accepting bool, maxConcurrent int) {
+	t.Helper()
+	var cap any
+	if maxConcurrent >= 0 {
+		cap = maxConcurrent
+	}
+	if _, err := db.Exec(
+		`INSERT INTO public.referee_availability (user_id, is_accepting, max_concurrent_assignments)
+		 VALUES ($1, $2, $3)
+		 ON CONFLICT (user_id) DO UPDATE SET is_accepting = $2, max_concurrent_assignments = $3`,
+		refereeID, accepting, cap); err != nil {
+		t.Fatalf("seed availability: %v", err)
+	}
+}
+
+// newPendingRequest inserts a pending referee_request for a task, returning its id.
+func newPendingRequest(t *testing.T, db *sql.DB, taskID string) string {
+	t.Helper()
+	var id string
+	if err := db.QueryRow(
+		`INSERT INTO public.referee_requests (task_id) VALUES ($1) RETURNING id`, taskID).Scan(&id); err != nil {
+		t.Fatalf("seed request: %v", err)
+	}
+	return id
+}
+
+// addActiveAssignment gives refereeID one unit of workload: a fresh task with an
+// accepted request matched to them and an awaiting_evidence judgement.
+func addActiveAssignment(t *testing.T, db *sql.DB, refereeID, taskerID string) {
+	t.Helper()
+	taskID := newTask(t, db, taskerID)
+	var reqID string
+	if err := db.QueryRow(
+		`INSERT INTO public.referee_requests (task_id, status, matched_referee_id)
+		 VALUES ($1, 'accepted', $2) RETURNING id`, taskID, refereeID).Scan(&reqID); err != nil {
+		t.Fatalf("seed accepted request: %v", err)
+	}
+	if _, err := db.Exec(
+		`INSERT INTO public.judgements (id, status) VALUES ($1, 'awaiting_evidence')`, reqID); err != nil {
+		t.Fatalf("seed judgement: %v", err)
+	}
+}
+
+// seedMatchingScenario builds the exclusion scenario: referee A fully available;
+// B blocked on the due date; C not accepting. Returns the request id and A's id.
+func seedMatchingScenario(t *testing.T, db *sql.DB) (requestID, refereeA string) {
+	t.Helper()
+	tasker := newUser(t, db)
+	taskID := newTask(t, db, tasker)
+
+	a := newReferee(t, db)
+	addAllDaySlot(t, db, a, taskID)
+
+	b := newReferee(t, db)
+	addAllDaySlot(t, db, b, taskID)
+	blockOnDueDate(t, db, b, taskID)
+
+	c := newReferee(t, db)
+	addAllDaySlot(t, db, c, taskID)
+	setAvailability(t, db, c, false, -1)
+
+	return newPendingRequest(t, db, taskID), a
+}
+
+// --- tests ----------------------------------------------------------------
+
+func TestCandidateRefereesAppliesExclusions(t *testing.T) {
+	db := testsupport.DB(t)
+	s := matching.NewStore(db)
+	reqID, wantA := seedMatchingScenario(t, db)
+
+	got, err := s.CandidateReferees(context.Background(), db, reqID)
+	if err != nil {
+		t.Fatalf("candidates: %v", err)
+	}
+	if len(got) != 1 || got[0] != wantA {
+		t.Fatalf("want [A=%s], got %v", wantA, got)
+	}
+}
+
+func TestCandidateRefereesLeastWorkloadOnly(t *testing.T) {
+	db := testsupport.DB(t)
+	s := matching.NewStore(db)
+	tasker := newUser(t, db)
+	taskID := newTask(t, db, tasker)
+
+	busy := newReferee(t, db)
+	addAllDaySlot(t, db, busy, taskID)
+	addActiveAssignment(t, db, busy, tasker) // workload 1
+
+	idle := newReferee(t, db)
+	addAllDaySlot(t, db, idle, taskID) // workload 0
+
+	reqID := newPendingRequest(t, db, taskID)
+	got, err := s.CandidateReferees(context.Background(), db, reqID)
+	if err != nil {
+		t.Fatalf("candidates: %v", err)
+	}
+	if len(got) != 1 || got[0] != idle {
+		t.Fatalf("want only least-workload [idle=%s], got %v", idle, got)
+	}
+}
+
+func TestMarkAcceptedInTx(t *testing.T) {
+	db := testsupport.DB(t)
+	s := matching.NewStore(db)
+	ctx := context.Background()
+
+	t.Run("accepts within the matching window", func(t *testing.T) {
+		tasker := newUser(t, db)
+		taskID := newTaskDueIn(t, db, tasker, "30 days")
+		referee := newReferee(t, db)
+		reqID := newPendingRequest(t, db, taskID)
+
+		var won bool
+		if err := database.WithTx(ctx, db, func(tx database.Querier) error {
+			var e error
+			won, e = s.MarkAcceptedInTx(ctx, tx, reqID, referee, false)
+			return e
+		}); err != nil {
+			t.Fatalf("mark accepted: %v", err)
+		}
+		if !won {
+			t.Fatal("want won=true within the window")
+		}
+		var status, matched string
+		if err := db.QueryRow(`SELECT status, matched_referee_id FROM public.referee_requests WHERE id=$1`, reqID).Scan(&status, &matched); err != nil {
+			t.Fatalf("scan: %v", err)
+		}
+		if status != "accepted" || matched != referee {
+			t.Fatalf("want accepted->%s, got %s/%s", referee, status, matched)
+		}
+	})
+
+	t.Run("same referee twice on one task returns ErrRefereeTaken", func(t *testing.T) {
+		tasker := newUser(t, db)
+		taskID := newTaskDueIn(t, db, tasker, "30 days")
+		referee := newReferee(t, db)
+		req1 := newPendingRequest(t, db, taskID)
+		req2 := newPendingRequest(t, db, taskID)
+
+		if err := database.WithTx(ctx, db, func(tx database.Querier) error {
+			_, e := s.MarkAcceptedInTx(ctx, tx, req1, referee, false)
+			return e
+		}); err != nil {
+			t.Fatalf("first accept: %v", err)
+		}
+		err := database.WithTx(ctx, db, func(tx database.Querier) error {
+			_, e := s.MarkAcceptedInTx(ctx, tx, req2, referee, false)
+			return e
+		})
+		if !errors.Is(err, matching.ErrRefereeTaken) {
+			t.Fatalf("want ErrRefereeTaken, got %v", err)
+		}
+	})
+
+	t.Run("past the rematch cutoff does not accept", func(t *testing.T) {
+		tasker := newUser(t, db)
+		taskID := newTaskDueIn(t, db, tasker, "5 hours") // inside the 14h rematch cutoff
+		referee := newReferee(t, db)
+		reqID := newPendingRequest(t, db, taskID)
+
+		var won bool
+		if err := database.WithTx(ctx, db, func(tx database.Querier) error {
+			var e error
+			won, e = s.MarkAcceptedInTx(ctx, tx, reqID, referee, false)
+			return e
+		}); err != nil {
+			t.Fatalf("mark accepted: %v", err)
+		}
+		if won {
+			t.Fatal("want won=false past the cutoff")
+		}
+		var status string
+		_ = db.QueryRow(`SELECT status FROM public.referee_requests WHERE id=$1`, reqID).Scan(&status)
+		if status != "pending" {
+			t.Fatalf("want request left pending, got %s", status)
+		}
+	})
+}
+
+func TestCandidateRefereesRespectsMaxConcurrent(t *testing.T) {
+	db := testsupport.DB(t)
+	s := matching.NewStore(db)
+	tasker := newUser(t, db)
+	taskID := newTask(t, db, tasker)
+
+	atCap := newReferee(t, db)
+	addAllDaySlot(t, db, atCap, taskID)
+	setAvailability(t, db, atCap, true, 1)
+	addActiveAssignment(t, db, atCap, tasker) // workload 1 == cap -> excluded
+
+	reqID := newPendingRequest(t, db, taskID)
+	got, err := s.CandidateReferees(context.Background(), db, reqID)
+	if err != nil {
+		t.Fatalf("candidates: %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("want no candidates (referee at cap), got %v", got)
+	}
+}

--- a/backend/internal/matching/sweep_test.go
+++ b/backend/internal/matching/sweep_test.go
@@ -1,0 +1,108 @@
+package matching_test
+
+import (
+	"context"
+	"database/sql"
+	"sync"
+	"testing"
+
+	"github.com/cloveclovedev/peppercheck/backend/internal/core/jobs"
+	"github.com/cloveclovedev/peppercheck/backend/internal/matching"
+	"github.com/cloveclovedev/peppercheck/backend/internal/testsupport"
+)
+
+func assertStatus(t *testing.T, db *sql.DB, reqID, want string) {
+	t.Helper()
+	status, _ := requestStatus(t, db, reqID)
+	if status != want {
+		t.Fatalf("request %s: want status %s, got %s", reqID, want, status)
+	}
+}
+
+// matchJobEnqueued reports whether a match job exists for the request.
+func matchJobEnqueued(t *testing.T, db *sql.DB, reqID string) bool {
+	t.Helper()
+	var n int
+	if err := db.QueryRow(
+		`SELECT count(*) FROM public.jobs WHERE kind=$1 AND payload->>'requestId'=$2`,
+		matching.JobKindMatch, reqID).Scan(&n); err != nil {
+		t.Fatalf("count match jobs: %v", err)
+	}
+	return n > 0
+}
+
+// sweepScheduled reports whether a future sweep job is queued (the chain lives on).
+func sweepScheduled(t *testing.T, db *sql.DB) bool {
+	t.Helper()
+	var n int
+	if err := db.QueryRow(
+		`SELECT count(*) FROM public.jobs WHERE kind=$1 AND status='pending'`,
+		matching.JobKindSweep).Scan(&n); err != nil {
+		t.Fatalf("count sweep jobs: %v", err)
+	}
+	return n > 0
+}
+
+func TestHandleSweepExpiresPastCutoffAndRetriesRest(t *testing.T) {
+	db := testsupport.DB(t)
+	svc, fn := newTestMatchingService(t, db)
+	ctx := context.Background()
+
+	// X: past the cutoff -> expired + refunded + notified.
+	taskerX := newUser(t, db)
+	taskX := newTaskDueIn(t, db, taskerX, "5 hours")
+	xID := newPendingRequest(t, db, taskX)
+
+	// Y: well inside the window with no candidate -> stays pending, match retried.
+	taskerY := newUser(t, db)
+	taskY := newTask(t, db, taskerY)
+	yID := newPendingRequest(t, db, taskY)
+
+	if err := svc.HandleSweep(ctx, &jobs.Job{Kind: matching.JobKindSweep}); err != nil {
+		t.Fatalf("sweep: %v", err)
+	}
+
+	assertStatus(t, db, xID, "expired")
+	assertStatus(t, db, yID, "pending")
+	if !matchJobEnqueued(t, db, yID) {
+		t.Fatal("want a match retry enqueued for the in-window pending")
+	}
+	if !sweepScheduled(t, db) {
+		t.Fatal("want the next sweep scheduled")
+	}
+	if keys := fn.keysFor(taskerX); len(keys) != 1 || keys[0] != "notification_matching_expired_refunded_tasker" {
+		t.Fatalf("want tasker told of the expiry+refund once, got %v", keys)
+	}
+}
+
+func TestHandleSweepExpireBeatsLateMatch(t *testing.T) {
+	db := testsupport.DB(t)
+	svc, fn := newTestMatchingService(t, db)
+	ctx := context.Background()
+
+	// A request past the cutoff with an otherwise-eligible referee. The late match
+	// cannot accept (the accept CAS embeds the cutoff guard), so the only valid
+	// terminal state is expired — with no judgement and no assignment notice.
+	tasker := newUser(t, db)
+	taskID := newTaskDueIn(t, db, tasker, "5 hours")
+	a := newReferee(t, db)
+	addAllDaySlot(t, db, a, taskID)
+	reqID := newPendingRequest(t, db, taskID)
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() { defer wg.Done(); _ = svc.HandleMatch(ctx, matchJob(reqID)) }()
+	go func() { defer wg.Done(); _ = svc.HandleSweep(ctx, &jobs.Job{Kind: matching.JobKindSweep}) }()
+	wg.Wait()
+
+	assertStatus(t, db, reqID, "expired")
+	if n := judgementCount(t, db, reqID); n != 0 {
+		t.Fatalf("want no judgement, got %d", n)
+	}
+	if keys := fn.keysFor(a); len(keys) != 0 {
+		t.Fatalf("want no assignment notice to the referee, got %v", keys)
+	}
+	if keys := fn.keysFor(tasker); len(keys) != 1 || keys[0] != "notification_matching_expired_refunded_tasker" {
+		t.Fatalf("want exactly the expiry notice to the tasker, got %v", keys)
+	}
+}

--- a/backend/internal/matching/worker.go
+++ b/backend/internal/matching/worker.go
@@ -2,6 +2,7 @@ package matching
 
 import (
 	"context"
+	"time"
 
 	"github.com/cloveclovedev/peppercheck/backend/internal/core/database"
 	"github.com/cloveclovedev/peppercheck/backend/internal/core/jobs"
@@ -9,6 +10,27 @@ import (
 
 // JobKindMatch is the worker job kind for matching a single referee request.
 const JobKindMatch = "match_referee_request"
+
+// JobKindSweep is the worker job kind for the recurring pass that expires
+// past-cutoff pending requests and re-matches the rest. It reschedules itself,
+// so a single bootstrap enqueue keeps the chain alive.
+const JobKindSweep = "sweep_pending_requests"
+
+// SweepInterval is the cadence of the self-rescheduling sweep.
+const SweepInterval = time.Minute
+
+// scheduleNextSweep enqueues the next sweep occurrence, keyed by the target
+// bucket so repeated calls within one interval (a retried run) collapse to a
+// single job. HandleSweep calls this first, before any processing, so a run that
+// fails partway cannot break the recurring chain.
+func (s *Service) scheduleNextSweep(ctx context.Context) error {
+	next := time.Now().Add(SweepInterval).Truncate(SweepInterval).UTC()
+	_, err := s.jobs.Enqueue(ctx, JobKindSweep, map[string]string{}, jobs.EnqueueOpts{
+		RunAt:          next,
+		IdempotencyKey: "sweep:" + next.Format(time.RFC3339),
+	})
+	return err
+}
 
 // EnqueueMatchInTx writes a match job into the caller's transaction (used by
 // publish, referee cancel, and the sweep's retry), so the match is queued

--- a/backend/internal/matching/worker.go
+++ b/backend/internal/matching/worker.go
@@ -1,0 +1,19 @@
+package matching
+
+import (
+	"context"
+
+	"github.com/cloveclovedev/peppercheck/backend/internal/core/database"
+	"github.com/cloveclovedev/peppercheck/backend/internal/core/jobs"
+)
+
+// JobKindMatch is the worker job kind for matching a single referee request.
+const JobKindMatch = "match_referee_request"
+
+// EnqueueMatchInTx writes a match job into the caller's transaction (used by
+// publish, referee cancel, and the sweep's retry), so the match is queued
+// atomically with the state change that warrants it.
+func (s *Service) EnqueueMatchInTx(ctx context.Context, tx database.Querier, requestID string) error {
+	_, err := s.jobs.EnqueueInTx(ctx, tx, JobKindMatch, map[string]string{"requestId": requestID}, jobs.EnqueueOpts{})
+	return err
+}

--- a/backend/internal/notification/sender.go
+++ b/backend/internal/notification/sender.go
@@ -20,6 +20,7 @@ type sendStore interface {
 	TokensForUser(ctx context.Context, userID string) ([]string, error)
 	DeleteTokens(ctx context.Context, userID string, tokens []string) error
 	EnqueueSendInTx(ctx context.Context, tx database.Querier, kind string, payload any) error
+	EnqueueSendIdempotentInTx(ctx context.Context, tx database.Querier, kind string, payload any, idempotencyKey string) error
 }
 
 // Sender enqueues and delivers push notifications. It is distinct from the
@@ -55,6 +56,18 @@ func (s *Sender) EnqueueInTx(ctx context.Context, tx database.Querier, userID, k
 		Args:    args,
 		Data:    data,
 	})
+}
+
+// EnqueueIdempotentInTx is EnqueueInTx keyed by idempotencyKey, so a caller that
+// may re-run the same enqueue (e.g. the matching sweep repeatedly re-matching a
+// still-pending request) delivers the push exactly once.
+func (s *Sender) EnqueueIdempotentInTx(ctx context.Context, tx database.Querier, userID, keyBase string, args []string, data map[string]string, idempotencyKey string) error {
+	return s.store.EnqueueSendIdempotentInTx(ctx, tx, JobKindSendNotification, sendPayload{
+		UserID:  userID,
+		KeyBase: keyBase,
+		Args:    args,
+		Data:    data,
+	}, idempotencyKey)
 }
 
 // HandleSend is the worker handler for JobKindSendNotification: load the user's

--- a/backend/internal/notification/store.go
+++ b/backend/internal/notification/store.go
@@ -100,3 +100,12 @@ func (s *Store) EnqueueSendInTx(ctx context.Context, tx database.Querier, kind s
 	_, err := s.jobs.EnqueueInTx(ctx, tx, kind, payload, jobs.EnqueueOpts{})
 	return err
 }
+
+// EnqueueSendIdempotentInTx is EnqueueSendInTx with an idempotency key, so a
+// caller that may re-run (e.g. the matching sweep re-enqueuing a match for a
+// still-pending request) enqueues the job at most once — a colliding key is a
+// no-op via the jobs table's ON CONFLICT (idempotency_key).
+func (s *Store) EnqueueSendIdempotentInTx(ctx context.Context, tx database.Querier, kind string, payload any, idempotencyKey string) error {
+	_, err := s.jobs.EnqueueInTx(ctx, tx, kind, payload, jobs.EnqueueOpts{IdempotencyKey: idempotencyKey})
+	return err
+}


### PR DESCRIPTION
Phase 4a backend, **PR2 of 3** (matching engine). Part of the Supabase → Go API/VPS refactor (parent #477); scoped by #519. Builds on PR1 (#521, T1–T6). Base branch: `refactor/go-api-vps`.

## Scope — T7–T9

- **T7 — matching store + candidate selection** (`store.go`, `domain.go`)
  - `LoadConfig`, `InsertRequestInTx`, `RequestContext`.
  - `CandidateReferees`: the full exclusion + least-workload query (timezone-aware availability window, blocked dates, prior-cancel and already-active exclusions, `max_concurrent_assignments` cap; returns the least-workload set for the service to break by obligation).
  - `MarkAcceptedInTx`: the pending→accepted CAS with the rematch-cutoff guard baked in; a same-task double-accept trips the partial unique index and surfaces as `ErrRefereeTaken`.
- **T8 — `match_referee_request` worker** (`service.go`, `worker.go`)
  - `HandleMatch`: idempotent single-request match — pick a least-workload eligible referee, accept (CAS), provision the `awaiting_evidence` judgement, notify both parties, all in one transaction. `ErrRefereeTaken` propagates to force rollback, then maps to success outside the tx. A vanished request is a no-op (#464).
  - Notifications: `notification_task_assigned_referee` (referee); `notification_request_matched_tasker` / `notification_matching_reassigned_tasker` (tasker); `notification_matching_cancelled_pending_tasker` on a cancel-originated no-candidate pending, enqueued once via a job idempotency key.
- **T9 — `sweep_pending_requests` worker** (`service.go`, `worker.go`, `store.go`)
  - `HandleSweep`: self-reschedules first (bucketed idempotency key so the chain survives a mid-run failure), expires past-cutoff pendings via CAS + refund seam + `notification_matching_expired_refunded_tasker` (each in its own tx), and re-enqueues a match for the in-window rest.

The Phase 5 point/obligation seams stay no-ops. IDs remain `string` (the #520 uuid migration is deferred). `notification.Sender` gains an idempotent-enqueue variant for the cancel-originated notice.

## Tests

TDD throughout; full `make test` green on a throwaway Postgres (`-race -p 1`). New integration tests cover candidate exclusions, least-workload tiebreak, `max_concurrent` exclusion, the accept CAS / `ErrRefereeTaken` / cutoff guard, concurrent same-request and same-task matching, reassign/cancelled-pending notifications, the missing-request no-op, sweep expiry+retry+self-reschedule, and expire-beats-late-match.

Cross-test isolation: the shared integration DB has no per-test cleanup and candidate selection is global by design, so `TestMain` gives each seeded task a globally-unique due instant (a persistent sequence) and referees a one-minute slot around it.

## Remaining in Phase 4a

- **PR3 — T10–T12**: availability + referee handlers, task store + draft handlers, publish orchestration, and composition-root wiring (real `fcm.New`, worker handler registration, sweep bootstrap, P4a-D18 operator FCM service account).

## Docs

No documentation change needed: this PR adds internal matching engine + workers with no HTTP surface (handlers land in T10) and no new setup steps, commands, or ports.

Part of #519.
