### PR TITLE
feat(backend): Phase 4a API surface — task authoring, referee handlers, publish + wiring (T10–T12)

### DIFF
--- a/backend/cmd/peppercheck/main.go
+++ b/backend/cmd/peppercheck/main.go
@@ -5,6 +5,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"os"
 	"os/signal"
@@ -17,13 +18,18 @@ import (
 	"github.com/cloveclovedev/peppercheck/backend/internal/api"
 	"github.com/cloveclovedev/peppercheck/backend/internal/core/config"
 	"github.com/cloveclovedev/peppercheck/backend/internal/core/database"
+	"github.com/cloveclovedev/peppercheck/backend/internal/core/jobs"
 	"github.com/cloveclovedev/peppercheck/backend/internal/core/logging"
 	"github.com/cloveclovedev/peppercheck/backend/internal/core/ratelimit"
 	"github.com/cloveclovedev/peppercheck/backend/internal/identity"
+	"github.com/cloveclovedev/peppercheck/backend/internal/judgement"
+	"github.com/cloveclovedev/peppercheck/backend/internal/matching"
 	"github.com/cloveclovedev/peppercheck/backend/internal/notification"
 	"github.com/cloveclovedev/peppercheck/backend/internal/platform/auth"
+	"github.com/cloveclovedev/peppercheck/backend/internal/platform/fcm"
 	"github.com/cloveclovedev/peppercheck/backend/internal/platform/r2"
 	"github.com/cloveclovedev/peppercheck/backend/internal/profile"
+	"github.com/cloveclovedev/peppercheck/backend/internal/task"
 	"github.com/cloveclovedev/peppercheck/backend/internal/web"
 	"github.com/cloveclovedev/peppercheck/backend/internal/worker"
 )
@@ -91,6 +97,20 @@ func main() {
 		profileSvc := profile.NewService(profileStore, avatarUploader, cfg.R2PublicDomain, avatarLimiter, logger)
 		notifSvc := notification.NewService(notifStore)
 
+		// Task authoring + referee matching. The api never sends FCM (that is the
+		// worker's job), so its matching service takes a no-op-FCM notifier: the
+		// referee/task HTTP paths only enqueue match jobs, never push. Points and
+		// obligations are the Phase 5 seams (no-ops in 4a).
+		matchingStore := matching.NewStore(db)
+		matchingSvc := matching.NewService(
+			db, matchingStore,
+			matching.NewNoopPointLocker(), matching.NewNoObligations(),
+			judgement.NewProvisioner(),
+			notification.NewSender(notifStore, fcm.NewNoop(logger)),
+			jobs.NewStore(db),
+		)
+		taskSvc := task.NewService(db, task.NewStore(db), matchingSvc)
+
 		// identity.Store's FindUserByEmail satisfies accountdeletion's
 		// userLookup; a separate identity.NewStore(db) here is cheap (no
 		// state beyond the *sql.DB handle already shared elsewhere).
@@ -105,6 +125,8 @@ func main() {
 			Identity:     idHandler,
 			Profile:      profile.NewHandler(profileSvc),
 			Notification: notification.NewHandler(notifSvc),
+			Task:         task.NewHandler(taskSvc),
+			Referee:      matching.NewHandler(matchingSvc, matchingStore),
 			ResolveUser:  identity.NewMiddleware(idSvc, logger),
 			Web: web.NewHandler(web.Deps{
 				Logger:    logger,
@@ -123,7 +145,27 @@ func main() {
 			os.Exit(1)
 		}
 		defer db.Close()
-		if err := worker.Run(ctx, cfg, logger, db); err != nil {
+
+		fcmClient, err := buildFCMClient(ctx, cfg, logger)
+		if err != nil {
+			logger.Error("fcm init failed", "error", err)
+			os.Exit(1)
+		}
+		sender := notification.NewSender(notification.NewStore(db), fcmClient)
+		matchingSvc := matching.NewService(
+			db, matching.NewStore(db),
+			matching.NewNoopPointLocker(), matching.NewNoObligations(),
+			judgement.NewProvisioner(), sender, jobs.NewStore(db),
+		)
+
+		if err := worker.Run(ctx, cfg, logger, db, func(ctx context.Context, w *worker.Worker) error {
+			w.Register(matching.JobKindMatch, matchingSvc.HandleMatch)
+			w.Register(matching.JobKindSweep, matchingSvc.HandleSweep)
+			w.Register(notification.JobKindSendNotification, sender.HandleSend)
+			// Seed the recurring sweep for the current interval; it self-reschedules
+			// thereafter. Idempotent across restarts and workers (bucketed key).
+			return matchingSvc.BootstrapSweep(ctx)
+		}); err != nil {
 			logger.Error("worker exited with error", "error", err)
 			os.Exit(1)
 		}
@@ -131,6 +173,29 @@ func main() {
 		fmt.Fprintf(os.Stderr, "unknown command: %s\n", os.Args[1])
 		os.Exit(2)
 	}
+}
+
+// buildFCMClient builds the worker's FCM sender. Production requires real
+// Firebase credentials (a missing/broken client is fatal); other environments
+// fall back to a no-op client that drops sends with a warning, so a local worker
+// runs end-to-end without Firebase.
+func buildFCMClient(ctx context.Context, cfg config.Config, logger *slog.Logger) (fcm.Client, error) {
+	if cfg.FirebaseProjectID == "" {
+		if cfg.Env == "production" {
+			return nil, fmt.Errorf("FIREBASE_PROJECT_ID is required in production")
+		}
+		logger.Warn("FIREBASE_PROJECT_ID unset; worker uses no-op FCM (notifications dropped)")
+		return fcm.NewNoop(logger), nil
+	}
+	client, err := fcm.New(ctx, cfg.FirebaseProjectID)
+	if err != nil {
+		if cfg.Env == "production" {
+			return nil, fmt.Errorf("fcm init (required in production): %w", err)
+		}
+		logger.Warn("FCM init failed; worker uses no-op FCM (notifications dropped)", "error", err)
+		return fcm.NewNoop(logger), nil
+	}
+	return client, nil
 }
 
 // runHealthcheck is used by the container HEALTHCHECK; it returns 0 when the

--- a/backend/cmd/peppercheck/main.go
+++ b/backend/cmd/peppercheck/main.go
@@ -162,13 +162,13 @@ func main() {
 			w.Register(matching.JobKindMatch, matchingSvc.HandleMatch)
 			w.Register(matching.JobKindSweep, matchingSvc.HandleSweep)
 			w.Register(notification.JobKindSendNotification, sender.HandleSend)
-			// Seed the recurring sweep for the current interval; it self-reschedules
-			// thereafter. Idempotent across restarts and workers (bucketed key). A
-			// failure here is non-fatal: match/notification processing must keep
-			// running, and the next restart (or a later interval) reseeds the chain.
-			if err := matchingSvc.BootstrapSweep(ctx); err != nil {
-				logger.Error("bootstrap sweep failed; recurring sweep not seeded this start", "error", err)
-			}
+			// Seed the recurring sweep in the background, retrying until it
+			// succeeds. Non-blocking so match/notification processing starts
+			// immediately; retrying (BootstrapSweep is idempotent via its bucketed
+			// key) so a transient DB error at startup can't leave the sweep chain
+			// permanently unseeded — which would strand pending requests with no
+			// retry or expiry until the process happened to restart.
+			go bootstrapSweep(ctx, matchingSvc, logger)
 			return nil
 		}); err != nil {
 			logger.Error("worker exited with error", "error", err)
@@ -177,6 +177,30 @@ func main() {
 	default:
 		fmt.Fprintf(os.Stderr, "unknown command: %s\n", os.Args[1])
 		os.Exit(2)
+	}
+}
+
+// bootstrapSweep seeds the recurring sweep, retrying with capped exponential
+// backoff until it succeeds or ctx is cancelled. BootstrapSweep is idempotent
+// (a per-interval bucketed key), so retrying after a partial or transient
+// failure never double-schedules.
+func bootstrapSweep(ctx context.Context, svc *matching.Service, logger *slog.Logger) {
+	const maxBackoff = time.Minute
+	backoff := time.Second
+	for {
+		if err := svc.BootstrapSweep(ctx); err == nil {
+			return
+		} else {
+			logger.Warn("bootstrap sweep failed; retrying", "error", err, "retryIn", backoff.String())
+		}
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(backoff):
+		}
+		if backoff *= 2; backoff > maxBackoff {
+			backoff = maxBackoff
+		}
 	}
 }
 

--- a/backend/cmd/peppercheck/main.go
+++ b/backend/cmd/peppercheck/main.go
@@ -109,7 +109,8 @@ func main() {
 			notification.NewSender(notifStore, fcm.NewNoop(logger)),
 			jobs.NewStore(db),
 		)
-		taskSvc := task.NewService(db, task.NewStore(db), matchingSvc)
+		taskStore := task.NewStore(db)
+		taskSvc := task.NewService(db, taskStore, matchingSvc)
 
 		// identity.Store's FindUserByEmail satisfies accountdeletion's
 		// userLookup; a separate identity.NewStore(db) here is cheap (no
@@ -126,7 +127,7 @@ func main() {
 			Profile:      profile.NewHandler(profileSvc),
 			Notification: notification.NewHandler(notifSvc),
 			Task:         task.NewHandler(taskSvc),
-			Referee:      matching.NewHandler(matchingSvc, matchingStore),
+			Referee:      matching.NewHandler(matchingSvc, matchingStore, taskStore),
 			ResolveUser:  identity.NewMiddleware(idSvc, logger),
 			Web: web.NewHandler(web.Deps{
 				Logger:    logger,

--- a/backend/cmd/peppercheck/main.go
+++ b/backend/cmd/peppercheck/main.go
@@ -163,8 +163,13 @@ func main() {
 			w.Register(matching.JobKindSweep, matchingSvc.HandleSweep)
 			w.Register(notification.JobKindSendNotification, sender.HandleSend)
 			// Seed the recurring sweep for the current interval; it self-reschedules
-			// thereafter. Idempotent across restarts and workers (bucketed key).
-			return matchingSvc.BootstrapSweep(ctx)
+			// thereafter. Idempotent across restarts and workers (bucketed key). A
+			// failure here is non-fatal: match/notification processing must keep
+			// running, and the next restart (or a later interval) reseeds the chain.
+			if err := matchingSvc.BootstrapSweep(ctx); err != nil {
+				logger.Error("bootstrap sweep failed; recurring sweep not seeded this start", "error", err)
+			}
+			return nil
 		}); err != nil {
 			logger.Error("worker exited with error", "error", err)
 			os.Exit(1)

--- a/backend/compose.prod.yaml
+++ b/backend/compose.prod.yaml
@@ -191,6 +191,13 @@ services:
       APP_ENV: ${PC_ENV}
       LOG_LEVEL: ${LOG_LEVEL:-info}
       DATABASE_URL_FILE: /run/secrets/database_url
+      # The worker sends FCM push (match/assignment/deadline notifications), so
+      # it -- unlike the api -- needs the Firebase project id and a service
+      # account. In production a missing/broken FCM client is fatal at startup
+      # (cmd/peppercheck buildFCMClient); other environments fall back to a
+      # no-op sender.
+      FIREBASE_PROJECT_ID: ${FIREBASE_PROJECT_ID:?FIREBASE_PROJECT_ID is required (worker FCM sender)}
+      GOOGLE_APPLICATION_CREDENTIALS: /run/secrets/firebase_service_account
       # The worker never uses this (internal/web only mounts in the api
       # command), but config.Load() is shared by both commands and fails
       # closed if it's missing -- see the api service's comment above.
@@ -198,6 +205,7 @@ services:
     secrets:
       - database_url
       - web_form_signing_key
+      - firebase_service_account
     depends_on:
       postgres:
         condition: service_healthy
@@ -278,6 +286,11 @@ secrets:
     file: ./secrets/migrator_database_url
   web_form_signing_key:
     file: ./secrets/web_form_signing_key
+  # Firebase service-account JSON for the worker's FCM sender (P4a-D18). Rendered
+  # to ./secrets/ at deploy from the deploy secret store, like every secret here.
+  # Only the worker mounts it; the api never sends FCM.
+  firebase_service_account:
+    file: ./secrets/firebase_service_account
 
 volumes:
   pgdata:

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/aws/aws-sdk-go-v2 v1.43.3
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.33
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.106.3
+	github.com/google/uuid v1.6.0
 	github.com/jackc/pgx/v5 v5.10.0
 	google.golang.org/api v0.279.0
 )
@@ -46,7 +47,6 @@ require (
 	github.com/golang-jwt/jwt/v4 v4.5.2 // indirect
 	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/google/s2a-go v0.1.9 // indirect
-	github.com/google/uuid v1.6.0 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.3.15 // indirect
 	github.com/googleapis/gax-go/v2 v2.22.0 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect

--- a/backend/internal/api/api.go
+++ b/backend/internal/api/api.go
@@ -78,6 +78,8 @@ func buildHandler(deps Deps) http.Handler {
 			mux.Handle("DELETE /api/v1/tasks/{id}", chain(deps.Task.DeleteTask))
 			mux.Handle("POST /api/v1/tasks/{id}/publish", chain(deps.Task.PostPublish))
 			mux.Handle("GET /api/v1/me/tasks", chain(deps.Task.GetMyTasks))
+			// Assignments return Task envelopes, so the task handler owns them.
+			mux.Handle("GET /api/v1/me/assignments", chain(deps.Task.GetAssignments))
 		}
 		if deps.Referee != nil {
 			mux.Handle("GET /api/v1/me/availability/time-slots", chain(deps.Referee.GetTimeSlots))
@@ -88,9 +90,14 @@ func buildHandler(deps Deps) http.Handler {
 			mux.Handle("POST /api/v1/me/availability/blocked-dates", chain(deps.Referee.PostBlockedDate))
 			mux.Handle("PUT /api/v1/me/availability/blocked-dates/{id}", chain(deps.Referee.PutBlockedDate))
 			mux.Handle("DELETE /api/v1/me/availability/blocked-dates/{id}", chain(deps.Referee.DeleteBlockedDate))
-			mux.Handle("GET /api/v1/me/assignments", chain(deps.Referee.GetAssignments))
 			mux.Handle("POST /api/v1/referee-requests/{id}/cancel", chain(deps.Referee.PostCancel))
 		}
+	}
+
+	// Public (no auth): the matching configuration the client needs before
+	// authenticating a publish/withdraw flow.
+	if deps.Referee != nil {
+		mux.Handle("GET /api/v1/matching/config", http.HandlerFunc(deps.Referee.GetConfig))
 	}
 
 	// Methodless /api/ fallback: without this, a request that hits a

--- a/backend/internal/api/api.go
+++ b/backend/internal/api/api.go
@@ -11,9 +11,11 @@ import (
 	"github.com/cloveclovedev/peppercheck/backend/internal/core/config"
 	"github.com/cloveclovedev/peppercheck/backend/internal/core/httpserver"
 	"github.com/cloveclovedev/peppercheck/backend/internal/identity"
+	"github.com/cloveclovedev/peppercheck/backend/internal/matching"
 	"github.com/cloveclovedev/peppercheck/backend/internal/notification"
 	"github.com/cloveclovedev/peppercheck/backend/internal/platform/auth"
 	"github.com/cloveclovedev/peppercheck/backend/internal/profile"
+	"github.com/cloveclovedev/peppercheck/backend/internal/task"
 )
 
 // Deps are the runtime dependencies the api handler wires into routes.
@@ -23,6 +25,8 @@ type Deps struct {
 	Identity     *identity.Handler
 	Profile      *profile.Handler
 	Notification *notification.Handler
+	Task         *task.Handler                   // task authoring (draft CRUD + publish)
+	Referee      *matching.Handler               // referee availability, assignments, cancel
 	ResolveUser  func(http.Handler) http.Handler // identity.NewMiddleware: verified Identity -> internal User in ctx
 	Logger       *slog.Logger                    // used by the auth middleware; Run injects the run logger when nil
 	Web          http.Handler                    // server-rendered public web (internal/web); mounted as the catch-all
@@ -66,6 +70,26 @@ func buildHandler(deps Deps) http.Handler {
 		if deps.Notification != nil {
 			mux.Handle("PUT /api/v1/me/device-push-tokens", chain(deps.Notification.PutToken))
 			mux.Handle("DELETE /api/v1/me/device-push-tokens", chain(deps.Notification.DeleteToken))
+		}
+		if deps.Task != nil {
+			mux.Handle("POST /api/v1/tasks", chain(deps.Task.PostTask))
+			mux.Handle("GET /api/v1/tasks/{id}", chain(deps.Task.GetTask))
+			mux.Handle("PATCH /api/v1/tasks/{id}", chain(deps.Task.PatchTask))
+			mux.Handle("DELETE /api/v1/tasks/{id}", chain(deps.Task.DeleteTask))
+			mux.Handle("POST /api/v1/tasks/{id}/publish", chain(deps.Task.PostPublish))
+			mux.Handle("GET /api/v1/me/tasks", chain(deps.Task.GetMyTasks))
+		}
+		if deps.Referee != nil {
+			mux.Handle("GET /api/v1/me/availability/time-slots", chain(deps.Referee.GetTimeSlots))
+			mux.Handle("POST /api/v1/me/availability/time-slots", chain(deps.Referee.PostTimeSlot))
+			mux.Handle("PUT /api/v1/me/availability/time-slots/{id}", chain(deps.Referee.PutTimeSlot))
+			mux.Handle("DELETE /api/v1/me/availability/time-slots/{id}", chain(deps.Referee.DeleteTimeSlot))
+			mux.Handle("GET /api/v1/me/availability/blocked-dates", chain(deps.Referee.GetBlockedDates))
+			mux.Handle("POST /api/v1/me/availability/blocked-dates", chain(deps.Referee.PostBlockedDate))
+			mux.Handle("PUT /api/v1/me/availability/blocked-dates/{id}", chain(deps.Referee.PutBlockedDate))
+			mux.Handle("DELETE /api/v1/me/availability/blocked-dates/{id}", chain(deps.Referee.DeleteBlockedDate))
+			mux.Handle("GET /api/v1/me/assignments", chain(deps.Referee.GetAssignments))
+			mux.Handle("POST /api/v1/referee-requests/{id}/cancel", chain(deps.Referee.PostCancel))
 		}
 	}
 

--- a/backend/internal/api/task_matching_test.go
+++ b/backend/internal/api/task_matching_test.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"io"
 	"log/slog"
@@ -207,6 +208,17 @@ func TestMyTasksEnvelopeAndConfig(t *testing.T) {
 	_ = json.Unmarshal(rec.Body.Bytes(), &cfg)
 	if cfg.MaxRefereesPerTask != 2 || cfg.CancelDeadlineHours != 12 {
 		t.Fatalf("unexpected config %+v", cfg)
+	}
+}
+
+func TestMalformedCursorIs400(t *testing.T) {
+	h, _ := taskStack(t, fakeVerifier("sub-A"))
+	// A well-formed-timestamp cursor with a non-uuid id must be rejected as 400,
+	// not reach the uuid keyset comparison and surface as a 500.
+	bad := base64.RawURLEncoding.EncodeToString([]byte("2026-08-06T00:00:00Z|not-a-uuid"))
+	rec := do(t, h, "GET", "/api/v1/me/tasks?cursor="+bad, "sub-A", nil)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("malformed cursor: status %d, want 400; body=%s", rec.Code, rec.Body.String())
 	}
 }
 

--- a/backend/internal/api/task_matching_test.go
+++ b/backend/internal/api/task_matching_test.go
@@ -41,12 +41,13 @@ func taskStack(t *testing.T, v auth.TokenVerifier) (http.Handler, *database.Hand
 		notification.NewSender(notifStore, fcm.NewNoop(discard)),
 		jobs.NewStore(db),
 	)
-	taskSvc := task.NewService(db, task.NewStore(db), matchingSvc)
+	taskStore := task.NewStore(db)
+	taskSvc := task.NewService(db, taskStore, matchingSvc)
 	h := rootHandler(Deps{
 		Verifier:    v,
 		Identity:    identity.NewHandler(idSvc, nil),
 		Task:        task.NewHandler(taskSvc),
-		Referee:     matching.NewHandler(matchingSvc, matchingStore),
+		Referee:     matching.NewHandler(matchingSvc, matchingStore, taskStore),
 		ResolveUser: identity.NewMiddleware(idSvc, nil),
 	}, discard)
 	return h, db
@@ -63,8 +64,9 @@ func TestTaskCreatePublishFlow(t *testing.T) {
 		t.Fatalf("create: status %d; body=%s", rec.Code, rec.Body.String())
 	}
 	var created struct {
-		ID     string `json:"id"`
-		Status string `json:"status"`
+		ID              string           `json:"id"`
+		Status          string           `json:"status"`
+		RefereeRequests []map[string]any `json:"refereeRequests"`
 	}
 	if err := json.Unmarshal(rec.Body.Bytes(), &created); err != nil {
 		t.Fatalf("unmarshal created: %v", err)
@@ -72,17 +74,39 @@ func TestTaskCreatePublishFlow(t *testing.T) {
 	if created.Status != "draft" {
 		t.Fatalf("want draft, got %s", created.Status)
 	}
+	if created.RefereeRequests == nil || len(created.RefereeRequests) != 0 {
+		t.Fatalf("draft must carry refereeRequests: [] (not null), got %v", created.RefereeRequests)
+	}
 
 	rec = do(t, h, "POST", "/api/v1/tasks/"+created.ID+"/publish", "sub-A", map[string]int{"refereeCount": 2})
 	if rec.Code != http.StatusOK {
 		t.Fatalf("publish: status %d; body=%s", rec.Code, rec.Body.String())
 	}
 	var published struct {
-		Status string `json:"status"`
+		Status   string `json:"status"`
+		TaskerID string `json:"taskerId"`
+		Tasker   *struct {
+			UserID   string `json:"userId"`
+			Username string `json:"username"`
+		} `json:"tasker"`
+		RefereeRequests []struct {
+			Status string `json:"status"`
+		} `json:"refereeRequests"`
 	}
 	_ = json.Unmarshal(rec.Body.Bytes(), &published)
 	if published.Status != "open" {
 		t.Fatalf("want open, got %s", published.Status)
+	}
+	if published.TaskerID == "" || published.Tasker == nil || published.Tasker.UserID != published.TaskerID {
+		t.Fatalf("publish response must embed taskerId + tasker profile, got %+v", published)
+	}
+	if len(published.RefereeRequests) != 2 {
+		t.Fatalf("publish response must carry 2 refereeRequests, got %d", len(published.RefereeRequests))
+	}
+	for _, rr := range published.RefereeRequests {
+		if rr.Status != "pending" {
+			t.Fatalf("want pending requests, got %s", rr.Status)
+		}
 	}
 
 	var requests, pending int
@@ -145,10 +169,44 @@ func TestRefereeTimeSlotCreateValidatesAndLists(t *testing.T) {
 		t.Fatalf("valid slot: status %d, want 201; body=%s", rec.Code, rec.Body.String())
 	}
 	rec = do(t, h, "GET", "/api/v1/me/availability/time-slots", "sub-A", nil)
-	var slots []map[string]any
-	_ = json.Unmarshal(rec.Body.Bytes(), &slots)
-	if len(slots) != 1 {
-		t.Fatalf("want 1 slot listed, got %d; body=%s", len(slots), rec.Body.String())
+	var slotsEnv struct {
+		TimeSlots []map[string]any `json:"timeSlots"`
+	}
+	_ = json.Unmarshal(rec.Body.Bytes(), &slotsEnv)
+	if len(slotsEnv.TimeSlots) != 1 {
+		t.Fatalf("want 1 slot under timeSlots, got %d; body=%s", len(slotsEnv.TimeSlots), rec.Body.String())
+	}
+}
+
+func TestMyTasksEnvelopeAndConfig(t *testing.T) {
+	h, _ := taskStack(t, fakeVerifier("sub-A"))
+	// Create a draft so the list is non-empty.
+	do(t, h, "POST", "/api/v1/tasks", "sub-A", map[string]any{"title": "t"})
+
+	rec := do(t, h, "GET", "/api/v1/me/tasks", "sub-A", nil)
+	var page struct {
+		Tasks      []map[string]any `json:"tasks"`
+		NextCursor *string          `json:"nextCursor"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &page); err != nil {
+		t.Fatalf("decode tasks envelope: %v; body=%s", err, rec.Body.String())
+	}
+	if len(page.Tasks) != 1 {
+		t.Fatalf("want 1 task in the envelope, got %d", len(page.Tasks))
+	}
+
+	// GET /matching/config is public and exposes the seeded limits.
+	rec = do(t, h, "GET", "/api/v1/matching/config", "sub-A", nil)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("config: status %d; body=%s", rec.Code, rec.Body.String())
+	}
+	var cfg struct {
+		MaxRefereesPerTask  int `json:"maxRefereesPerTask"`
+		CancelDeadlineHours int `json:"cancelDeadlineHours"`
+	}
+	_ = json.Unmarshal(rec.Body.Bytes(), &cfg)
+	if cfg.MaxRefereesPerTask != 2 || cfg.CancelDeadlineHours != 12 {
+		t.Fatalf("unexpected config %+v", cfg)
 	}
 }
 

--- a/backend/internal/api/task_matching_test.go
+++ b/backend/internal/api/task_matching_test.go
@@ -1,0 +1,175 @@
+package api
+
+import (
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/cloveclovedev/peppercheck/backend/internal/core/database"
+	"github.com/cloveclovedev/peppercheck/backend/internal/core/jobs"
+	"github.com/cloveclovedev/peppercheck/backend/internal/identity"
+	"github.com/cloveclovedev/peppercheck/backend/internal/judgement"
+	"github.com/cloveclovedev/peppercheck/backend/internal/matching"
+	"github.com/cloveclovedev/peppercheck/backend/internal/notification"
+	"github.com/cloveclovedev/peppercheck/backend/internal/platform/auth"
+	"github.com/cloveclovedev/peppercheck/backend/internal/platform/fcm"
+	"github.com/cloveclovedev/peppercheck/backend/internal/profile"
+	"github.com/cloveclovedev/peppercheck/backend/internal/task"
+	"github.com/cloveclovedev/peppercheck/backend/internal/testsupport"
+)
+
+// taskStack builds the full authed stack with the task + referee handlers over a
+// truncated DB. Both are wired exactly as main.go wires the api process (no-op
+// FCM notifier, no-op Phase 5 seams).
+func taskStack(t *testing.T, v auth.TokenVerifier) (http.Handler, *database.Handle) {
+	t.Helper()
+	db := testsupport.DB(t)
+	if _, err := db.Exec("TRUNCATE public.users CASCADE"); err != nil {
+		t.Fatalf("truncate: %v", err)
+	}
+	discard := slog.New(slog.NewTextHandler(io.Discard, nil))
+	notifStore := notification.NewStore(db)
+	idSvc := identity.NewService(identity.NewStore(db), NewProvisioner(profile.NewStore(db), notifStore))
+	matchingStore := matching.NewStore(db)
+	matchingSvc := matching.NewService(
+		db, matchingStore,
+		matching.NewNoopPointLocker(), matching.NewNoObligations(),
+		judgement.NewProvisioner(),
+		notification.NewSender(notifStore, fcm.NewNoop(discard)),
+		jobs.NewStore(db),
+	)
+	taskSvc := task.NewService(db, task.NewStore(db), matchingSvc)
+	h := rootHandler(Deps{
+		Verifier:    v,
+		Identity:    identity.NewHandler(idSvc, nil),
+		Task:        task.NewHandler(taskSvc),
+		Referee:     matching.NewHandler(matchingSvc, matchingStore),
+		ResolveUser: identity.NewMiddleware(idSvc, nil),
+	}, discard)
+	return h, db
+}
+
+func TestTaskCreatePublishFlow(t *testing.T) {
+	h, db := taskStack(t, fakeVerifier("sub-A"))
+	due := time.Now().Add(48 * time.Hour).UTC().Format(time.RFC3339)
+
+	rec := do(t, h, "POST", "/api/v1/tasks", "sub-A", map[string]any{
+		"title": "Wash the car", "criteria": "photo of a clean car", "dueDate": due,
+	})
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("create: status %d; body=%s", rec.Code, rec.Body.String())
+	}
+	var created struct {
+		ID     string `json:"id"`
+		Status string `json:"status"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &created); err != nil {
+		t.Fatalf("unmarshal created: %v", err)
+	}
+	if created.Status != "draft" {
+		t.Fatalf("want draft, got %s", created.Status)
+	}
+
+	rec = do(t, h, "POST", "/api/v1/tasks/"+created.ID+"/publish", "sub-A", map[string]int{"refereeCount": 2})
+	if rec.Code != http.StatusOK {
+		t.Fatalf("publish: status %d; body=%s", rec.Code, rec.Body.String())
+	}
+	var published struct {
+		Status string `json:"status"`
+	}
+	_ = json.Unmarshal(rec.Body.Bytes(), &published)
+	if published.Status != "open" {
+		t.Fatalf("want open, got %s", published.Status)
+	}
+
+	var requests, pending int
+	_ = db.QueryRow(`SELECT count(*), count(*) FILTER (WHERE status='pending') FROM public.referee_requests WHERE task_id=$1`, created.ID).Scan(&requests, &pending)
+	if requests != 2 || pending != 2 {
+		t.Fatalf("want 2 pending requests, got total=%d pending=%d", requests, pending)
+	}
+	var jobsCount int
+	_ = db.QueryRow(`SELECT count(*) FROM public.jobs WHERE kind='match_referee_request'
+		AND payload->>'requestId' IN (SELECT id::text FROM public.referee_requests WHERE task_id=$1)`, created.ID).Scan(&jobsCount)
+	if jobsCount != 2 {
+		t.Fatalf("want 2 match jobs, got %d", jobsCount)
+	}
+}
+
+func TestTaskCrossOwnerEditIsNotFound(t *testing.T) {
+	// A creates a draft; B may not edit it (scoped away -> 404, not 403, so B
+	// cannot even probe its existence).
+	hA, _ := taskStack(t, fakeVerifier("sub-A"))
+	rec := do(t, hA, "POST", "/api/v1/tasks", "sub-A", map[string]any{"title": "A's task"})
+	var created struct {
+		ID string `json:"id"`
+	}
+	_ = json.Unmarshal(rec.Body.Bytes(), &created)
+
+	hB, _ := taskStack(t, fakeVerifier("sub-B"))
+	rec = do(t, hB, "PATCH", "/api/v1/tasks/"+created.ID, "sub-B", map[string]any{"title": "hijack"})
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("cross-owner edit: status %d, want 404; body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestPublishMissingCriteriaIs400(t *testing.T) {
+	h, _ := taskStack(t, fakeVerifier("sub-A"))
+	due := time.Now().Add(48 * time.Hour).UTC().Format(time.RFC3339)
+	rec := do(t, h, "POST", "/api/v1/tasks", "sub-A", map[string]any{"title": "no criteria", "dueDate": due})
+	var created struct {
+		ID string `json:"id"`
+	}
+	_ = json.Unmarshal(rec.Body.Bytes(), &created)
+
+	rec = do(t, h, "POST", "/api/v1/tasks/"+created.ID+"/publish", "sub-A", map[string]int{"refereeCount": 1})
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("publish without criteria: status %d, want 400; body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestRefereeTimeSlotCreateValidatesAndLists(t *testing.T) {
+	h, _ := taskStack(t, fakeVerifier("sub-A"))
+
+	// Invalid: endMin before startMin -> 400.
+	rec := do(t, h, "POST", "/api/v1/me/availability/time-slots", "sub-A", map[string]any{"dow": 1, "startMin": 600, "endMin": 500})
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("invalid slot: status %d, want 400; body=%s", rec.Code, rec.Body.String())
+	}
+
+	// Valid -> 201, then it appears in the list.
+	rec = do(t, h, "POST", "/api/v1/me/availability/time-slots", "sub-A", map[string]any{"dow": 1, "startMin": 540, "endMin": 1020})
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("valid slot: status %d, want 201; body=%s", rec.Code, rec.Body.String())
+	}
+	rec = do(t, h, "GET", "/api/v1/me/availability/time-slots", "sub-A", nil)
+	var slots []map[string]any
+	_ = json.Unmarshal(rec.Body.Bytes(), &slots)
+	if len(slots) != 1 {
+		t.Fatalf("want 1 slot listed, got %d; body=%s", len(slots), rec.Body.String())
+	}
+}
+
+func TestCancelForbiddenAndNotFound(t *testing.T) {
+	h, db := taskStack(t, fakeVerifier("sub-A"))
+	_ = meID(t, h, "sub-A") // provision A
+
+	// Missing request -> 404.
+	rec := do(t, h, "POST", "/api/v1/referee-requests/00000000-0000-0000-0000-000000000000/cancel", "sub-A", nil)
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("cancel missing: status %d, want 404; body=%s", rec.Code, rec.Body.String())
+	}
+
+	// A request accepted by someone else -> A cancelling it is 403.
+	var otherUser, taskID, reqID string
+	_ = db.QueryRow(`INSERT INTO public.users DEFAULT VALUES RETURNING id`).Scan(&otherUser)
+	_ = db.QueryRow(`INSERT INTO public.tasks (tasker_id, title, status, due_date) VALUES ($1,'t','open', now()+interval '30 days') RETURNING id`, otherUser).Scan(&taskID)
+	_ = db.QueryRow(`INSERT INTO public.referee_requests (task_id, status, matched_referee_id) VALUES ($1,'accepted',$2) RETURNING id`, taskID, otherUser).Scan(&reqID)
+
+	rec = do(t, h, "POST", "/api/v1/referee-requests/"+reqID+"/cancel", "sub-A", nil)
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("cancel other's request: status %d, want 403; body=%s", rec.Code, rec.Body.String())
+	}
+}

--- a/backend/internal/api/task_matching_test.go
+++ b/backend/internal/api/task_matching_test.go
@@ -152,6 +152,34 @@ func TestRefereeTimeSlotCreateValidatesAndLists(t *testing.T) {
 	}
 }
 
+func TestMalformedIDPathParamsAre400(t *testing.T) {
+	h, _ := taskStack(t, fakeVerifier("sub-A"))
+	// Malformed (non-uuid) ids must be rejected at the boundary as 400, not reach
+	// the uuid-typed query and surface as a 500.
+	cases := []struct{ method, path string }{
+		{"GET", "/api/v1/tasks/not-a-uuid"},
+		{"PATCH", "/api/v1/tasks/not-a-uuid"},
+		{"DELETE", "/api/v1/tasks/not-a-uuid"},
+		{"POST", "/api/v1/tasks/not-a-uuid/publish"},
+		{"POST", "/api/v1/referee-requests/not-a-uuid/cancel"},
+		{"PUT", "/api/v1/me/availability/time-slots/not-a-uuid"},
+		{"DELETE", "/api/v1/me/availability/blocked-dates/not-a-uuid"},
+	}
+	for _, c := range cases {
+		var body any
+		if c.method == "PATCH" || (c.method == "POST" && c.path != "/api/v1/referee-requests/not-a-uuid/cancel") {
+			body = map[string]any{"title": "x", "refereeCount": 1}
+		}
+		if c.method == "PUT" {
+			body = map[string]any{"dow": 1, "startMin": 0, "endMin": 1}
+		}
+		rec := do(t, h, c.method, c.path, "sub-A", body)
+		if rec.Code != http.StatusBadRequest {
+			t.Fatalf("%s %s: status %d, want 400; body=%s", c.method, c.path, rec.Code, rec.Body.String())
+		}
+	}
+}
+
 func TestCancelForbiddenAndNotFound(t *testing.T) {
 	h, db := taskStack(t, fakeVerifier("sub-A"))
 	_ = meID(t, h, "sub-A") // provision A

--- a/backend/internal/matching/availability_test.go
+++ b/backend/internal/matching/availability_test.go
@@ -103,26 +103,3 @@ func TestBlockedDateCRUD(t *testing.T) {
 		t.Fatalf("delete: %v", err)
 	}
 }
-
-func TestActiveAssignments(t *testing.T) {
-	db := testsupport.DB(t)
-	s := matching.NewStore(db)
-	ctx := context.Background()
-
-	reqID, _, referee := seedAccepted(t, db, "10 days", "regular")
-	got, err := s.ActiveAssignments(ctx, referee)
-	if err != nil {
-		t.Fatalf("assignments: %v", err)
-	}
-	if len(got) != 1 || got[0].RequestID != reqID || got[0].JudgementStatus != "awaiting_evidence" {
-		t.Fatalf("want [reqID awaiting_evidence], got %+v", got)
-	}
-
-	// A completed (approved) judgement is no longer an active assignment.
-	if _, err := db.Exec(`UPDATE public.judgements SET status='approved' WHERE id=$1`, reqID); err != nil {
-		t.Fatalf("complete judgement: %v", err)
-	}
-	if got, _ := s.ActiveAssignments(ctx, referee); len(got) != 0 {
-		t.Fatalf("want no active assignments after completion, got %+v", got)
-	}
-}

--- a/backend/internal/matching/availability_test.go
+++ b/backend/internal/matching/availability_test.go
@@ -1,0 +1,128 @@
+package matching_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/cloveclovedev/peppercheck/backend/internal/matching"
+	"github.com/cloveclovedev/peppercheck/backend/internal/testsupport"
+)
+
+func mustDate(t *testing.T, s string) time.Time {
+	t.Helper()
+	d, err := time.Parse("2006-01-02", s)
+	if err != nil {
+		t.Fatalf("parse date %q: %v", s, err)
+	}
+	return d
+}
+
+func TestTimeSlotCRUD(t *testing.T) {
+	db := testsupport.DB(t)
+	s := matching.NewStore(db)
+	ctx := context.Background()
+	user := newUser(t, db)
+
+	created, err := s.CreateTimeSlot(ctx, user, matching.TimeSlot{DOW: 1, StartMin: 540, EndMin: 1020, IsActive: true})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if created.ID == "" {
+		t.Fatal("want created id")
+	}
+
+	slots, err := s.ListTimeSlots(ctx, user)
+	if err != nil || len(slots) != 1 {
+		t.Fatalf("list: %v len=%d", err, len(slots))
+	}
+
+	if err := s.UpdateTimeSlot(ctx, user, created.ID, matching.TimeSlot{DOW: 2, StartMin: 600, EndMin: 700, IsActive: false}); err != nil {
+		t.Fatalf("update: %v", err)
+	}
+
+	// A different user cannot update or delete this slot.
+	other := newUser(t, db)
+	if err := s.UpdateTimeSlot(ctx, other, created.ID, matching.TimeSlot{DOW: 0, StartMin: 0, EndMin: 1}); !errors.Is(err, matching.ErrNotFound) {
+		t.Fatalf("cross-user update: want ErrNotFound, got %v", err)
+	}
+	if err := s.DeleteTimeSlot(ctx, other, created.ID); !errors.Is(err, matching.ErrNotFound) {
+		t.Fatalf("cross-user delete: want ErrNotFound, got %v", err)
+	}
+
+	if err := s.DeleteTimeSlot(ctx, user, created.ID); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	if err := s.DeleteTimeSlot(ctx, user, created.ID); !errors.Is(err, matching.ErrNotFound) {
+		t.Fatalf("delete again: want ErrNotFound, got %v", err)
+	}
+}
+
+func TestTimeSlotDuplicateIsConflict(t *testing.T) {
+	db := testsupport.DB(t)
+	s := matching.NewStore(db)
+	ctx := context.Background()
+	user := newUser(t, db)
+	slot := matching.TimeSlot{DOW: 3, StartMin: 480, EndMin: 600, IsActive: true}
+	if _, err := s.CreateTimeSlot(ctx, user, slot); err != nil {
+		t.Fatalf("first create: %v", err)
+	}
+	if _, err := s.CreateTimeSlot(ctx, user, slot); !errors.Is(err, matching.ErrConflict) {
+		t.Fatalf("duplicate (user,dow,start): want ErrConflict, got %v", err)
+	}
+}
+
+func TestBlockedDateCRUD(t *testing.T) {
+	db := testsupport.DB(t)
+	s := matching.NewStore(db)
+	ctx := context.Background()
+	user := newUser(t, db)
+
+	start := mustDate(t, "2027-01-10")
+	end := mustDate(t, "2027-01-12")
+	created, err := s.CreateBlockedDate(ctx, user, matching.BlockedDate{StartDate: start, EndDate: end})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	dates, err := s.ListBlockedDates(ctx, user)
+	if err != nil || len(dates) != 1 {
+		t.Fatalf("list: %v len=%d", err, len(dates))
+	}
+
+	reason := "holiday"
+	if err := s.UpdateBlockedDate(ctx, user, created.ID, matching.BlockedDate{StartDate: start, EndDate: end, Reason: &reason}); err != nil {
+		t.Fatalf("update: %v", err)
+	}
+	other := newUser(t, db)
+	if err := s.DeleteBlockedDate(ctx, other, created.ID); !errors.Is(err, matching.ErrNotFound) {
+		t.Fatalf("cross-user delete: want ErrNotFound, got %v", err)
+	}
+	if err := s.DeleteBlockedDate(ctx, user, created.ID); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+}
+
+func TestActiveAssignments(t *testing.T) {
+	db := testsupport.DB(t)
+	s := matching.NewStore(db)
+	ctx := context.Background()
+
+	reqID, _, referee := seedAccepted(t, db, "10 days", "regular")
+	got, err := s.ActiveAssignments(ctx, referee)
+	if err != nil {
+		t.Fatalf("assignments: %v", err)
+	}
+	if len(got) != 1 || got[0].RequestID != reqID || got[0].JudgementStatus != "awaiting_evidence" {
+		t.Fatalf("want [reqID awaiting_evidence], got %+v", got)
+	}
+
+	// A completed (approved) judgement is no longer an active assignment.
+	if _, err := db.Exec(`UPDATE public.judgements SET status='approved' WHERE id=$1`, reqID); err != nil {
+		t.Fatalf("complete judgement: %v", err)
+	}
+	if got, _ := s.ActiveAssignments(ctx, referee); len(got) != 0 {
+		t.Fatalf("want no active assignments after completion, got %+v", got)
+	}
+}

--- a/backend/internal/matching/cancel_test.go
+++ b/backend/internal/matching/cancel_test.go
@@ -1,0 +1,97 @@
+package matching_test
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"testing"
+
+	"github.com/cloveclovedev/peppercheck/backend/internal/matching"
+	"github.com/cloveclovedev/peppercheck/backend/internal/testsupport"
+)
+
+// seedAccepted inserts a task (due dueInterval from now) with an accepted request
+// matched to a fresh referee, an awaiting_evidence judgement, and the given
+// point source. Returns the request id, task id, and referee id.
+func seedAccepted(t *testing.T, db *sql.DB, dueInterval, pointSource string) (requestID, taskID, refereeID string) {
+	t.Helper()
+	tasker := newUser(t, db)
+	taskID = newTaskDueIn(t, db, tasker, dueInterval)
+	refereeID = newReferee(t, db)
+	if err := db.QueryRow(
+		`INSERT INTO public.referee_requests (task_id, status, matched_referee_id, point_source, responded_at)
+		 VALUES ($1, 'accepted', $2, $3::public.point_source_type, now()) RETURNING id`,
+		taskID, refereeID, pointSource).Scan(&requestID); err != nil {
+		t.Fatalf("seed accepted request: %v", err)
+	}
+	if _, err := db.Exec(`INSERT INTO public.judgements (id, status) VALUES ($1, 'awaiting_evidence')`, requestID); err != nil {
+		t.Fatalf("seed judgement: %v", err)
+	}
+	return requestID, taskID, refereeID
+}
+
+func replacementPending(t *testing.T, db *sql.DB, taskID, cancelledID string) (id, pointSource string) {
+	t.Helper()
+	if err := db.QueryRow(
+		`SELECT id, point_source FROM public.referee_requests
+		 WHERE task_id=$1 AND status='pending' AND id<>$2`, taskID, cancelledID).
+		Scan(&id, &pointSource); err != nil {
+		t.Fatalf("load replacement pending: %v", err)
+	}
+	return id, pointSource
+}
+
+func TestCancelByRefereeReMatches(t *testing.T) {
+	db := testsupport.DB(t)
+	svc, _ := newTestMatchingService(t, db)
+	reqID, taskID, ref := seedAccepted(t, db, "30 days", "regular")
+
+	if err := svc.Cancel(context.Background(), reqID, ref); err != nil {
+		t.Fatalf("cancel: %v", err)
+	}
+	assertStatus(t, db, reqID, "cancelled")
+	if n := judgementCount(t, db, reqID); n != 0 {
+		t.Fatalf("want judgement deleted, got %d", n)
+	}
+	newID, _ := replacementPending(t, db, taskID, reqID)
+	if !matchJobEnqueued(t, db, newID) {
+		t.Fatal("want a match job enqueued for the replacement request")
+	}
+}
+
+func TestCancelRejectsNonAssignedReferee(t *testing.T) {
+	db := testsupport.DB(t)
+	svc, _ := newTestMatchingService(t, db)
+	reqID, _, _ := seedAccepted(t, db, "30 days", "regular")
+	other := newUser(t, db)
+
+	if err := svc.Cancel(context.Background(), reqID, other); !errors.Is(err, matching.ErrForbidden) {
+		t.Fatalf("want ErrForbidden, got %v", err)
+	}
+	assertStatus(t, db, reqID, "accepted") // unchanged
+}
+
+func TestCancelPreservesPointSource(t *testing.T) {
+	db := testsupport.DB(t)
+	svc, _ := newTestMatchingService(t, db)
+	reqID, taskID, ref := seedAccepted(t, db, "30 days", "trial")
+
+	if err := svc.Cancel(context.Background(), reqID, ref); err != nil {
+		t.Fatalf("cancel: %v", err)
+	}
+	if _, src := replacementPending(t, db, taskID, reqID); src != "trial" {
+		t.Fatalf("want replacement point_source=trial (P4a-D17), got %q", src)
+	}
+}
+
+func TestCancelPastDeadline(t *testing.T) {
+	db := testsupport.DB(t)
+	svc, _ := newTestMatchingService(t, db)
+	// Due in 5h is inside the 12h cancel deadline.
+	reqID, _, ref := seedAccepted(t, db, "5 hours", "regular")
+
+	if err := svc.Cancel(context.Background(), reqID, ref); !errors.Is(err, matching.ErrCancelDeadlinePassed) {
+		t.Fatalf("want ErrCancelDeadlinePassed, got %v", err)
+	}
+	assertStatus(t, db, reqID, "accepted") // unchanged
+}

--- a/backend/internal/matching/cancel_test.go
+++ b/backend/internal/matching/cancel_test.go
@@ -46,8 +46,12 @@ func TestCancelByRefereeReMatches(t *testing.T) {
 	svc, _ := newTestMatchingService(t, db)
 	reqID, taskID, ref := seedAccepted(t, db, "30 days", "regular")
 
-	if err := svc.Cancel(context.Background(), reqID, ref); err != nil {
+	gotTaskID, err := svc.Cancel(context.Background(), reqID, ref)
+	if err != nil {
 		t.Fatalf("cancel: %v", err)
+	}
+	if gotTaskID != taskID {
+		t.Fatalf("cancel returned task %s, want %s", gotTaskID, taskID)
 	}
 	assertStatus(t, db, reqID, "cancelled")
 	if n := judgementCount(t, db, reqID); n != 0 {
@@ -65,7 +69,7 @@ func TestCancelRejectsNonAssignedReferee(t *testing.T) {
 	reqID, _, _ := seedAccepted(t, db, "30 days", "regular")
 	other := newUser(t, db)
 
-	if err := svc.Cancel(context.Background(), reqID, other); !errors.Is(err, matching.ErrForbidden) {
+	if _, err := svc.Cancel(context.Background(), reqID, other); !errors.Is(err, matching.ErrForbidden) {
 		t.Fatalf("want ErrForbidden, got %v", err)
 	}
 	assertStatus(t, db, reqID, "accepted") // unchanged
@@ -76,7 +80,7 @@ func TestCancelPreservesPointSource(t *testing.T) {
 	svc, _ := newTestMatchingService(t, db)
 	reqID, taskID, ref := seedAccepted(t, db, "30 days", "trial")
 
-	if err := svc.Cancel(context.Background(), reqID, ref); err != nil {
+	if _, err := svc.Cancel(context.Background(), reqID, ref); err != nil {
 		t.Fatalf("cancel: %v", err)
 	}
 	if _, src := replacementPending(t, db, taskID, reqID); src != "trial" {
@@ -90,7 +94,7 @@ func TestCancelPastDeadline(t *testing.T) {
 	// Due in 5h is inside the 12h cancel deadline.
 	reqID, _, ref := seedAccepted(t, db, "5 hours", "regular")
 
-	if err := svc.Cancel(context.Background(), reqID, ref); !errors.Is(err, matching.ErrCancelDeadlinePassed) {
+	if _, err := svc.Cancel(context.Background(), reqID, ref); !errors.Is(err, matching.ErrCancelDeadlinePassed) {
 		t.Fatalf("want ErrCancelDeadlinePassed, got %v", err)
 	}
 	assertStatus(t, db, reqID, "accepted") // unchanged

--- a/backend/internal/matching/domain.go
+++ b/backend/internal/matching/domain.go
@@ -104,13 +104,3 @@ func (b BlockedDate) Validate() error {
 	}
 	return nil
 }
-
-// Assignment is one active seat a referee currently holds: the accepted request,
-// its task, and the judgement's status.
-type Assignment struct {
-	RequestID       string
-	TaskID          string
-	Title           string
-	DueDate         *time.Time
-	JudgementStatus string
-}

--- a/backend/internal/matching/domain.go
+++ b/backend/internal/matching/domain.go
@@ -1,12 +1,30 @@
 package matching
 
-import "errors"
+import (
+	"errors"
+	"fmt"
+	"time"
+)
 
 // ErrRefereeTaken signals that a referee already holds an accepted seat on the
 // task: the partial unique index uq_referee_requests_task_accepted_referee
 // tripped (P4a-D16). The match handler maps it to success OUTSIDE the
 // transaction — the request stays pending and the sweep retries it.
 var ErrRefereeTaken = errors.New("matching: referee already accepted on this task")
+
+// Use-case errors the handler maps to HTTP status codes.
+var (
+	// ErrNotFound: the referee request does not exist.
+	ErrNotFound = errors.New("matching: request not found")
+	// ErrForbidden: the caller is not the referee assigned to the request.
+	ErrForbidden = errors.New("matching: not the assigned referee")
+	// ErrConflict: the request is not in a state that allows the action.
+	ErrConflict = errors.New("matching: request state conflict")
+	// ErrCancelDeadlinePassed: too close to the task due date to cancel.
+	ErrCancelDeadlinePassed = errors.New("matching: cancel deadline passed")
+	// ErrValidation: a request field failed validation (e.g. referee count).
+	ErrValidation = errors.New("matching: validation failed")
+)
 
 // Config is the typed matching configuration singleton (matching_config, one
 // row id = true). The ordering invariant open > rematch > cancel is enforced in
@@ -40,4 +58,59 @@ type ExpiredCandidate struct {
 	TaskID   string
 	TaskerID string // "" when the task's tasker was deleted
 	Title    string
+}
+
+// TimeSlot is a weekly recurring availability window in the referee's local
+// timezone. DOW is 0=Sunday..6=Saturday; StartMin/EndMin are minutes past
+// midnight.
+type TimeSlot struct {
+	ID       string
+	DOW      int
+	StartMin int
+	EndMin   int
+	IsActive bool
+}
+
+// Validate mirrors the referee_available_time_slots CHECKs so a bad slot is
+// rejected as a 400 before it reaches the DB.
+func (s TimeSlot) Validate() error {
+	if s.DOW < 0 || s.DOW > 6 {
+		return fmt.Errorf("%w: dow must be 0..6", ErrValidation)
+	}
+	if s.StartMin < 0 || s.StartMin > 1439 {
+		return fmt.Errorf("%w: startMin must be 0..1439", ErrValidation)
+	}
+	if s.EndMin < 1 || s.EndMin > 1440 {
+		return fmt.Errorf("%w: endMin must be 1..1440", ErrValidation)
+	}
+	if s.StartMin >= s.EndMin {
+		return fmt.Errorf("%w: startMin must be before endMin", ErrValidation)
+	}
+	return nil
+}
+
+// BlockedDate is an inclusive date range the referee is unavailable.
+type BlockedDate struct {
+	ID        string
+	StartDate time.Time
+	EndDate   time.Time
+	Reason    *string
+}
+
+// Validate mirrors the referee_blocked_dates CHECK (end >= start).
+func (b BlockedDate) Validate() error {
+	if b.EndDate.Before(b.StartDate) {
+		return fmt.Errorf("%w: endDate must be on or after startDate", ErrValidation)
+	}
+	return nil
+}
+
+// Assignment is one active seat a referee currently holds: the accepted request,
+// its task, and the judgement's status.
+type Assignment struct {
+	RequestID       string
+	TaskID          string
+	Title           string
+	DueDate         *time.Time
+	JudgementStatus string
 }

--- a/backend/internal/matching/handler.go
+++ b/backend/internal/matching/handler.go
@@ -1,6 +1,7 @@
 package matching
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"net/http"
@@ -10,21 +11,34 @@ import (
 
 	"github.com/cloveclovedev/peppercheck/backend/internal/core/httpserver"
 	"github.com/cloveclovedev/peppercheck/backend/internal/identity"
+	"github.com/cloveclovedev/peppercheck/backend/internal/task"
 )
 
 const dateLayout = "2006-01-02"
 
-// Handler serves the referee HTTP surface: availability CRUD, active
-// assignments, and request cancellation, all scoped to the authenticated
-// caller. Availability reads/writes go straight to the store (plain CRUD);
-// cancel goes through the service (cross-store orchestration).
+// taskLoader renders the Task read-model for the cancel response. Declared here
+// so the referee handler can return the §7.1 Task envelope after a cancel;
+// task.Store satisfies it.
+type taskLoader interface {
+	LoadAggregate(ctx context.Context, taskID string) (task.Task, error)
+}
+
+// Handler serves the referee HTTP surface: availability CRUD and request
+// cancellation, scoped to the authenticated caller. Availability reads/writes go
+// straight to the store (plain CRUD); cancel goes through the service and
+// renders the updated Task via the task loader. GET /matching/config exposes the
+// public matching configuration.
 type Handler struct {
 	svc   *Service
 	store *Store
+	tasks taskLoader
 }
 
-// NewHandler builds a Handler over the matching service and store.
-func NewHandler(svc *Service, store *Store) *Handler { return &Handler{svc: svc, store: store} }
+// NewHandler builds a Handler over the matching service, store, and the task
+// loader used to render the cancel response.
+func NewHandler(svc *Service, store *Store, tasks taskLoader) *Handler {
+	return &Handler{svc: svc, store: store, tasks: tasks}
+}
 
 // --- DTOs -----------------------------------------------------------------
 
@@ -77,12 +91,28 @@ func toBlockedDateDTO(b BlockedDate) blockedDateDTO {
 	}
 }
 
-type assignmentDTO struct {
-	RequestID       string  `json:"requestId"`
-	TaskID          string  `json:"taskId"`
-	Title           string  `json:"title"`
-	DueDate         *string `json:"dueDate"`
-	JudgementStatus string  `json:"judgementStatus"`
+type matchingConfigDTO struct {
+	OpenDeadlineHours   int `json:"openDeadlineHours"`
+	CancelDeadlineHours int `json:"cancelDeadlineHours"`
+	RematchCutoffHours  int `json:"rematchCutoffHours"`
+	MaxRefereesPerTask  int `json:"maxRefereesPerTask"`
+	MatchingPointCost   int `json:"matchingPointCost"`
+}
+
+// GetConfig returns the public matching configuration (deadlines + limits).
+func (h *Handler) GetConfig(w http.ResponseWriter, r *http.Request) {
+	cfg, err := h.store.LoadConfig(r.Context())
+	if err != nil {
+		httpserver.WriteError(w, r, http.StatusInternalServerError, httpserver.CodeInternal, "internal error")
+		return
+	}
+	writeJSON(w, http.StatusOK, matchingConfigDTO{
+		OpenDeadlineHours:   cfg.OpenDeadlineHours,
+		CancelDeadlineHours: cfg.CancelDeadlineHours,
+		RematchCutoffHours:  cfg.RematchCutoffHours,
+		MaxRefereesPerTask:  cfg.MaxRefereesPerTask,
+		MatchingPointCost:   cfg.PointCostPerRequest,
+	})
 }
 
 // --- time slots -----------------------------------------------------------
@@ -102,7 +132,7 @@ func (h *Handler) GetTimeSlots(w http.ResponseWriter, r *http.Request) {
 	for _, s := range slots {
 		out = append(out, toTimeSlotDTO(s))
 	}
-	writeJSON(w, http.StatusOK, out)
+	writeJSON(w, http.StatusOK, map[string]any{"timeSlots": out})
 }
 
 // PostTimeSlot creates a slot for the caller.
@@ -188,7 +218,7 @@ func (h *Handler) GetBlockedDates(w http.ResponseWriter, r *http.Request) {
 	for _, b := range dates {
 		out = append(out, toBlockedDateDTO(b))
 	}
-	writeJSON(w, http.StatusOK, out)
+	writeJSON(w, http.StatusOK, map[string]any{"blockedDates": out})
 }
 
 // PostBlockedDate creates a blocked range for the caller.
@@ -273,32 +303,10 @@ func parseBlockedDate(req blockedDateRequest) (BlockedDate, error) {
 	return b, nil
 }
 
-// --- assignments + cancel -------------------------------------------------
+// --- cancel ---------------------------------------------------------------
 
-// GetAssignments lists the caller's active referee assignments.
-func (h *Handler) GetAssignments(w http.ResponseWriter, r *http.Request) {
-	u, ok := currentUser(w, r)
-	if !ok {
-		return
-	}
-	items, err := h.store.ActiveAssignments(r.Context(), u.ID)
-	if err != nil {
-		h.writeError(w, r, err)
-		return
-	}
-	out := make([]assignmentDTO, 0, len(items))
-	for _, a := range items {
-		dto := assignmentDTO{RequestID: a.RequestID, TaskID: a.TaskID, Title: a.Title, JudgementStatus: a.JudgementStatus}
-		if a.DueDate != nil {
-			s := a.DueDate.UTC().Format(time.RFC3339)
-			dto.DueDate = &s
-		}
-		out = append(out, dto)
-	}
-	writeJSON(w, http.StatusOK, out)
-}
-
-// PostCancel cancels the caller's accepted request and triggers a re-match.
+// PostCancel cancels the caller's accepted request, triggers a re-match, and
+// returns the updated Task (§7.1).
 func (h *Handler) PostCancel(w http.ResponseWriter, r *http.Request) {
 	u, ok := currentUser(w, r)
 	if !ok {
@@ -308,11 +316,17 @@ func (h *Handler) PostCancel(w http.ResponseWriter, r *http.Request) {
 	if !ok {
 		return
 	}
-	if err := h.svc.Cancel(r.Context(), id, u.ID); err != nil {
+	taskID, err := h.svc.Cancel(r.Context(), id, u.ID)
+	if err != nil {
 		h.writeError(w, r, err)
 		return
 	}
-	w.WriteHeader(http.StatusNoContent)
+	t, err := h.tasks.LoadAggregate(r.Context(), taskID)
+	if err != nil {
+		h.writeError(w, r, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, task.TaskResponse(t))
 }
 
 // --- helpers --------------------------------------------------------------

--- a/backend/internal/matching/handler.go
+++ b/backend/internal/matching/handler.go
@@ -6,6 +6,8 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/google/uuid"
+
 	"github.com/cloveclovedev/peppercheck/backend/internal/core/httpserver"
 	"github.com/cloveclovedev/peppercheck/backend/internal/identity"
 )
@@ -132,6 +134,10 @@ func (h *Handler) PutTimeSlot(w http.ResponseWriter, r *http.Request) {
 	if !ok {
 		return
 	}
+	id, ok := pathID(w, r)
+	if !ok {
+		return
+	}
 	var req timeSlotRequest
 	if !httpserver.DecodeJSON(w, r, &req) {
 		return
@@ -141,7 +147,7 @@ func (h *Handler) PutTimeSlot(w http.ResponseWriter, r *http.Request) {
 		h.writeError(w, r, err)
 		return
 	}
-	if err := h.store.UpdateTimeSlot(r.Context(), u.ID, r.PathValue("id"), slot); err != nil {
+	if err := h.store.UpdateTimeSlot(r.Context(), u.ID, id, slot); err != nil {
 		h.writeError(w, r, err)
 		return
 	}
@@ -154,7 +160,11 @@ func (h *Handler) DeleteTimeSlot(w http.ResponseWriter, r *http.Request) {
 	if !ok {
 		return
 	}
-	if err := h.store.DeleteTimeSlot(r.Context(), u.ID, r.PathValue("id")); err != nil {
+	id, ok := pathID(w, r)
+	if !ok {
+		return
+	}
+	if err := h.store.DeleteTimeSlot(r.Context(), u.ID, id); err != nil {
 		h.writeError(w, r, err)
 		return
 	}
@@ -210,6 +220,10 @@ func (h *Handler) PutBlockedDate(w http.ResponseWriter, r *http.Request) {
 	if !ok {
 		return
 	}
+	id, ok := pathID(w, r)
+	if !ok {
+		return
+	}
 	var req blockedDateRequest
 	if !httpserver.DecodeJSON(w, r, &req) {
 		return
@@ -219,7 +233,7 @@ func (h *Handler) PutBlockedDate(w http.ResponseWriter, r *http.Request) {
 		h.writeError(w, r, err)
 		return
 	}
-	if err := h.store.UpdateBlockedDate(r.Context(), u.ID, r.PathValue("id"), b); err != nil {
+	if err := h.store.UpdateBlockedDate(r.Context(), u.ID, id, b); err != nil {
 		h.writeError(w, r, err)
 		return
 	}
@@ -232,7 +246,11 @@ func (h *Handler) DeleteBlockedDate(w http.ResponseWriter, r *http.Request) {
 	if !ok {
 		return
 	}
-	if err := h.store.DeleteBlockedDate(r.Context(), u.ID, r.PathValue("id")); err != nil {
+	id, ok := pathID(w, r)
+	if !ok {
+		return
+	}
+	if err := h.store.DeleteBlockedDate(r.Context(), u.ID, id); err != nil {
 		h.writeError(w, r, err)
 		return
 	}
@@ -286,7 +304,11 @@ func (h *Handler) PostCancel(w http.ResponseWriter, r *http.Request) {
 	if !ok {
 		return
 	}
-	if err := h.svc.Cancel(r.Context(), r.PathValue("id"), u.ID); err != nil {
+	id, ok := pathID(w, r)
+	if !ok {
+		return
+	}
+	if err := h.svc.Cancel(r.Context(), id, u.ID); err != nil {
 		h.writeError(w, r, err)
 		return
 	}
@@ -301,6 +323,18 @@ func currentUser(w http.ResponseWriter, r *http.Request) (identity.User, bool) {
 		httpserver.WriteError(w, r, http.StatusUnauthorized, httpserver.CodeUnauthenticated, "missing user")
 	}
 	return u, ok
+}
+
+// pathID reads and validates the {id} path parameter as a UUID, rejecting a
+// malformed id as a 400 before it reaches a uuid-typed query (which would
+// otherwise surface as a 500 invalid-text-representation error).
+func pathID(w http.ResponseWriter, r *http.Request) (string, bool) {
+	id := r.PathValue("id")
+	if uuid.Validate(id) != nil {
+		httpserver.WriteError(w, r, http.StatusBadRequest, httpserver.CodeInvalidArgument, "invalid id")
+		return "", false
+	}
+	return id, true
 }
 
 func (h *Handler) writeError(w http.ResponseWriter, r *http.Request, err error) {

--- a/backend/internal/matching/handler.go
+++ b/backend/internal/matching/handler.go
@@ -1,0 +1,325 @@
+package matching
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"time"
+
+	"github.com/cloveclovedev/peppercheck/backend/internal/core/httpserver"
+	"github.com/cloveclovedev/peppercheck/backend/internal/identity"
+)
+
+const dateLayout = "2006-01-02"
+
+// Handler serves the referee HTTP surface: availability CRUD, active
+// assignments, and request cancellation, all scoped to the authenticated
+// caller. Availability reads/writes go straight to the store (plain CRUD);
+// cancel goes through the service (cross-store orchestration).
+type Handler struct {
+	svc   *Service
+	store *Store
+}
+
+// NewHandler builds a Handler over the matching service and store.
+func NewHandler(svc *Service, store *Store) *Handler { return &Handler{svc: svc, store: store} }
+
+// --- DTOs -----------------------------------------------------------------
+
+type timeSlotDTO struct {
+	ID       string `json:"id"`
+	DOW      int    `json:"dow"`
+	StartMin int    `json:"startMin"`
+	EndMin   int    `json:"endMin"`
+	IsActive bool   `json:"isActive"`
+}
+
+type timeSlotRequest struct {
+	DOW      int   `json:"dow"`
+	StartMin int   `json:"startMin"`
+	EndMin   int   `json:"endMin"`
+	IsActive *bool `json:"isActive"` // defaults to true when omitted
+}
+
+func (r timeSlotRequest) toDomain() TimeSlot {
+	active := true
+	if r.IsActive != nil {
+		active = *r.IsActive
+	}
+	return TimeSlot{DOW: r.DOW, StartMin: r.StartMin, EndMin: r.EndMin, IsActive: active}
+}
+
+func toTimeSlotDTO(s TimeSlot) timeSlotDTO {
+	return timeSlotDTO{ID: s.ID, DOW: s.DOW, StartMin: s.StartMin, EndMin: s.EndMin, IsActive: s.IsActive}
+}
+
+type blockedDateDTO struct {
+	ID        string  `json:"id"`
+	StartDate string  `json:"startDate"`
+	EndDate   string  `json:"endDate"`
+	Reason    *string `json:"reason"`
+}
+
+type blockedDateRequest struct {
+	StartDate string  `json:"startDate"`
+	EndDate   string  `json:"endDate"`
+	Reason    *string `json:"reason"`
+}
+
+func toBlockedDateDTO(b BlockedDate) blockedDateDTO {
+	return blockedDateDTO{
+		ID:        b.ID,
+		StartDate: b.StartDate.Format(dateLayout),
+		EndDate:   b.EndDate.Format(dateLayout),
+		Reason:    b.Reason,
+	}
+}
+
+type assignmentDTO struct {
+	RequestID       string  `json:"requestId"`
+	TaskID          string  `json:"taskId"`
+	Title           string  `json:"title"`
+	DueDate         *string `json:"dueDate"`
+	JudgementStatus string  `json:"judgementStatus"`
+}
+
+// --- time slots -----------------------------------------------------------
+
+// GetTimeSlots lists the caller's availability slots.
+func (h *Handler) GetTimeSlots(w http.ResponseWriter, r *http.Request) {
+	u, ok := currentUser(w, r)
+	if !ok {
+		return
+	}
+	slots, err := h.store.ListTimeSlots(r.Context(), u.ID)
+	if err != nil {
+		h.writeError(w, r, err)
+		return
+	}
+	out := make([]timeSlotDTO, 0, len(slots))
+	for _, s := range slots {
+		out = append(out, toTimeSlotDTO(s))
+	}
+	writeJSON(w, http.StatusOK, out)
+}
+
+// PostTimeSlot creates a slot for the caller.
+func (h *Handler) PostTimeSlot(w http.ResponseWriter, r *http.Request) {
+	u, ok := currentUser(w, r)
+	if !ok {
+		return
+	}
+	var req timeSlotRequest
+	if !httpserver.DecodeJSON(w, r, &req) {
+		return
+	}
+	slot := req.toDomain()
+	if err := slot.Validate(); err != nil {
+		h.writeError(w, r, err)
+		return
+	}
+	created, err := h.store.CreateTimeSlot(r.Context(), u.ID, slot)
+	if err != nil {
+		h.writeError(w, r, err)
+		return
+	}
+	writeJSON(w, http.StatusCreated, toTimeSlotDTO(created))
+}
+
+// PutTimeSlot updates a slot the caller owns.
+func (h *Handler) PutTimeSlot(w http.ResponseWriter, r *http.Request) {
+	u, ok := currentUser(w, r)
+	if !ok {
+		return
+	}
+	var req timeSlotRequest
+	if !httpserver.DecodeJSON(w, r, &req) {
+		return
+	}
+	slot := req.toDomain()
+	if err := slot.Validate(); err != nil {
+		h.writeError(w, r, err)
+		return
+	}
+	if err := h.store.UpdateTimeSlot(r.Context(), u.ID, r.PathValue("id"), slot); err != nil {
+		h.writeError(w, r, err)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// DeleteTimeSlot removes a slot the caller owns.
+func (h *Handler) DeleteTimeSlot(w http.ResponseWriter, r *http.Request) {
+	u, ok := currentUser(w, r)
+	if !ok {
+		return
+	}
+	if err := h.store.DeleteTimeSlot(r.Context(), u.ID, r.PathValue("id")); err != nil {
+		h.writeError(w, r, err)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// --- blocked dates --------------------------------------------------------
+
+// GetBlockedDates lists the caller's blocked date ranges.
+func (h *Handler) GetBlockedDates(w http.ResponseWriter, r *http.Request) {
+	u, ok := currentUser(w, r)
+	if !ok {
+		return
+	}
+	dates, err := h.store.ListBlockedDates(r.Context(), u.ID)
+	if err != nil {
+		h.writeError(w, r, err)
+		return
+	}
+	out := make([]blockedDateDTO, 0, len(dates))
+	for _, b := range dates {
+		out = append(out, toBlockedDateDTO(b))
+	}
+	writeJSON(w, http.StatusOK, out)
+}
+
+// PostBlockedDate creates a blocked range for the caller.
+func (h *Handler) PostBlockedDate(w http.ResponseWriter, r *http.Request) {
+	u, ok := currentUser(w, r)
+	if !ok {
+		return
+	}
+	var req blockedDateRequest
+	if !httpserver.DecodeJSON(w, r, &req) {
+		return
+	}
+	b, err := parseBlockedDate(req)
+	if err != nil {
+		h.writeError(w, r, err)
+		return
+	}
+	created, err := h.store.CreateBlockedDate(r.Context(), u.ID, b)
+	if err != nil {
+		h.writeError(w, r, err)
+		return
+	}
+	writeJSON(w, http.StatusCreated, toBlockedDateDTO(created))
+}
+
+// PutBlockedDate updates a blocked range the caller owns.
+func (h *Handler) PutBlockedDate(w http.ResponseWriter, r *http.Request) {
+	u, ok := currentUser(w, r)
+	if !ok {
+		return
+	}
+	var req blockedDateRequest
+	if !httpserver.DecodeJSON(w, r, &req) {
+		return
+	}
+	b, err := parseBlockedDate(req)
+	if err != nil {
+		h.writeError(w, r, err)
+		return
+	}
+	if err := h.store.UpdateBlockedDate(r.Context(), u.ID, r.PathValue("id"), b); err != nil {
+		h.writeError(w, r, err)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// DeleteBlockedDate removes a blocked range the caller owns.
+func (h *Handler) DeleteBlockedDate(w http.ResponseWriter, r *http.Request) {
+	u, ok := currentUser(w, r)
+	if !ok {
+		return
+	}
+	if err := h.store.DeleteBlockedDate(r.Context(), u.ID, r.PathValue("id")); err != nil {
+		h.writeError(w, r, err)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func parseBlockedDate(req blockedDateRequest) (BlockedDate, error) {
+	start, err := time.Parse(dateLayout, req.StartDate)
+	if err != nil {
+		return BlockedDate{}, errors.Join(ErrValidation, err)
+	}
+	end, err := time.Parse(dateLayout, req.EndDate)
+	if err != nil {
+		return BlockedDate{}, errors.Join(ErrValidation, err)
+	}
+	b := BlockedDate{StartDate: start, EndDate: end, Reason: req.Reason}
+	if err := b.Validate(); err != nil {
+		return BlockedDate{}, err
+	}
+	return b, nil
+}
+
+// --- assignments + cancel -------------------------------------------------
+
+// GetAssignments lists the caller's active referee assignments.
+func (h *Handler) GetAssignments(w http.ResponseWriter, r *http.Request) {
+	u, ok := currentUser(w, r)
+	if !ok {
+		return
+	}
+	items, err := h.store.ActiveAssignments(r.Context(), u.ID)
+	if err != nil {
+		h.writeError(w, r, err)
+		return
+	}
+	out := make([]assignmentDTO, 0, len(items))
+	for _, a := range items {
+		dto := assignmentDTO{RequestID: a.RequestID, TaskID: a.TaskID, Title: a.Title, JudgementStatus: a.JudgementStatus}
+		if a.DueDate != nil {
+			s := a.DueDate.UTC().Format(time.RFC3339)
+			dto.DueDate = &s
+		}
+		out = append(out, dto)
+	}
+	writeJSON(w, http.StatusOK, out)
+}
+
+// PostCancel cancels the caller's accepted request and triggers a re-match.
+func (h *Handler) PostCancel(w http.ResponseWriter, r *http.Request) {
+	u, ok := currentUser(w, r)
+	if !ok {
+		return
+	}
+	if err := h.svc.Cancel(r.Context(), r.PathValue("id"), u.ID); err != nil {
+		h.writeError(w, r, err)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// --- helpers --------------------------------------------------------------
+
+func currentUser(w http.ResponseWriter, r *http.Request) (identity.User, bool) {
+	u, ok := identity.CurrentUser(r.Context())
+	if !ok {
+		httpserver.WriteError(w, r, http.StatusUnauthorized, httpserver.CodeUnauthenticated, "missing user")
+	}
+	return u, ok
+}
+
+func (h *Handler) writeError(w http.ResponseWriter, r *http.Request, err error) {
+	switch {
+	case errors.Is(err, ErrNotFound):
+		httpserver.WriteError(w, r, http.StatusNotFound, httpserver.CodeNotFound, "not found")
+	case errors.Is(err, ErrForbidden):
+		httpserver.WriteError(w, r, http.StatusForbidden, httpserver.CodeForbidden, "not allowed")
+	case errors.Is(err, ErrConflict), errors.Is(err, ErrCancelDeadlinePassed):
+		httpserver.WriteError(w, r, http.StatusConflict, httpserver.CodeConflict, "request state conflict")
+	case errors.Is(err, ErrValidation):
+		httpserver.WriteError(w, r, http.StatusBadRequest, httpserver.CodeInvalidArgument, "invalid argument")
+	default:
+		httpserver.WriteError(w, r, http.StatusInternalServerError, httpserver.CodeInternal, "internal error")
+	}
+}
+
+func writeJSON(w http.ResponseWriter, status int, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(v)
+}

--- a/backend/internal/matching/service.go
+++ b/backend/internal/matching/service.go
@@ -209,12 +209,13 @@ func (s *Service) CreateInTx(ctx context.Context, tx database.Querier, taskID, t
 // source (P4a-D17), and enqueues a match — all atomically. Only the matched
 // referee may cancel, only while the request is still accepted with its
 // judgement un-progressed, and only before due minus cancel_deadline_hours.
-func (s *Service) Cancel(ctx context.Context, requestID, callerID string) error {
+// It returns the affected task's id so the handler can render the updated Task.
+func (s *Service) Cancel(ctx context.Context, requestID, callerID string) (taskID string, err error) {
 	cfg, err := s.store.LoadConfig(ctx)
 	if err != nil {
-		return err
+		return "", err
 	}
-	return database.WithTx(ctx, s.db, func(tx database.Querier) error {
+	err = database.WithTx(ctx, s.db, func(tx database.Querier) error {
 		req, err := s.store.GetRequestForCancelInTx(ctx, tx, requestID)
 		if errors.Is(err, sql.ErrNoRows) {
 			return ErrNotFound
@@ -251,8 +252,16 @@ func (s *Service) Cancel(ctx context.Context, requestID, callerID string) error 
 		if err := s.store.SetPointSourceInTx(ctx, tx, newID, req.PointSource); err != nil {
 			return err
 		}
-		return s.EnqueueMatchInTx(ctx, tx, newID)
+		if err := s.EnqueueMatchInTx(ctx, tx, newID); err != nil {
+			return err
+		}
+		taskID = req.TaskID
+		return nil
 	})
+	if err != nil {
+		return "", err
+	}
+	return taskID, nil
 }
 
 // HandleSweep is the recurring worker pass. It first reschedules itself (so a

--- a/backend/internal/matching/service.go
+++ b/backend/internal/matching/service.go
@@ -158,6 +158,48 @@ func (s *Service) maybeNotifyCancelledPending(ctx context.Context, tx database.Q
 		"cancelled_pending:"+requestID)
 }
 
+// PublishBounds reports the two matching-config values the task publish path
+// needs: the minimum publish lead time (open_deadline_hours) and the maximum
+// referee count per task.
+func (s *Service) PublishBounds(ctx context.Context) (minLeadHours, maxReferees int, err error) {
+	cfg, err := s.store.LoadConfig(ctx)
+	if err != nil {
+		return 0, 0, err
+	}
+	return cfg.OpenDeadlineHours, cfg.MaxRefereesPerTask, nil
+}
+
+// CreateInTx creates count pending referee requests for a task and enqueues a
+// match job per request, all in the caller's transaction (the publish outbox).
+// Each request locks its cost points via the seam and records the returned
+// funding source (P4a-D17); a failed lock rolls back the whole publish.
+func (s *Service) CreateInTx(ctx context.Context, tx database.Querier, taskID, taskerID string, count int) error {
+	cfg, err := s.store.LoadConfig(ctx)
+	if err != nil {
+		return err
+	}
+	if count < 1 || count > cfg.MaxRefereesPerTask {
+		return fmt.Errorf("%w: refereeCount must be 1..%d", ErrValidation, cfg.MaxRefereesPerTask)
+	}
+	for i := 0; i < count; i++ {
+		reqID, err := s.store.InsertRequestInTx(ctx, tx, taskID)
+		if err != nil {
+			return err
+		}
+		source, err := s.points.LockForRequestInTx(ctx, tx, taskerID, reqID, cfg.PointCostPerRequest)
+		if err != nil {
+			return err
+		}
+		if err := s.store.SetPointSourceInTx(ctx, tx, reqID, source); err != nil {
+			return err
+		}
+		if err := s.EnqueueMatchInTx(ctx, tx, reqID); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // Cancel lets the assigned referee drop an accepted request before the cancel
 // deadline: it marks the request cancelled, removes the awaiting_evidence
 // judgement, inserts a fresh pending replacement carrying the original funding

--- a/backend/internal/matching/service.go
+++ b/backend/internal/matching/service.go
@@ -174,7 +174,10 @@ func (s *Service) PublishBounds(ctx context.Context) (minLeadHours, maxReferees 
 // Each request locks its cost points via the seam and records the returned
 // funding source (P4a-D17); a failed lock rolls back the whole publish.
 func (s *Service) CreateInTx(ctx context.Context, tx database.Querier, taskID, taskerID string, count int) error {
-	cfg, err := s.store.LoadConfig(ctx)
+	// Read config through the caller's tx, not the pool: this runs while the
+	// publish transaction already holds a connection, and a pool read here would
+	// need a second one (pool-exhaustion deadlock under concurrent publishes).
+	cfg, err := s.store.LoadConfigInTx(ctx, tx)
 	if err != nil {
 		return err
 	}

--- a/backend/internal/matching/service.go
+++ b/backend/internal/matching/service.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"hash/fnv"
+	"time"
 
 	"github.com/cloveclovedev/peppercheck/backend/internal/core/database"
 	"github.com/cloveclovedev/peppercheck/backend/internal/core/jobs"
@@ -155,6 +156,58 @@ func (s *Service) maybeNotifyCancelledPending(ctx context.Context, tx database.Q
 		"notification_matching_cancelled_pending_tasker", []string{rc.Title},
 		map[string]string{"route": "/tasks/" + rc.TaskID},
 		"cancelled_pending:"+requestID)
+}
+
+// Cancel lets the assigned referee drop an accepted request before the cancel
+// deadline: it marks the request cancelled, removes the awaiting_evidence
+// judgement, inserts a fresh pending replacement carrying the original funding
+// source (P4a-D17), and enqueues a match — all atomically. Only the matched
+// referee may cancel, only while the request is still accepted with its
+// judgement un-progressed, and only before due minus cancel_deadline_hours.
+func (s *Service) Cancel(ctx context.Context, requestID, callerID string) error {
+	cfg, err := s.store.LoadConfig(ctx)
+	if err != nil {
+		return err
+	}
+	return database.WithTx(ctx, s.db, func(tx database.Querier) error {
+		req, err := s.store.GetRequestForCancelInTx(ctx, tx, requestID)
+		if errors.Is(err, sql.ErrNoRows) {
+			return ErrNotFound
+		}
+		if err != nil {
+			return err
+		}
+		if !req.MatchedRefereeID.Valid || req.MatchedRefereeID.String != callerID {
+			return ErrForbidden
+		}
+		if req.Status != "accepted" {
+			return ErrConflict
+		}
+		if !req.DueDate.Valid {
+			return ErrConflict
+		}
+		if req.DueDate.Time.Add(-time.Duration(cfg.CancelDeadlineHours) * time.Hour).Before(time.Now()) {
+			return ErrCancelDeadlinePassed
+		}
+		if err := s.store.SetStatusInTx(ctx, tx, requestID, "cancelled"); err != nil {
+			return err
+		}
+		deleted, err := s.judgements.DeleteIfAwaitingEvidenceInTx(ctx, tx, requestID)
+		if err != nil {
+			return err
+		}
+		if !deleted {
+			return ErrConflict // evidence review has progressed; cannot cancel
+		}
+		newID, err := s.store.InsertRequestInTx(ctx, tx, req.TaskID)
+		if err != nil {
+			return err
+		}
+		if err := s.store.SetPointSourceInTx(ctx, tx, newID, req.PointSource); err != nil {
+			return err
+		}
+		return s.EnqueueMatchInTx(ctx, tx, newID)
+	})
 }
 
 // HandleSweep is the recurring worker pass. It first reschedules itself (so a

--- a/backend/internal/matching/store.go
+++ b/backend/internal/matching/store.go
@@ -21,10 +21,22 @@ type Store struct {
 // NewStore builds a Store over an open database handle.
 func NewStore(db *database.Handle) *Store { return &Store{db: db} }
 
-// LoadConfig reads the singleton matching configuration.
+// LoadConfig reads the singleton matching configuration on the pool.
 func (s *Store) LoadConfig(ctx context.Context) (Config, error) {
+	return s.loadConfig(ctx, s.db)
+}
+
+// LoadConfigInTx reads the config through the caller's transaction. Callers
+// already inside a WithTx MUST use this, not LoadConfig: reading through the
+// pool while holding a transaction's connection needs a second pooled
+// connection, so enough concurrent in-transaction reads would deadlock the pool.
+func (s *Store) LoadConfigInTx(ctx context.Context, q database.Querier) (Config, error) {
+	return s.loadConfig(ctx, q)
+}
+
+func (s *Store) loadConfig(ctx context.Context, q database.Querier) (Config, error) {
 	var c Config
-	err := s.db.QueryRowContext(ctx, `
+	err := q.QueryRowContext(ctx, `
 		SELECT open_deadline_hours, cancel_deadline_hours, rematch_cutoff_hours,
 		       max_referees_per_task, point_cost_per_request
 		FROM public.matching_config WHERE id = true`).

--- a/backend/internal/matching/store.go
+++ b/backend/internal/matching/store.go
@@ -335,36 +335,6 @@ func (s *Store) DeleteBlockedDate(ctx context.Context, userID, id string) error 
 	return rowsAffectedOrNotFound(res)
 }
 
-// ActiveAssignments lists the referee's accepted requests whose judgement is
-// still active, with the task facts the app shows.
-func (s *Store) ActiveAssignments(ctx context.Context, refereeID string) ([]Assignment, error) {
-	rows, err := s.db.QueryContext(ctx, `
-		SELECT r.id, r.task_id, t.title, t.due_date, j.status
-		FROM public.referee_requests r
-		JOIN public.tasks t ON t.id = r.task_id
-		JOIN public.judgements j ON j.id = r.id
-		WHERE r.matched_referee_id = $1 AND r.status = 'accepted'
-		  AND j.status IN ('awaiting_evidence','in_review','rejected','review_timeout')
-		ORDER BY t.due_date NULLS LAST`, refereeID)
-	if err != nil {
-		return nil, fmt.Errorf("list assignments: %w", err)
-	}
-	defer rows.Close()
-	var out []Assignment
-	for rows.Next() {
-		var a Assignment
-		var due sql.NullTime
-		if err := rows.Scan(&a.RequestID, &a.TaskID, &a.Title, &due, &a.JudgementStatus); err != nil {
-			return nil, err
-		}
-		if due.Valid {
-			a.DueDate = &due.Time
-		}
-		out = append(out, a)
-	}
-	return out, rows.Err()
-}
-
 // rowsAffectedOrNotFound turns a zero-row write into ErrNotFound so a
 // missing-or-foreign id reads as 404 without leaking whether it exists.
 func rowsAffectedOrNotFound(res sql.Result) error {

--- a/backend/internal/matching/store.go
+++ b/backend/internal/matching/store.go
@@ -143,6 +143,226 @@ func (s *Store) RequestContext(ctx context.Context, q database.Querier, requestI
 	return rc, nil
 }
 
+// cancelRow is the request state the cancel use case guards on.
+type cancelRow struct {
+	Status           string
+	MatchedRefereeID sql.NullString
+	TaskID           string
+	DueDate          sql.NullTime
+	PointSource      string
+}
+
+// GetRequestForCancelInTx loads and row-locks a request (with its task's due
+// date) so the cancel use case can validate the caller/status/deadline without a
+// concurrent match or sweep changing it mid-transaction.
+func (s *Store) GetRequestForCancelInTx(ctx context.Context, q database.Querier, requestID string) (cancelRow, error) {
+	var c cancelRow
+	err := q.QueryRowContext(ctx, `
+		SELECT r.status, r.matched_referee_id, r.task_id, t.due_date, r.point_source
+		FROM public.referee_requests r
+		JOIN public.tasks t ON t.id = r.task_id
+		WHERE r.id = $1
+		FOR UPDATE OF r`, requestID).
+		Scan(&c.Status, &c.MatchedRefereeID, &c.TaskID, &c.DueDate, &c.PointSource)
+	if err != nil {
+		return cancelRow{}, err // caller distinguishes sql.ErrNoRows
+	}
+	return c, nil
+}
+
+// SetStatusInTx sets a request's status unconditionally (the caller has already
+// validated the transition under a row lock).
+func (s *Store) SetStatusInTx(ctx context.Context, q database.Querier, requestID, status string) error {
+	if _, err := q.ExecContext(ctx,
+		`UPDATE public.referee_requests SET status = $2, updated_at = now() WHERE id = $1`,
+		requestID, status); err != nil {
+		return fmt.Errorf("set request status: %w", err)
+	}
+	return nil
+}
+
+// SetPointSourceInTx stamps the request's funding source (P4a-D17: a cancel's
+// replacement inherits it, and publish records the locker's source). The no-op
+// locker returns 'regular', so this is a no-op stamp in 4a.
+func (s *Store) SetPointSourceInTx(ctx context.Context, q database.Querier, requestID, source string) error {
+	if _, err := q.ExecContext(ctx,
+		`UPDATE public.referee_requests SET point_source = $2::public.point_source_type, updated_at = now() WHERE id = $1`,
+		requestID, source); err != nil {
+		return fmt.Errorf("set point source: %w", err)
+	}
+	return nil
+}
+
+// --- referee availability CRUD (all user-scoped) --------------------------
+
+// ListTimeSlots returns the referee's weekly availability slots.
+func (s *Store) ListTimeSlots(ctx context.Context, userID string) ([]TimeSlot, error) {
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT id, dow, start_min, end_min, is_active
+		 FROM public.referee_available_time_slots WHERE user_id = $1
+		 ORDER BY dow, start_min`, userID)
+	if err != nil {
+		return nil, fmt.Errorf("list time slots: %w", err)
+	}
+	defer rows.Close()
+	var out []TimeSlot
+	for rows.Next() {
+		var t TimeSlot
+		if err := rows.Scan(&t.ID, &t.DOW, &t.StartMin, &t.EndMin, &t.IsActive); err != nil {
+			return nil, err
+		}
+		out = append(out, t)
+	}
+	return out, rows.Err()
+}
+
+// CreateTimeSlot inserts a slot for the referee. A duplicate (user, dow, start)
+// maps to ErrConflict.
+func (s *Store) CreateTimeSlot(ctx context.Context, userID string, in TimeSlot) (TimeSlot, error) {
+	out := in
+	err := s.db.QueryRowContext(ctx,
+		`INSERT INTO public.referee_available_time_slots (user_id, dow, start_min, end_min, is_active)
+		 VALUES ($1, $2, $3, $4, $5) RETURNING id`,
+		userID, in.DOW, in.StartMin, in.EndMin, in.IsActive).Scan(&out.ID)
+	if err != nil {
+		var pgErr *pgconn.PgError
+		if errors.As(err, &pgErr) && pgErr.Code == "23505" {
+			return TimeSlot{}, ErrConflict
+		}
+		return TimeSlot{}, fmt.Errorf("create time slot: %w", err)
+	}
+	return out, nil
+}
+
+// UpdateTimeSlot updates a slot the referee owns; a missing/foreign id is
+// ErrNotFound. A collision with another of the referee's slots is ErrConflict.
+func (s *Store) UpdateTimeSlot(ctx context.Context, userID, id string, in TimeSlot) error {
+	res, err := s.db.ExecContext(ctx,
+		`UPDATE public.referee_available_time_slots
+		 SET dow = $3, start_min = $4, end_min = $5, is_active = $6, updated_at = now()
+		 WHERE id = $1 AND user_id = $2`,
+		id, userID, in.DOW, in.StartMin, in.EndMin, in.IsActive)
+	if err != nil {
+		var pgErr *pgconn.PgError
+		if errors.As(err, &pgErr) && pgErr.Code == "23505" {
+			return ErrConflict
+		}
+		return fmt.Errorf("update time slot: %w", err)
+	}
+	return rowsAffectedOrNotFound(res)
+}
+
+// DeleteTimeSlot removes a slot the referee owns; a missing/foreign id is ErrNotFound.
+func (s *Store) DeleteTimeSlot(ctx context.Context, userID, id string) error {
+	res, err := s.db.ExecContext(ctx,
+		`DELETE FROM public.referee_available_time_slots WHERE id = $1 AND user_id = $2`, id, userID)
+	if err != nil {
+		return fmt.Errorf("delete time slot: %w", err)
+	}
+	return rowsAffectedOrNotFound(res)
+}
+
+// ListBlockedDates returns the referee's blocked date ranges.
+func (s *Store) ListBlockedDates(ctx context.Context, userID string) ([]BlockedDate, error) {
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT id, start_date, end_date, reason
+		 FROM public.referee_blocked_dates WHERE user_id = $1
+		 ORDER BY start_date`, userID)
+	if err != nil {
+		return nil, fmt.Errorf("list blocked dates: %w", err)
+	}
+	defer rows.Close()
+	var out []BlockedDate
+	for rows.Next() {
+		var b BlockedDate
+		var reason sql.NullString
+		if err := rows.Scan(&b.ID, &b.StartDate, &b.EndDate, &reason); err != nil {
+			return nil, err
+		}
+		if reason.Valid {
+			b.Reason = &reason.String
+		}
+		out = append(out, b)
+	}
+	return out, rows.Err()
+}
+
+// CreateBlockedDate inserts a blocked range for the referee.
+func (s *Store) CreateBlockedDate(ctx context.Context, userID string, in BlockedDate) (BlockedDate, error) {
+	out := in
+	err := s.db.QueryRowContext(ctx,
+		`INSERT INTO public.referee_blocked_dates (user_id, start_date, end_date, reason)
+		 VALUES ($1, $2, $3, $4) RETURNING id`,
+		userID, in.StartDate, in.EndDate, in.Reason).Scan(&out.ID)
+	if err != nil {
+		return BlockedDate{}, fmt.Errorf("create blocked date: %w", err)
+	}
+	return out, nil
+}
+
+// UpdateBlockedDate updates a range the referee owns; a missing/foreign id is ErrNotFound.
+func (s *Store) UpdateBlockedDate(ctx context.Context, userID, id string, in BlockedDate) error {
+	res, err := s.db.ExecContext(ctx,
+		`UPDATE public.referee_blocked_dates
+		 SET start_date = $3, end_date = $4, reason = $5, updated_at = now()
+		 WHERE id = $1 AND user_id = $2`,
+		id, userID, in.StartDate, in.EndDate, in.Reason)
+	if err != nil {
+		return fmt.Errorf("update blocked date: %w", err)
+	}
+	return rowsAffectedOrNotFound(res)
+}
+
+// DeleteBlockedDate removes a range the referee owns; a missing/foreign id is ErrNotFound.
+func (s *Store) DeleteBlockedDate(ctx context.Context, userID, id string) error {
+	res, err := s.db.ExecContext(ctx,
+		`DELETE FROM public.referee_blocked_dates WHERE id = $1 AND user_id = $2`, id, userID)
+	if err != nil {
+		return fmt.Errorf("delete blocked date: %w", err)
+	}
+	return rowsAffectedOrNotFound(res)
+}
+
+// ActiveAssignments lists the referee's accepted requests whose judgement is
+// still active, with the task facts the app shows.
+func (s *Store) ActiveAssignments(ctx context.Context, refereeID string) ([]Assignment, error) {
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT r.id, r.task_id, t.title, t.due_date, j.status
+		FROM public.referee_requests r
+		JOIN public.tasks t ON t.id = r.task_id
+		JOIN public.judgements j ON j.id = r.id
+		WHERE r.matched_referee_id = $1 AND r.status = 'accepted'
+		  AND j.status IN ('awaiting_evidence','in_review','rejected','review_timeout')
+		ORDER BY t.due_date NULLS LAST`, refereeID)
+	if err != nil {
+		return nil, fmt.Errorf("list assignments: %w", err)
+	}
+	defer rows.Close()
+	var out []Assignment
+	for rows.Next() {
+		var a Assignment
+		var due sql.NullTime
+		if err := rows.Scan(&a.RequestID, &a.TaskID, &a.Title, &due, &a.JudgementStatus); err != nil {
+			return nil, err
+		}
+		if due.Valid {
+			a.DueDate = &due.Time
+		}
+		out = append(out, a)
+	}
+	return out, rows.Err()
+}
+
+// rowsAffectedOrNotFound turns a zero-row write into ErrNotFound so a
+// missing-or-foreign id reads as 404 without leaking whether it exists.
+func rowsAffectedOrNotFound(res sql.Result) error {
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
 // PastCutoffPendingIDs lists pending requests whose task is within
 // rematchCutoffHours of its due date (or already past it) — matching can no
 // longer place them, so the sweep expires them. Rows carry the task facts the

--- a/backend/internal/matching/worker.go
+++ b/backend/internal/matching/worker.go
@@ -17,18 +17,32 @@ const JobKindMatch = "match_referee_request"
 const JobKindSweep = "sweep_pending_requests"
 
 // SweepInterval is the cadence of the self-rescheduling sweep.
-const SweepInterval = time.Minute
+const SweepInterval = time.Hour
 
-// scheduleNextSweep enqueues the next sweep occurrence, keyed by the target
-// bucket so repeated calls within one interval (a retried run) collapse to a
-// single job. HandleSweep calls this first, before any processing, so a run that
-// fails partway cannot break the recurring chain.
+// sweepKey is a per-bucket idempotency key so at most one sweep is scheduled per
+// interval, no matter how many workers (or retries) try to enqueue it.
+func sweepKey(runAt time.Time) string {
+	return JobKindSweep + ":" + runAt.UTC().Truncate(SweepInterval).Format(time.RFC3339)
+}
+
+// scheduleNextSweep enqueues the sweep at the next interval boundary. The
+// bucketed key + ON CONFLICT DO NOTHING makes concurrent/duplicate schedules a
+// no-op, so the chain never forks or dies. HandleSweep calls this first, before
+// any processing, so a run that fails partway cannot break the recurring chain.
 func (s *Service) scheduleNextSweep(ctx context.Context) error {
-	next := time.Now().Add(SweepInterval).Truncate(SweepInterval).UTC()
-	_, err := s.jobs.Enqueue(ctx, JobKindSweep, map[string]string{}, jobs.EnqueueOpts{
-		RunAt:          next,
-		IdempotencyKey: "sweep:" + next.Format(time.RFC3339),
-	})
+	next := time.Now().Truncate(SweepInterval).Add(SweepInterval)
+	_, err := s.jobs.Enqueue(ctx, JobKindSweep, struct{}{},
+		jobs.EnqueueOpts{RunAt: next, IdempotencyKey: sweepKey(next)})
+	return err
+}
+
+// BootstrapSweep seeds the current interval's sweep on startup. It is idempotent
+// across restarts and multiple workers (the bucketed key), so a worker that
+// comes up mid-interval re-seeds the chain without duplicating it.
+func (s *Service) BootstrapSweep(ctx context.Context) error {
+	now := time.Now().Truncate(SweepInterval)
+	_, err := s.jobs.Enqueue(ctx, JobKindSweep, struct{}{},
+		jobs.EnqueueOpts{RunAt: now, IdempotencyKey: sweepKey(now)})
 	return err
 }
 

--- a/backend/internal/platform/fcm/fcm.go
+++ b/backend/internal/platform/fcm/fcm.go
@@ -14,6 +14,7 @@ package fcm
 import (
 	"context"
 	"fmt"
+	"log/slog"
 
 	firebase "firebase.google.com/go/v4"
 	"firebase.google.com/go/v4/messaging"
@@ -61,6 +62,24 @@ func New(ctx context.Context, projectID string) (Client, error) {
 		return nil, fmt.Errorf("messaging client: %w", err)
 	}
 	return &client{msg: m}, nil
+}
+
+// noopClient drops every send with a warning. It is the fail-open fallback for
+// environments without Firebase credentials (local/dev), so the worker still
+// runs end-to-end without Firebase; production wires a real fcm.New client (and
+// startup treats a missing client as fatal). A richer local stub — one that
+// records sends for inspection — is tracked separately (#525).
+type noopClient struct{ logger *slog.Logger }
+
+// NewNoop returns an FCM client that drops sends, logging each at warn level.
+func NewNoop(logger *slog.Logger) Client { return noopClient{logger: logger} }
+
+func (n noopClient) Send(_ context.Context, tokens []string, m Message) (SendResult, error) {
+	if n.logger != nil {
+		n.logger.Warn("FCM not configured; notification dropped",
+			"titleLocKey", m.TitleLocKey, "recipients", len(tokens))
+	}
+	return SendResult{}, nil
 }
 
 // buildMulticast builds a loc-key multicast message for Android and iOS. The

--- a/backend/internal/task/cursor.go
+++ b/backend/internal/task/cursor.go
@@ -1,0 +1,42 @@
+package task
+
+import (
+	"encoding/base64"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// cursor is an opaque keyset position over the (created_at DESC, id DESC) sort
+// used by the task and assignment listings. It is serialized as an opaque
+// base64 token the client echoes back as ?cursor=; clients must not parse it.
+type cursor struct {
+	CreatedAt time.Time
+	ID        string
+}
+
+// encodeCursor renders a keyset position as an opaque token.
+func encodeCursor(c cursor) string {
+	raw := c.CreatedAt.UTC().Format(time.RFC3339Nano) + "|" + c.ID
+	return base64.RawURLEncoding.EncodeToString([]byte(raw))
+}
+
+// decodeCursor parses an opaque token; an empty token means "from the start".
+func decodeCursor(token string) (cursor, bool, error) {
+	if token == "" {
+		return cursor{}, false, nil
+	}
+	raw, err := base64.RawURLEncoding.DecodeString(token)
+	if err != nil {
+		return cursor{}, false, fmt.Errorf("%w: malformed cursor", ErrValidation)
+	}
+	parts := strings.SplitN(string(raw), "|", 2)
+	if len(parts) != 2 {
+		return cursor{}, false, fmt.Errorf("%w: malformed cursor", ErrValidation)
+	}
+	ts, err := time.Parse(time.RFC3339Nano, parts[0])
+	if err != nil {
+		return cursor{}, false, fmt.Errorf("%w: malformed cursor", ErrValidation)
+	}
+	return cursor{CreatedAt: ts, ID: parts[1]}, true, nil
+}

--- a/backend/internal/task/cursor.go
+++ b/backend/internal/task/cursor.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"strings"
 	"time"
+
+	"github.com/google/uuid"
 )
 
 // cursor is an opaque keyset position over the (created_at DESC, id DESC) sort
@@ -36,6 +38,11 @@ func decodeCursor(token string) (cursor, bool, error) {
 	}
 	ts, err := time.Parse(time.RFC3339Nano, parts[0])
 	if err != nil {
+		return cursor{}, false, fmt.Errorf("%w: malformed cursor", ErrValidation)
+	}
+	// The id is bound to a uuid comparison in the keyset query; validate it here
+	// so a crafted cursor is a 400, not a 500 from a Postgres uuid-syntax error.
+	if uuid.Validate(parts[1]) != nil {
 		return cursor{}, false, fmt.Errorf("%w: malformed cursor", ErrValidation)
 	}
 	return cursor{CreatedAt: ts, ID: parts[1]}, true, nil

--- a/backend/internal/task/domain.go
+++ b/backend/internal/task/domain.go
@@ -20,18 +20,46 @@ var (
 	ErrValidation = errors.New("task: validation failed")
 )
 
+// PublicProfile is the minimal display projection of a user (username + avatar),
+// embedded in Task responses for the tasker and each matched referee. It is the
+// Phase-3a-deferred shared projection, not the owner's editable profile.
+type PublicProfile struct {
+	UserID    string
+	Username  string
+	AvatarURL *string
+}
+
+// RefereeRequest is one seat on a task, as carried in the Task wire object. The
+// embedded Referee profile is set only once the seat is matched.
+type RefereeRequest struct {
+	ID               string
+	TaskID           string
+	Status           string
+	MatchedRefereeID *string
+	RespondedAt      *time.Time
+	PointSource      *string
+	IsObligation     bool
+	CreatedAt        time.Time
+	UpdatedAt        time.Time
+	Referee          *PublicProfile
+}
+
 // Task is a tasker-authored task. Description/Criteria/DueDate are nil until the
-// tasker fills them in; publishing requires Criteria and DueDate.
+// tasker fills them in; publishing requires Criteria and DueDate. Tasker is the
+// embedded public profile of the author (nil if the author was deleted);
+// RefereeRequests are the task's seats (empty for a draft).
 type Task struct {
-	ID          string
-	TaskerID    string
-	Title       string
-	Description *string
-	Criteria    *string
-	DueDate     *time.Time
-	Status      string
-	CreatedAt   time.Time
-	UpdatedAt   time.Time
+	ID              string
+	TaskerID        string
+	Title           string
+	Description     *string
+	Criteria        *string
+	DueDate         *time.Time
+	Status          string
+	CreatedAt       time.Time
+	UpdatedAt       time.Time
+	Tasker          *PublicProfile
+	RefereeRequests []RefereeRequest
 }
 
 // ValidateOpenRequirements enforces the rules for the draft->open transition

--- a/backend/internal/task/domain.go
+++ b/backend/internal/task/domain.go
@@ -1,0 +1,53 @@
+// Package task owns tasker-authored tasks: draft CRUD and the draft->open
+// publish transition. A task starts as a draft the tasker can edit or delete;
+// publishing validates the open requirements, flips it to open, and (via the
+// matching feature) creates its referee requests atomically. IDs are strings to
+// match the codebase's internal identifier convention; the columns are uuid.
+package task
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// Use-case errors the handler maps to HTTP status codes.
+var (
+	ErrNotFound   = errors.New("task: not found")
+	ErrForbidden  = errors.New("task: not the owner")
+	ErrConflict   = errors.New("task: state conflict")
+	ErrValidation = errors.New("task: validation failed")
+)
+
+// Task is a tasker-authored task. Description/Criteria/DueDate are nil until the
+// tasker fills them in; publishing requires Criteria and DueDate.
+type Task struct {
+	ID          string
+	TaskerID    string
+	Title       string
+	Description *string
+	Criteria    *string
+	DueDate     *time.Time
+	Status      string
+	CreatedAt   time.Time
+	UpdatedAt   time.Time
+}
+
+// ValidateOpenRequirements enforces the rules for the draft->open transition
+// (porting the legacy validate_task_open_requirements minus the point-balance
+// check, which the PointLocker now owns): a non-empty title and criteria, and a
+// due date at least minLeadHours ahead of now (matching_config.open_deadline_hours).
+func ValidateOpenRequirements(t Task, minLeadHours int) error {
+	if strings.TrimSpace(t.Title) == "" {
+		return fmt.Errorf("%w: title required", ErrValidation)
+	}
+	if t.Criteria == nil || strings.TrimSpace(*t.Criteria) == "" {
+		return fmt.Errorf("%w: criteria required", ErrValidation)
+	}
+	minDue := time.Now().Add(time.Duration(minLeadHours) * time.Hour)
+	if t.DueDate == nil || !t.DueDate.After(minDue) {
+		return fmt.Errorf("%w: due_date must be at least %d hours from now", ErrValidation, minLeadHours)
+	}
+	return nil
+}

--- a/backend/internal/task/handler.go
+++ b/backend/internal/task/handler.go
@@ -1,0 +1,230 @@
+package task
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/cloveclovedev/peppercheck/backend/internal/core/httpserver"
+	"github.com/cloveclovedev/peppercheck/backend/internal/identity"
+)
+
+// Handler serves the task HTTP surface, scoped to the authenticated caller.
+type Handler struct {
+	svc *Service
+}
+
+// NewHandler builds a Handler over the task service.
+func NewHandler(svc *Service) *Handler { return &Handler{svc: svc} }
+
+// --- DTOs -----------------------------------------------------------------
+
+type taskDTO struct {
+	ID          string  `json:"id"`
+	TaskerID    string  `json:"taskerId"`
+	Title       string  `json:"title"`
+	Description *string `json:"description"`
+	Criteria    *string `json:"criteria"`
+	DueDate     *string `json:"dueDate"`
+	Status      string  `json:"status"`
+	CreatedAt   string  `json:"createdAt"`
+	UpdatedAt   string  `json:"updatedAt"`
+}
+
+func toDTO(t Task) taskDTO {
+	dto := taskDTO{
+		ID:          t.ID,
+		TaskerID:    t.TaskerID,
+		Title:       t.Title,
+		Description: t.Description,
+		Criteria:    t.Criteria,
+		Status:      t.Status,
+		CreatedAt:   t.CreatedAt.UTC().Format(time.RFC3339),
+		UpdatedAt:   t.UpdatedAt.UTC().Format(time.RFC3339),
+	}
+	if t.DueDate != nil {
+		s := t.DueDate.UTC().Format(time.RFC3339)
+		dto.DueDate = &s
+	}
+	return dto
+}
+
+type taskRequest struct {
+	Title       string  `json:"title"`
+	Description *string `json:"description"`
+	Criteria    *string `json:"criteria"`
+	DueDate     *string `json:"dueDate"`
+}
+
+func (req taskRequest) toInput() (DraftInput, error) {
+	in := DraftInput{Title: req.Title, Description: req.Description, Criteria: req.Criteria}
+	if req.DueDate != nil {
+		due, err := time.Parse(time.RFC3339, *req.DueDate)
+		if err != nil {
+			return DraftInput{}, errors.Join(ErrValidation, err)
+		}
+		in.DueDate = &due
+	}
+	return in, nil
+}
+
+// --- handlers -------------------------------------------------------------
+
+// PostTask creates a draft owned by the caller.
+func (h *Handler) PostTask(w http.ResponseWriter, r *http.Request) {
+	u, ok := currentUser(w, r)
+	if !ok {
+		return
+	}
+	var req taskRequest
+	if !httpserver.DecodeJSON(w, r, &req) {
+		return
+	}
+	in, err := req.toInput()
+	if err != nil {
+		h.writeError(w, r, err)
+		return
+	}
+	t, err := h.svc.CreateDraft(r.Context(), u.ID, in)
+	if err != nil {
+		h.writeError(w, r, err)
+		return
+	}
+	writeJSON(w, http.StatusCreated, toDTO(t))
+}
+
+// GetTask returns a task the caller may read (owner or assigned referee).
+func (h *Handler) GetTask(w http.ResponseWriter, r *http.Request) {
+	u, ok := currentUser(w, r)
+	if !ok {
+		return
+	}
+	t, err := h.svc.GetReadable(r.Context(), u.ID, r.PathValue("id"))
+	if err != nil {
+		h.writeError(w, r, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, toDTO(t))
+}
+
+// PatchTask replaces the editable fields of a draft the caller owns.
+func (h *Handler) PatchTask(w http.ResponseWriter, r *http.Request) {
+	u, ok := currentUser(w, r)
+	if !ok {
+		return
+	}
+	var req taskRequest
+	if !httpserver.DecodeJSON(w, r, &req) {
+		return
+	}
+	in, err := req.toInput()
+	if err != nil {
+		h.writeError(w, r, err)
+		return
+	}
+	t, err := h.svc.UpdateDraft(r.Context(), u.ID, r.PathValue("id"), in)
+	if err != nil {
+		h.writeError(w, r, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, toDTO(t))
+}
+
+// DeleteTask removes a draft the caller owns.
+func (h *Handler) DeleteTask(w http.ResponseWriter, r *http.Request) {
+	u, ok := currentUser(w, r)
+	if !ok {
+		return
+	}
+	if err := h.svc.DeleteDraft(r.Context(), u.ID, r.PathValue("id")); err != nil {
+		h.writeError(w, r, err)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// GetMyTasks lists the caller's tasks, optionally filtered by ?status= with
+// ?limit=/?offset= paging (defaults: 50 / 0, capped at 100).
+func (h *Handler) GetMyTasks(w http.ResponseWriter, r *http.Request) {
+	u, ok := currentUser(w, r)
+	if !ok {
+		return
+	}
+	q := r.URL.Query()
+	p := ListParams{
+		Status: q.Get("status"),
+		Limit:  clampInt(atoiOr(q.Get("limit"), 50), 1, 100),
+		Offset: maxInt(atoiOr(q.Get("offset"), 0), 0),
+	}
+	tasks, err := h.svc.ListOwned(r.Context(), u.ID, p)
+	if err != nil {
+		h.writeError(w, r, err)
+		return
+	}
+	out := make([]taskDTO, 0, len(tasks))
+	for _, t := range tasks {
+		out = append(out, toDTO(t))
+	}
+	writeJSON(w, http.StatusOK, out)
+}
+
+// --- helpers --------------------------------------------------------------
+
+func currentUser(w http.ResponseWriter, r *http.Request) (identity.User, bool) {
+	u, ok := identity.CurrentUser(r.Context())
+	if !ok {
+		httpserver.WriteError(w, r, http.StatusUnauthorized, httpserver.CodeUnauthenticated, "missing user")
+	}
+	return u, ok
+}
+
+func (h *Handler) writeError(w http.ResponseWriter, r *http.Request, err error) {
+	switch {
+	case errors.Is(err, ErrNotFound):
+		httpserver.WriteError(w, r, http.StatusNotFound, httpserver.CodeNotFound, "not found")
+	case errors.Is(err, ErrForbidden):
+		httpserver.WriteError(w, r, http.StatusForbidden, httpserver.CodeForbidden, "not allowed")
+	case errors.Is(err, ErrConflict):
+		httpserver.WriteError(w, r, http.StatusConflict, httpserver.CodeConflict, "task state conflict")
+	case errors.Is(err, ErrValidation):
+		httpserver.WriteError(w, r, http.StatusBadRequest, httpserver.CodeInvalidArgument, "invalid argument")
+	default:
+		httpserver.WriteError(w, r, http.StatusInternalServerError, httpserver.CodeInternal, "internal error")
+	}
+}
+
+func writeJSON(w http.ResponseWriter, status int, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(v)
+}
+
+func atoiOr(s string, def int) int {
+	if s == "" {
+		return def
+	}
+	n, err := strconv.Atoi(s)
+	if err != nil {
+		return def
+	}
+	return n
+}
+
+func clampInt(v, lo, hi int) int {
+	if v < lo {
+		return lo
+	}
+	if v > hi {
+		return hi
+	}
+	return v
+}
+
+func maxInt(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}

--- a/backend/internal/task/handler.go
+++ b/backend/internal/task/handler.go
@@ -170,6 +170,28 @@ func (h *Handler) GetMyTasks(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, out)
 }
 
+type publishRequest struct {
+	RefereeCount int `json:"refereeCount"`
+}
+
+// PostPublish opens a draft the caller owns and creates its referee requests.
+func (h *Handler) PostPublish(w http.ResponseWriter, r *http.Request) {
+	u, ok := currentUser(w, r)
+	if !ok {
+		return
+	}
+	var req publishRequest
+	if !httpserver.DecodeJSON(w, r, &req) {
+		return
+	}
+	t, err := h.svc.Publish(r.Context(), u.ID, r.PathValue("id"), req.RefereeCount)
+	if err != nil {
+		h.writeError(w, r, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, toDTO(t))
+}
+
 // --- helpers --------------------------------------------------------------
 
 func currentUser(w http.ResponseWriter, r *http.Request) (identity.User, bool) {

--- a/backend/internal/task/handler.go
+++ b/backend/internal/task/handler.go
@@ -3,6 +3,7 @@ package task
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"strconv"
 	"time"
@@ -13,7 +14,10 @@ import (
 	"github.com/cloveclovedev/peppercheck/backend/internal/identity"
 )
 
-// Handler serves the task HTTP surface, scoped to the authenticated caller.
+const defaultPageLimit = 20
+
+// Handler serves the task HTTP surface (the §7.1 wire contract), scoped to the
+// authenticated caller.
 type Handler struct {
 	svc *Service
 }
@@ -21,44 +25,127 @@ type Handler struct {
 // NewHandler builds a Handler over the task service.
 func NewHandler(svc *Service) *Handler { return &Handler{svc: svc} }
 
-// --- DTOs -----------------------------------------------------------------
+// --- DTOs (§7.1) ----------------------------------------------------------
+
+type publicProfileDTO struct {
+	UserID    string  `json:"userId"`
+	Username  string  `json:"username"`
+	AvatarURL *string `json:"avatarUrl"`
+}
+
+func toProfileDTO(p *PublicProfile) *publicProfileDTO {
+	if p == nil {
+		return nil
+	}
+	return &publicProfileDTO{UserID: p.UserID, Username: p.Username, AvatarURL: p.AvatarURL}
+}
+
+type refereeRequestDTO struct {
+	ID               string            `json:"id"`
+	TaskID           string            `json:"taskId"`
+	Status           string            `json:"status"`
+	MatchedRefereeID *string           `json:"matchedRefereeId"`
+	RespondedAt      *string           `json:"respondedAt"`
+	PointSource      *string           `json:"pointSource"`
+	IsObligation     bool              `json:"isObligation"`
+	CreatedAt        string            `json:"createdAt"`
+	UpdatedAt        string            `json:"updatedAt"`
+	Referee          *publicProfileDTO `json:"referee"`
+}
 
 type taskDTO struct {
-	ID          string  `json:"id"`
-	Title       string  `json:"title"`
-	Description *string `json:"description"`
-	Criteria    *string `json:"criteria"`
-	DueDate     *string `json:"dueDate"`
-	Status      string  `json:"status"`
-	CreatedAt   string  `json:"createdAt"`
-	UpdatedAt   string  `json:"updatedAt"`
+	ID              string              `json:"id"`
+	TaskerID        string              `json:"taskerId"`
+	Title           string              `json:"title"`
+	Description     *string             `json:"description"`
+	Criteria        *string             `json:"criteria"`
+	DueDate         *string             `json:"dueDate"`
+	Status          string              `json:"status"`
+	CreatedAt       string              `json:"createdAt"`
+	UpdatedAt       string              `json:"updatedAt"`
+	Tasker          *publicProfileDTO   `json:"tasker"`
+	RefereeRequests []refereeRequestDTO `json:"refereeRequests"`
+}
+
+func rfc3339Ptr(t *time.Time) *string {
+	if t == nil {
+		return nil
+	}
+	s := t.UTC().Format(time.RFC3339)
+	return &s
 }
 
 func toDTO(t Task) taskDTO {
-	dto := taskDTO{
-		ID:          t.ID,
-		Title:       t.Title,
-		Description: t.Description,
-		Criteria:    t.Criteria,
-		Status:      t.Status,
-		CreatedAt:   t.CreatedAt.UTC().Format(time.RFC3339),
-		UpdatedAt:   t.UpdatedAt.UTC().Format(time.RFC3339),
+	reqs := make([]refereeRequestDTO, 0, len(t.RefereeRequests))
+	for _, r := range t.RefereeRequests {
+		reqs = append(reqs, refereeRequestDTO{
+			ID:               r.ID,
+			TaskID:           r.TaskID,
+			Status:           r.Status,
+			MatchedRefereeID: r.MatchedRefereeID,
+			RespondedAt:      rfc3339Ptr(r.RespondedAt),
+			PointSource:      r.PointSource,
+			IsObligation:     r.IsObligation,
+			CreatedAt:        r.CreatedAt.UTC().Format(time.RFC3339),
+			UpdatedAt:        r.UpdatedAt.UTC().Format(time.RFC3339),
+			Referee:          toProfileDTO(r.Referee),
+		})
 	}
-	if t.DueDate != nil {
-		s := t.DueDate.UTC().Format(time.RFC3339)
-		dto.DueDate = &s
+	return taskDTO{
+		ID:              t.ID,
+		TaskerID:        t.TaskerID,
+		Title:           t.Title,
+		Description:     t.Description,
+		Criteria:        t.Criteria,
+		DueDate:         rfc3339Ptr(t.DueDate),
+		Status:          t.Status,
+		CreatedAt:       t.CreatedAt.UTC().Format(time.RFC3339),
+		UpdatedAt:       t.UpdatedAt.UTC().Format(time.RFC3339),
+		Tasker:          toProfileDTO(t.Tasker),
+		RefereeRequests: reqs,
 	}
-	return dto
 }
 
-type taskRequest struct {
+func nextCursorPtr(s string) *string {
+	if s == "" {
+		return nil
+	}
+	return &s
+}
+
+type tasksPageDTO struct {
+	Tasks      []taskDTO `json:"tasks"`
+	NextCursor *string   `json:"nextCursor"`
+}
+
+type assignmentsPageDTO struct {
+	Assignments []taskDTO `json:"assignments"`
+	NextCursor  *string   `json:"nextCursor"`
+}
+
+func toTaskDTOs(tasks []Task) []taskDTO {
+	out := make([]taskDTO, 0, len(tasks))
+	for _, t := range tasks {
+		out = append(out, toDTO(t))
+	}
+	return out
+}
+
+// TaskResponse renders a Task as its §7.1 wire object, for cross-feature
+// handlers that must return a Task (e.g. matching's cancel endpoint) without
+// re-implementing the DTO.
+func TaskResponse(t Task) any { return toDTO(t) }
+
+// --- request bodies -------------------------------------------------------
+
+type createTaskRequest struct {
 	Title       string  `json:"title"`
 	Description *string `json:"description"`
 	Criteria    *string `json:"criteria"`
 	DueDate     *string `json:"dueDate"`
 }
 
-func (req taskRequest) toInput() (DraftInput, error) {
+func (req createTaskRequest) toInput() (DraftInput, error) {
 	in := DraftInput{Title: req.Title, Description: req.Description, Criteria: req.Criteria}
 	if req.DueDate != nil {
 		due, err := time.Parse(time.RFC3339, *req.DueDate)
@@ -78,7 +165,7 @@ func (h *Handler) PostTask(w http.ResponseWriter, r *http.Request) {
 	if !ok {
 		return
 	}
-	var req taskRequest
+	var req createTaskRequest
 	if !httpserver.DecodeJSON(w, r, &req) {
 		return
 	}
@@ -113,7 +200,7 @@ func (h *Handler) GetTask(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, toDTO(t))
 }
 
-// PatchTask replaces the editable fields of a draft the caller owns.
+// PatchTask applies a presence-aware partial update to a draft the caller owns.
 func (h *Handler) PatchTask(w http.ResponseWriter, r *http.Request) {
 	u, ok := currentUser(w, r)
 	if !ok {
@@ -123,16 +210,12 @@ func (h *Handler) PatchTask(w http.ResponseWriter, r *http.Request) {
 	if !ok {
 		return
 	}
-	var req taskRequest
-	if !httpserver.DecodeJSON(w, r, &req) {
-		return
-	}
-	in, err := req.toInput()
+	patch, err := decodePatch(r)
 	if err != nil {
 		h.writeError(w, r, err)
 		return
 	}
-	t, err := h.svc.UpdateDraft(r.Context(), u.ID, id, in)
+	t, err := h.svc.UpdateDraft(r.Context(), u.ID, id, patch)
 	if err != nil {
 		h.writeError(w, r, err)
 		return
@@ -157,29 +240,34 @@ func (h *Handler) DeleteTask(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusNoContent)
 }
 
-// GetMyTasks lists the caller's tasks, optionally filtered by ?status= with
-// ?limit=/?offset= paging (defaults: 50 / 0, capped at 100).
+// GetMyTasks lists the caller's tasks as a cursor page (?status=&cursor=&limit=).
 func (h *Handler) GetMyTasks(w http.ResponseWriter, r *http.Request) {
 	u, ok := currentUser(w, r)
 	if !ok {
 		return
 	}
 	q := r.URL.Query()
-	p := ListParams{
-		Status: q.Get("status"),
-		Limit:  clampInt(atoiOr(q.Get("limit"), 50), 1, 100),
-		Offset: max(atoiOr(q.Get("offset"), 0), 0),
-	}
-	tasks, err := h.svc.ListOwned(r.Context(), u.ID, p)
+	page, err := h.svc.ListOwned(r.Context(), u.ID, q.Get("status"), q.Get("cursor"), pageLimit(q.Get("limit")))
 	if err != nil {
 		h.writeError(w, r, err)
 		return
 	}
-	out := make([]taskDTO, 0, len(tasks))
-	for _, t := range tasks {
-		out = append(out, toDTO(t))
+	writeJSON(w, http.StatusOK, tasksPageDTO{Tasks: toTaskDTOs(page.Tasks), NextCursor: nextCursorPtr(page.NextCursor)})
+}
+
+// GetAssignments lists the tasks the caller referees as a cursor page.
+func (h *Handler) GetAssignments(w http.ResponseWriter, r *http.Request) {
+	u, ok := currentUser(w, r)
+	if !ok {
+		return
 	}
-	writeJSON(w, http.StatusOK, out)
+	q := r.URL.Query()
+	page, err := h.svc.Assignments(r.Context(), u.ID, q.Get("cursor"), pageLimit(q.Get("limit")))
+	if err != nil {
+		h.writeError(w, r, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, assignmentsPageDTO{Assignments: toTaskDTOs(page.Tasks), NextCursor: nextCursorPtr(page.NextCursor)})
 }
 
 type publishRequest struct {
@@ -210,6 +298,54 @@ func (h *Handler) PostPublish(w http.ResponseWriter, r *http.Request) {
 
 // --- helpers --------------------------------------------------------------
 
+// decodePatch parses a presence-aware PATCH body: only the keys present in the
+// JSON are marked for update, so an omitted field is untouched while an explicit
+// null clears a nullable field. Unknown keys and a malformed dueDate are 400.
+func decodePatch(r *http.Request) (PatchInput, error) {
+	var raw map[string]json.RawMessage
+	dec := json.NewDecoder(r.Body)
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&raw); err != nil {
+		return PatchInput{}, fmt.Errorf("%w: invalid request body", ErrValidation)
+	}
+	var p PatchInput
+	for k, v := range raw {
+		switch k {
+		case "title":
+			p.SetTitle = true
+			if err := json.Unmarshal(v, &p.Title); err != nil {
+				return PatchInput{}, fmt.Errorf("%w: title", ErrValidation)
+			}
+		case "description":
+			p.SetDesc = true
+			if err := json.Unmarshal(v, &p.Description); err != nil {
+				return PatchInput{}, fmt.Errorf("%w: description", ErrValidation)
+			}
+		case "criteria":
+			p.SetCriteria = true
+			if err := json.Unmarshal(v, &p.Criteria); err != nil {
+				return PatchInput{}, fmt.Errorf("%w: criteria", ErrValidation)
+			}
+		case "dueDate":
+			p.SetDueDate = true
+			var s *string
+			if err := json.Unmarshal(v, &s); err != nil {
+				return PatchInput{}, fmt.Errorf("%w: dueDate", ErrValidation)
+			}
+			if s != nil {
+				due, err := time.Parse(time.RFC3339, *s)
+				if err != nil {
+					return PatchInput{}, fmt.Errorf("%w: dueDate must be RFC3339", ErrValidation)
+				}
+				p.DueDate = &due
+			}
+		default:
+			return PatchInput{}, fmt.Errorf("%w: unknown field %q", ErrValidation, k)
+		}
+	}
+	return p, nil
+}
+
 func currentUser(w http.ResponseWriter, r *http.Request) (identity.User, bool) {
 	u, ok := identity.CurrentUser(r.Context())
 	if !ok {
@@ -219,8 +355,7 @@ func currentUser(w http.ResponseWriter, r *http.Request) (identity.User, bool) {
 }
 
 // pathID reads and validates the {id} path parameter as a UUID, rejecting a
-// malformed id as a 400 before it reaches a uuid-typed query (which would
-// otherwise surface as a 500 invalid-text-representation error).
+// malformed id as a 400 before it reaches a uuid-typed query.
 func pathID(w http.ResponseWriter, r *http.Request) (string, bool) {
 	id := r.PathValue("id")
 	if uuid.Validate(id) != nil {
@@ -251,17 +386,14 @@ func writeJSON(w http.ResponseWriter, status int, v any) {
 	_ = json.NewEncoder(w).Encode(v)
 }
 
-func atoiOr(s string, def int) int {
+// pageLimit parses ?limit= with a default of 20, clamped to 1..100.
+func pageLimit(s string) int {
 	if s == "" {
-		return def
+		return defaultPageLimit
 	}
 	n, err := strconv.Atoi(s)
 	if err != nil {
-		return def
+		return defaultPageLimit
 	}
-	return n
-}
-
-func clampInt(v, lo, hi int) int {
-	return min(max(v, lo), hi)
+	return min(max(n, 1), 100)
 }

--- a/backend/internal/task/handler.go
+++ b/backend/internal/task/handler.go
@@ -7,6 +7,8 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/google/uuid"
+
 	"github.com/cloveclovedev/peppercheck/backend/internal/core/httpserver"
 	"github.com/cloveclovedev/peppercheck/backend/internal/identity"
 )
@@ -99,7 +101,11 @@ func (h *Handler) GetTask(w http.ResponseWriter, r *http.Request) {
 	if !ok {
 		return
 	}
-	t, err := h.svc.GetReadable(r.Context(), u.ID, r.PathValue("id"))
+	id, ok := pathID(w, r)
+	if !ok {
+		return
+	}
+	t, err := h.svc.GetReadable(r.Context(), u.ID, id)
 	if err != nil {
 		h.writeError(w, r, err)
 		return
@@ -113,6 +119,10 @@ func (h *Handler) PatchTask(w http.ResponseWriter, r *http.Request) {
 	if !ok {
 		return
 	}
+	id, ok := pathID(w, r)
+	if !ok {
+		return
+	}
 	var req taskRequest
 	if !httpserver.DecodeJSON(w, r, &req) {
 		return
@@ -122,7 +132,7 @@ func (h *Handler) PatchTask(w http.ResponseWriter, r *http.Request) {
 		h.writeError(w, r, err)
 		return
 	}
-	t, err := h.svc.UpdateDraft(r.Context(), u.ID, r.PathValue("id"), in)
+	t, err := h.svc.UpdateDraft(r.Context(), u.ID, id, in)
 	if err != nil {
 		h.writeError(w, r, err)
 		return
@@ -136,7 +146,11 @@ func (h *Handler) DeleteTask(w http.ResponseWriter, r *http.Request) {
 	if !ok {
 		return
 	}
-	if err := h.svc.DeleteDraft(r.Context(), u.ID, r.PathValue("id")); err != nil {
+	id, ok := pathID(w, r)
+	if !ok {
+		return
+	}
+	if err := h.svc.DeleteDraft(r.Context(), u.ID, id); err != nil {
 		h.writeError(w, r, err)
 		return
 	}
@@ -178,11 +192,15 @@ func (h *Handler) PostPublish(w http.ResponseWriter, r *http.Request) {
 	if !ok {
 		return
 	}
+	id, ok := pathID(w, r)
+	if !ok {
+		return
+	}
 	var req publishRequest
 	if !httpserver.DecodeJSON(w, r, &req) {
 		return
 	}
-	t, err := h.svc.Publish(r.Context(), u.ID, r.PathValue("id"), req.RefereeCount)
+	t, err := h.svc.Publish(r.Context(), u.ID, id, req.RefereeCount)
 	if err != nil {
 		h.writeError(w, r, err)
 		return
@@ -198,6 +216,18 @@ func currentUser(w http.ResponseWriter, r *http.Request) (identity.User, bool) {
 		httpserver.WriteError(w, r, http.StatusUnauthorized, httpserver.CodeUnauthenticated, "missing user")
 	}
 	return u, ok
+}
+
+// pathID reads and validates the {id} path parameter as a UUID, rejecting a
+// malformed id as a 400 before it reaches a uuid-typed query (which would
+// otherwise surface as a 500 invalid-text-representation error).
+func pathID(w http.ResponseWriter, r *http.Request) (string, bool) {
+	id := r.PathValue("id")
+	if uuid.Validate(id) != nil {
+		httpserver.WriteError(w, r, http.StatusBadRequest, httpserver.CodeInvalidArgument, "invalid id")
+		return "", false
+	}
+	return id, true
 }
 
 func (h *Handler) writeError(w http.ResponseWriter, r *http.Request, err error) {

--- a/backend/internal/task/handler.go
+++ b/backend/internal/task/handler.go
@@ -23,7 +23,6 @@ func NewHandler(svc *Service) *Handler { return &Handler{svc: svc} }
 
 type taskDTO struct {
 	ID          string  `json:"id"`
-	TaskerID    string  `json:"taskerId"`
 	Title       string  `json:"title"`
 	Description *string `json:"description"`
 	Criteria    *string `json:"criteria"`
@@ -36,7 +35,6 @@ type taskDTO struct {
 func toDTO(t Task) taskDTO {
 	dto := taskDTO{
 		ID:          t.ID,
-		TaskerID:    t.TaskerID,
 		Title:       t.Title,
 		Description: t.Description,
 		Criteria:    t.Criteria,
@@ -156,7 +154,7 @@ func (h *Handler) GetMyTasks(w http.ResponseWriter, r *http.Request) {
 	p := ListParams{
 		Status: q.Get("status"),
 		Limit:  clampInt(atoiOr(q.Get("limit"), 50), 1, 100),
-		Offset: maxInt(atoiOr(q.Get("offset"), 0), 0),
+		Offset: max(atoiOr(q.Get("offset"), 0), 0),
 	}
 	tasks, err := h.svc.ListOwned(r.Context(), u.ID, p)
 	if err != nil {
@@ -235,18 +233,5 @@ func atoiOr(s string, def int) int {
 }
 
 func clampInt(v, lo, hi int) int {
-	if v < lo {
-		return lo
-	}
-	if v > hi {
-		return hi
-	}
-	return v
-}
-
-func maxInt(a, b int) int {
-	if a > b {
-		return a
-	}
-	return b
+	return min(max(v, lo), hi)
 }

--- a/backend/internal/task/publish_test.go
+++ b/backend/internal/task/publish_test.go
@@ -1,0 +1,187 @@
+package task_test
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/cloveclovedev/peppercheck/backend/internal/core/database"
+	"github.com/cloveclovedev/peppercheck/backend/internal/core/jobs"
+	"github.com/cloveclovedev/peppercheck/backend/internal/judgement"
+	"github.com/cloveclovedev/peppercheck/backend/internal/matching"
+	"github.com/cloveclovedev/peppercheck/backend/internal/task"
+	"github.com/cloveclovedev/peppercheck/backend/internal/testsupport"
+)
+
+// noopNotifier satisfies matching's notifier interface; publish enqueues match
+// jobs but sends no notifications, so it is never called here.
+type noopNotifier struct{}
+
+func (noopNotifier) EnqueueInTx(context.Context, database.Querier, string, string, []string, map[string]string) error {
+	return nil
+}
+func (noopNotifier) EnqueueIdempotentInTx(context.Context, database.Querier, string, string, []string, map[string]string, string) error {
+	return nil
+}
+
+// realMatchingCreator wires a matching.Service with no-op seams as the publish
+// creator.
+func realMatchingCreator(db *sql.DB) *matching.Service {
+	return matching.NewService(
+		db, matching.NewStore(db),
+		matching.NewNoopPointLocker(), matching.NewNoObligations(),
+		judgement.NewProvisioner(), noopNotifier{}, jobs.NewStore(db),
+	)
+}
+
+// seedDraftReady creates a publish-ready draft (title, criteria, due 48h out)
+// owned by a fresh user; returns task id and tasker id.
+func seedDraftReady(t *testing.T, db *sql.DB, svc *task.Service) (taskID, taskerID string) {
+	t.Helper()
+	taskerID = newUser(t, db)
+	due := time.Now().Add(48 * time.Hour)
+	created, err := svc.CreateDraft(context.Background(), taskerID,
+		task.DraftInput{Title: "Wash the car", Criteria: ptr("photo of a clean car"), DueDate: &due})
+	if err != nil {
+		t.Fatalf("seed draft: %v", err)
+	}
+	return created.ID, taskerID
+}
+
+func countRequests(t *testing.T, db *sql.DB, taskID string) int {
+	t.Helper()
+	var n int
+	if err := db.QueryRow(`SELECT count(*) FROM public.referee_requests WHERE task_id=$1`, taskID).Scan(&n); err != nil {
+		t.Fatalf("count requests: %v", err)
+	}
+	return n
+}
+
+func countMatchJobsForTask(t *testing.T, db *sql.DB, taskID string) int {
+	t.Helper()
+	var n int
+	if err := db.QueryRow(
+		`SELECT count(*) FROM public.jobs
+		 WHERE kind='match_referee_request'
+		   AND payload->>'requestId' IN (SELECT id::text FROM public.referee_requests WHERE task_id=$1)`,
+		taskID).Scan(&n); err != nil {
+		t.Fatalf("count match jobs: %v", err)
+	}
+	return n
+}
+
+func TestPublishOpensTaskAndCreatesRequestsAtomically(t *testing.T) {
+	db := testsupport.DB(t)
+	svc := task.NewService(db, task.NewStore(db), realMatchingCreator(db))
+	taskID, taskerID := seedDraftReady(t, db, svc)
+
+	out, err := svc.Publish(context.Background(), taskerID, taskID, 2)
+	if err != nil {
+		t.Fatalf("publish: %v", err)
+	}
+	if out.Status != "open" {
+		t.Fatalf("want open, got %s", out.Status)
+	}
+	if got := countRequests(t, db, taskID); got != 2 {
+		t.Fatalf("want 2 requests, got %d", got)
+	}
+	if got := countMatchJobsForTask(t, db, taskID); got != 2 {
+		t.Fatalf("want 2 match jobs, got %d", got)
+	}
+}
+
+func TestPublishRollsBackWhenCreatorFails(t *testing.T) {
+	db := testsupport.DB(t)
+	// The service used to seed a ready draft uses the real creator; the service
+	// under test uses a failing creator so publish rolls the open + requests back.
+	seedSvc := task.NewService(db, task.NewStore(db), realMatchingCreator(db))
+	taskID, taskerID := seedDraftReady(t, db, seedSvc)
+
+	failing := task.NewService(db, task.NewStore(db), failingCreator{})
+	if _, err := failing.Publish(context.Background(), taskerID, taskID, 2); err == nil {
+		t.Fatal("want publish error from the creator")
+	}
+	// Task stays draft; no requests, no jobs.
+	var status string
+	_ = db.QueryRow(`SELECT status FROM public.tasks WHERE id=$1`, taskID).Scan(&status)
+	if status != "draft" {
+		t.Fatalf("want task rolled back to draft, got %s", status)
+	}
+	if got := countRequests(t, db, taskID); got != 0 {
+		t.Fatalf("want no requests after rollback, got %d", got)
+	}
+}
+
+type failingCreator struct{}
+
+func (failingCreator) PublishBounds(context.Context) (int, int, error) { return 24, 2, nil }
+func (failingCreator) CreateInTx(context.Context, database.Querier, string, string, int) error {
+	return errors.New("creator boom")
+}
+
+func TestPublishRejectsInvalidCount(t *testing.T) {
+	db := testsupport.DB(t)
+	svc := task.NewService(db, task.NewStore(db), realMatchingCreator(db))
+	taskID, taskerID := seedDraftReady(t, db, svc)
+
+	if _, err := svc.Publish(context.Background(), taskerID, taskID, 0); !errors.Is(err, task.ErrValidation) {
+		t.Fatalf("count 0: want ErrValidation, got %v", err)
+	}
+	if _, err := svc.Publish(context.Background(), taskerID, taskID, 99); !errors.Is(err, task.ErrValidation) {
+		t.Fatalf("count over max: want ErrValidation, got %v", err)
+	}
+	assertDraft(t, db, taskID)
+}
+
+func TestPublishRejectsMissingCriteria(t *testing.T) {
+	db := testsupport.DB(t)
+	svc := task.NewService(db, task.NewStore(db), realMatchingCreator(db))
+	taskerID := newUser(t, db)
+	due := time.Now().Add(48 * time.Hour)
+	created, _ := svc.CreateDraft(context.Background(), taskerID, task.DraftInput{Title: "no criteria", DueDate: &due})
+
+	if _, err := svc.Publish(context.Background(), taskerID, created.ID, 1); !errors.Is(err, task.ErrValidation) {
+		t.Fatalf("missing criteria: want ErrValidation, got %v", err)
+	}
+	assertDraft(t, db, created.ID)
+}
+
+func TestPublishRejectsNonOwnerAndNonDraft(t *testing.T) {
+	db := testsupport.DB(t)
+	svc := task.NewService(db, task.NewStore(db), realMatchingCreator(db))
+	taskID, _ := seedDraftReady(t, db, svc)
+
+	stranger := newUser(t, db)
+	if _, err := svc.Publish(context.Background(), stranger, taskID, 1); !errors.Is(err, task.ErrNotFound) {
+		t.Fatalf("non-owner: want ErrNotFound, got %v", err)
+	}
+
+	// Publish once, then a second publish conflicts (already open).
+	owner := ownerOf(t, db, taskID)
+	if _, err := svc.Publish(context.Background(), owner, taskID, 1); err != nil {
+		t.Fatalf("first publish: %v", err)
+	}
+	if _, err := svc.Publish(context.Background(), owner, taskID, 1); !errors.Is(err, task.ErrConflict) {
+		t.Fatalf("re-publish: want ErrConflict, got %v", err)
+	}
+}
+
+func assertDraft(t *testing.T, db *sql.DB, taskID string) {
+	t.Helper()
+	var status string
+	_ = db.QueryRow(`SELECT status FROM public.tasks WHERE id=$1`, taskID).Scan(&status)
+	if status != "draft" {
+		t.Fatalf("want task still draft, got %s", status)
+	}
+}
+
+func ownerOf(t *testing.T, db *sql.DB, taskID string) string {
+	t.Helper()
+	var owner string
+	if err := db.QueryRow(`SELECT tasker_id FROM public.tasks WHERE id=$1`, taskID).Scan(&owner); err != nil {
+		t.Fatalf("owner of: %v", err)
+	}
+	return owner
+}

--- a/backend/internal/task/publish_test.go
+++ b/backend/internal/task/publish_test.go
@@ -92,6 +92,24 @@ func TestPublishOpensTaskAndCreatesRequestsAtomically(t *testing.T) {
 	}
 }
 
+func TestPublishRefreshesUpdatedAt(t *testing.T) {
+	db := testsupport.DB(t)
+	svc := task.NewService(db, task.NewStore(db), realMatchingCreator(db))
+	taskID, taskerID := seedDraftReady(t, db, svc)
+
+	var draftUpdated time.Time
+	if err := db.QueryRow(`SELECT updated_at FROM public.tasks WHERE id=$1`, taskID).Scan(&draftUpdated); err != nil {
+		t.Fatalf("read draft updated_at: %v", err)
+	}
+	out, err := svc.Publish(context.Background(), taskerID, taskID, 1)
+	if err != nil {
+		t.Fatalf("publish: %v", err)
+	}
+	if !out.UpdatedAt.After(draftUpdated) {
+		t.Fatalf("publish response updatedAt %v not refreshed past draft's %v", out.UpdatedAt, draftUpdated)
+	}
+}
+
 func TestPublishRollsBackWhenCreatorFails(t *testing.T) {
 	db := testsupport.DB(t)
 	// The service used to seed a ready draft uses the real creator; the service

--- a/backend/internal/task/service.go
+++ b/backend/internal/task/service.go
@@ -132,14 +132,14 @@ func (s *Service) Publish(ctx context.Context, callerID, taskID string, refereeC
 		if err := ValidateOpenRequirements(t, minLead); err != nil {
 			return err
 		}
-		if err := s.store.SetStatusInTx(ctx, tx, taskID, "open"); err != nil {
+		opened, err := s.store.SetStatusInTx(ctx, tx, taskID, "open")
+		if err != nil {
 			return err
 		}
 		if err := s.requests.CreateInTx(ctx, tx, taskID, callerID, refereeCount); err != nil {
 			return err
 		}
-		t.Status = "open"
-		out = t
+		out = opened
 		return nil
 	})
 	return out, err

--- a/backend/internal/task/service.go
+++ b/backend/internal/task/service.go
@@ -1,0 +1,116 @@
+package task
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/cloveclovedev/peppercheck/backend/internal/core/database"
+)
+
+// RefereeRequestCreator creates a task's referee requests (and their match
+// jobs) inside the publish transaction, and reports the minimum publish lead
+// time. It is declared here (consumer-side) so the task feature stays
+// independent of the matching feature; matching.Service implements it.
+type RefereeRequestCreator interface {
+	CreateInTx(ctx context.Context, tx database.Querier, taskID, taskerID string, count int) error
+	OpenDeadlineHours(ctx context.Context) (int, error)
+}
+
+// Service is the task use case: draft CRUD (owner-scoped) and the publish
+// transition that opens a task and creates its referee requests atomically.
+type Service struct {
+	db       *database.Handle
+	store    *Store
+	requests RefereeRequestCreator
+}
+
+// NewService wires the task use case. requests is the matching-side creator used
+// only by Publish; draft CRUD does not touch it.
+func NewService(db *database.Handle, store *Store, requests RefereeRequestCreator) *Service {
+	return &Service{db: db, store: store, requests: requests}
+}
+
+// DraftInput is the editable field set of a draft. Description/Criteria/DueDate
+// are optional at the draft stage; publishing enforces criteria + due date.
+type DraftInput struct {
+	Title       string
+	Description *string
+	Criteria    *string
+	DueDate     *time.Time
+}
+
+// ListParams is the owner task listing filter + paging.
+type ListParams struct {
+	Status string // "" = any
+	Limit  int
+	Offset int
+}
+
+// CreateDraft creates a draft owned by taskerID.
+func (s *Service) CreateDraft(ctx context.Context, taskerID string, in DraftInput) (Task, error) {
+	if err := validateTitle(in.Title); err != nil {
+		return Task{}, err
+	}
+	return s.store.InsertDraft(ctx, taskerID, strings.TrimSpace(in.Title), in.Description, in.Criteria, in.DueDate)
+}
+
+// GetOwned returns a task the caller owns.
+func (s *Service) GetOwned(ctx context.Context, taskerID, taskID string) (Task, error) {
+	return s.store.GetOwned(ctx, taskID, taskerID)
+}
+
+// GetReadable returns a task the caller may read (owner or assigned referee).
+func (s *Service) GetReadable(ctx context.Context, userID, taskID string) (Task, error) {
+	return s.store.GetReadable(ctx, taskID, userID)
+}
+
+// ListOwned returns the caller's tasks.
+func (s *Service) ListOwned(ctx context.Context, taskerID string, p ListParams) ([]Task, error) {
+	return s.store.ListOwned(ctx, taskerID, p.Status, p.Limit, p.Offset)
+}
+
+// UpdateDraft replaces the editable fields of a draft the caller owns. A
+// non-draft task is ErrConflict; a missing/foreign id is ErrNotFound.
+func (s *Service) UpdateDraft(ctx context.Context, taskerID, taskID string, in DraftInput) (Task, error) {
+	if err := validateTitle(in.Title); err != nil {
+		return Task{}, err
+	}
+	var out Task
+	err := database.WithTx(ctx, s.db, func(tx database.Querier) error {
+		t, err := s.store.GetOwnedForUpdateInTx(ctx, tx, taskID, taskerID)
+		if err != nil {
+			return err
+		}
+		if t.Status != "draft" {
+			return ErrConflict
+		}
+		out, err = s.store.UpdateDraftFieldsInTx(ctx, tx, taskID,
+			strings.TrimSpace(in.Title), in.Description, in.Criteria, in.DueDate)
+		return err
+	})
+	return out, err
+}
+
+// DeleteDraft removes a draft the caller owns. A non-draft task is ErrConflict;
+// a missing/foreign id is ErrNotFound.
+func (s *Service) DeleteDraft(ctx context.Context, taskerID, taskID string) error {
+	return database.WithTx(ctx, s.db, func(tx database.Querier) error {
+		t, err := s.store.GetOwnedForUpdateInTx(ctx, tx, taskID, taskerID)
+		if err != nil {
+			return err
+		}
+		if t.Status != "draft" {
+			return ErrConflict
+		}
+		return s.store.DeleteInTx(ctx, tx, taskID)
+	})
+}
+
+func validateTitle(title string) error {
+	if strings.TrimSpace(title) == "" {
+		return fmt.Errorf("%w: title required", ErrValidation)
+	}
+	return nil
+}

--- a/backend/internal/task/service.go
+++ b/backend/internal/task/service.go
@@ -33,8 +33,9 @@ func NewService(db *database.Handle, store *Store, requests RefereeRequestCreato
 	return &Service{db: db, store: store, requests: requests}
 }
 
-// DraftInput is the editable field set of a draft. Description/Criteria/DueDate
-// are optional at the draft stage; publishing enforces criteria + due date.
+// DraftInput is the full editable field set for creating a draft.
+// Description/Criteria/DueDate are optional at the draft stage; publishing
+// enforces criteria + due date.
 type DraftInput struct {
 	Title       string
 	Description *string
@@ -42,56 +43,104 @@ type DraftInput struct {
 	DueDate     *time.Time
 }
 
-// ListParams is the owner task listing filter + paging.
-type ListParams struct {
-	Status string // "" = any
-	Limit  int
-	Offset int
+// PatchInput is a presence-aware partial update: each Set* flag records whether
+// the field appeared in the request body, so an omitted field is left unchanged
+// while an explicit null clears a nullable field.
+type PatchInput struct {
+	SetTitle    bool
+	Title       *string
+	SetDesc     bool
+	Description *string
+	SetCriteria bool
+	Criteria    *string
+	SetDueDate  bool
+	DueDate     *time.Time
 }
 
-// CreateDraft creates a draft owned by taskerID.
+// Page is a cursor page of tasks with the next opaque cursor ("" when exhausted).
+type Page struct {
+	Tasks      []Task
+	NextCursor string
+}
+
+// CreateDraft creates a draft owned by taskerID and returns the full Task.
 func (s *Service) CreateDraft(ctx context.Context, taskerID string, in DraftInput) (Task, error) {
 	if err := validateTitle(in.Title); err != nil {
 		return Task{}, err
 	}
-	return s.store.InsertDraft(ctx, taskerID, strings.TrimSpace(in.Title), in.Description, in.Criteria, in.DueDate)
+	created, err := s.store.InsertDraft(ctx, taskerID, strings.TrimSpace(in.Title), in.Description, in.Criteria, in.DueDate)
+	if err != nil {
+		return Task{}, err
+	}
+	return s.store.LoadAggregate(ctx, created.ID)
 }
 
-// GetOwned returns a task the caller owns.
+// GetOwned returns the bare row of a task the caller owns (ownership probe).
 func (s *Service) GetOwned(ctx context.Context, taskerID, taskID string) (Task, error) {
 	return s.store.GetOwned(ctx, taskID, taskerID)
 }
 
-// GetReadable returns a task the caller may read (owner or assigned referee).
+// GetReadable returns the full Task a caller may read (owner or assigned referee).
 func (s *Service) GetReadable(ctx context.Context, userID, taskID string) (Task, error) {
-	return s.store.GetReadable(ctx, taskID, userID)
+	return s.store.GetReadableAggregate(ctx, taskID, userID)
 }
 
-// ListOwned returns the caller's tasks.
-func (s *Service) ListOwned(ctx context.Context, taskerID string, p ListParams) ([]Task, error) {
-	return s.store.ListOwned(ctx, taskerID, p.Status, p.Limit, p.Offset)
-}
-
-// UpdateDraft replaces the editable fields of a draft the caller owns. A
-// non-draft task is ErrConflict; a missing/foreign id is ErrNotFound.
-func (s *Service) UpdateDraft(ctx context.Context, taskerID, taskID string, in DraftInput) (Task, error) {
-	if err := validateTitle(in.Title); err != nil {
-		return Task{}, err
+// ListOwned returns a cursor page of the caller's tasks.
+func (s *Service) ListOwned(ctx context.Context, taskerID, status, cursor string, limit int) (Page, error) {
+	tasks, next, err := s.store.ListOwnedPage(ctx, taskerID, status, cursor, limit)
+	if err != nil {
+		return Page{}, err
 	}
-	var out Task
+	return Page{Tasks: tasks, NextCursor: next}, nil
+}
+
+// Assignments returns a cursor page of the tasks the caller currently referees.
+func (s *Service) Assignments(ctx context.Context, refereeID, cursor string, limit int) (Page, error) {
+	tasks, next, err := s.store.ListAssignmentsPage(ctx, refereeID, cursor, limit)
+	if err != nil {
+		return Page{}, err
+	}
+	return Page{Tasks: tasks, NextCursor: next}, nil
+}
+
+// UpdateDraft applies a presence-aware partial update to a draft the caller owns
+// (omitted fields unchanged; explicit null clears nullable fields) and returns
+// the full Task. A non-draft task is ErrConflict; a missing/foreign id is
+// ErrNotFound.
+func (s *Service) UpdateDraft(ctx context.Context, taskerID, taskID string, patch PatchInput) (Task, error) {
 	err := database.WithTx(ctx, s.db, func(tx database.Querier) error {
-		t, err := s.store.GetOwnedForUpdateInTx(ctx, tx, taskID, taskerID)
+		draft, err := s.store.GetOwnedForUpdateInTx(ctx, tx, taskID, taskerID)
 		if err != nil {
 			return err
 		}
-		if t.Status != "draft" {
+		if draft.Status != "draft" {
 			return ErrConflict
 		}
-		out, err = s.store.UpdateDraftFieldsInTx(ctx, tx, taskID,
-			strings.TrimSpace(in.Title), in.Description, in.Criteria, in.DueDate)
-		return err
+		title := draft.Title
+		if patch.SetTitle {
+			if patch.Title == nil || strings.TrimSpace(*patch.Title) == "" {
+				return fmt.Errorf("%w: title cannot be empty", ErrValidation)
+			}
+			title = strings.TrimSpace(*patch.Title)
+		}
+		description := draft.Description
+		if patch.SetDesc {
+			description = patch.Description
+		}
+		criteria := draft.Criteria
+		if patch.SetCriteria {
+			criteria = patch.Criteria
+		}
+		due := draft.DueDate
+		if patch.SetDueDate {
+			due = patch.DueDate
+		}
+		return s.store.UpdateDraftFieldsInTx(ctx, tx, taskID, title, description, criteria, due)
 	})
-	return out, err
+	if err != nil {
+		return Task{}, err
+	}
+	return s.store.LoadAggregate(ctx, taskID)
 }
 
 // DeleteDraft removes a draft the caller owns. A non-draft task is ErrConflict;
@@ -120,7 +169,6 @@ func (s *Service) Publish(ctx context.Context, callerID, taskID string, refereeC
 	if refereeCount < 1 || refereeCount > maxReferees {
 		return Task{}, fmt.Errorf("%w: refereeCount must be 1..%d", ErrValidation, maxReferees)
 	}
-	var out Task
 	err = database.WithTx(ctx, s.db, func(tx database.Querier) error {
 		t, err := s.store.GetOwnedForUpdateInTx(ctx, tx, taskID, callerID)
 		if err != nil {
@@ -132,17 +180,15 @@ func (s *Service) Publish(ctx context.Context, callerID, taskID string, refereeC
 		if err := ValidateOpenRequirements(t, minLead); err != nil {
 			return err
 		}
-		opened, err := s.store.SetStatusInTx(ctx, tx, taskID, "open")
-		if err != nil {
+		if err := s.store.SetStatusInTx(ctx, tx, taskID, "open"); err != nil {
 			return err
 		}
-		if err := s.requests.CreateInTx(ctx, tx, taskID, callerID, refereeCount); err != nil {
-			return err
-		}
-		out = opened
-		return nil
+		return s.requests.CreateInTx(ctx, tx, taskID, callerID, refereeCount)
 	})
-	return out, err
+	if err != nil {
+		return Task{}, err
+	}
+	return s.store.LoadAggregate(ctx, taskID)
 }
 
 func validateTitle(title string) error {

--- a/backend/internal/task/service.go
+++ b/backend/internal/task/service.go
@@ -10,12 +10,13 @@ import (
 )
 
 // RefereeRequestCreator creates a task's referee requests (and their match
-// jobs) inside the publish transaction, and reports the minimum publish lead
-// time. It is declared here (consumer-side) so the task feature stays
-// independent of the matching feature; matching.Service implements it.
+// jobs) inside the publish transaction, and reports the publish bounds
+// (minimum lead hours, maximum referee count). It is declared here
+// (consumer-side) so the task feature stays independent of the matching
+// feature; matching.Service implements it.
 type RefereeRequestCreator interface {
 	CreateInTx(ctx context.Context, tx database.Querier, taskID, taskerID string, count int) error
-	OpenDeadlineHours(ctx context.Context) (int, error)
+	PublishBounds(ctx context.Context) (minLeadHours, maxReferees int, err error)
 }
 
 // Service is the task use case: draft CRUD (owner-scoped) and the publish
@@ -106,6 +107,42 @@ func (s *Service) DeleteDraft(ctx context.Context, taskerID, taskID string) erro
 		}
 		return s.store.DeleteInTx(ctx, tx, taskID)
 	})
+}
+
+// Publish validates the open requirements, flips the draft to open, and creates
+// its referee requests + match jobs in one transaction. Only the owner, only
+// from draft, with a referee count within the matching-config bounds.
+func (s *Service) Publish(ctx context.Context, callerID, taskID string, refereeCount int) (Task, error) {
+	minLead, maxReferees, err := s.requests.PublishBounds(ctx)
+	if err != nil {
+		return Task{}, err
+	}
+	if refereeCount < 1 || refereeCount > maxReferees {
+		return Task{}, fmt.Errorf("%w: refereeCount must be 1..%d", ErrValidation, maxReferees)
+	}
+	var out Task
+	err = database.WithTx(ctx, s.db, func(tx database.Querier) error {
+		t, err := s.store.GetOwnedForUpdateInTx(ctx, tx, taskID, callerID)
+		if err != nil {
+			return err
+		}
+		if t.Status != "draft" {
+			return ErrConflict
+		}
+		if err := ValidateOpenRequirements(t, minLead); err != nil {
+			return err
+		}
+		if err := s.store.SetStatusInTx(ctx, tx, taskID, "open"); err != nil {
+			return err
+		}
+		if err := s.requests.CreateInTx(ctx, tx, taskID, callerID, refereeCount); err != nil {
+			return err
+		}
+		t.Status = "open"
+		out = t
+		return nil
+	})
+	return out, err
 }
 
 func validateTitle(title string) error {

--- a/backend/internal/task/service_test.go
+++ b/backend/internal/task/service_test.go
@@ -90,7 +90,9 @@ func TestUpdateDraft(t *testing.T) {
 	owner := newUser(t, db)
 	created, _ := svc.CreateDraft(ctx, owner, task.DraftInput{Title: "draft"})
 
-	updated, err := svc.UpdateDraft(ctx, owner, created.ID, task.DraftInput{Title: "edited", Criteria: ptr("done")})
+	updated, err := svc.UpdateDraft(ctx, owner, created.ID, task.PatchInput{
+		SetTitle: true, Title: ptr("edited"), SetCriteria: true, Criteria: ptr("done"),
+	})
 	if err != nil {
 		t.Fatalf("update: %v", err)
 	}
@@ -98,9 +100,18 @@ func TestUpdateDraft(t *testing.T) {
 		t.Fatalf("unexpected update %+v", updated)
 	}
 
+	// A patch that omits title leaves it unchanged (presence-aware).
+	patched, err := svc.UpdateDraft(ctx, owner, created.ID, task.PatchInput{SetDesc: true, Description: ptr("note")})
+	if err != nil {
+		t.Fatalf("partial update: %v", err)
+	}
+	if patched.Title != "edited" || patched.Description == nil || *patched.Description != "note" {
+		t.Fatalf("partial update did not preserve title / set description: %+v", patched)
+	}
+
 	// Non-owner update is not found.
 	other := newUser(t, db)
-	if _, err := svc.UpdateDraft(ctx, other, created.ID, task.DraftInput{Title: "x"}); !errors.Is(err, task.ErrNotFound) {
+	if _, err := svc.UpdateDraft(ctx, other, created.ID, task.PatchInput{SetTitle: true, Title: ptr("x")}); !errors.Is(err, task.ErrNotFound) {
 		t.Fatalf("cross-user update: want ErrNotFound, got %v", err)
 	}
 
@@ -108,7 +119,7 @@ func TestUpdateDraft(t *testing.T) {
 	if _, err := db.Exec(`UPDATE public.tasks SET status='open' WHERE id=$1`, created.ID); err != nil {
 		t.Fatalf("open task: %v", err)
 	}
-	if _, err := svc.UpdateDraft(ctx, owner, created.ID, task.DraftInput{Title: "x"}); !errors.Is(err, task.ErrConflict) {
+	if _, err := svc.UpdateDraft(ctx, owner, created.ID, task.PatchInput{SetTitle: true, Title: ptr("x")}); !errors.Is(err, task.ErrConflict) {
 		t.Fatalf("update opened: want ErrConflict, got %v", err)
 	}
 }
@@ -148,13 +159,13 @@ func TestListOwnedFiltersByStatus(t *testing.T) {
 		t.Fatalf("open: %v", err)
 	}
 
-	all, err := svc.ListOwned(ctx, owner, task.ListParams{Limit: 50})
-	if err != nil || len(all) != 2 {
-		t.Fatalf("list all: %v len=%d", err, len(all))
+	all, err := svc.ListOwned(ctx, owner, "", "", 50)
+	if err != nil || len(all.Tasks) != 2 {
+		t.Fatalf("list all: %v len=%d", err, len(all.Tasks))
 	}
-	drafts, err := svc.ListOwned(ctx, owner, task.ListParams{Status: "draft", Limit: 50})
-	if err != nil || len(drafts) != 1 || drafts[0].Status != "draft" {
-		t.Fatalf("list drafts: %v %+v", err, drafts)
+	drafts, err := svc.ListOwned(ctx, owner, "draft", "", 50)
+	if err != nil || len(drafts.Tasks) != 1 || drafts.Tasks[0].Status != "draft" {
+		t.Fatalf("list drafts: %v %+v", err, drafts.Tasks)
 	}
 }
 

--- a/backend/internal/task/service_test.go
+++ b/backend/internal/task/service_test.go
@@ -1,0 +1,182 @@
+package task_test
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/cloveclovedev/peppercheck/backend/internal/task"
+	"github.com/cloveclovedev/peppercheck/backend/internal/testsupport"
+)
+
+func newUser(t *testing.T, db *sql.DB) string {
+	t.Helper()
+	var id string
+	if err := db.QueryRow(`INSERT INTO public.users DEFAULT VALUES RETURNING id`).Scan(&id); err != nil {
+		t.Fatalf("seed user: %v", err)
+	}
+	return id
+}
+
+func newService(t *testing.T, db *sql.DB) *task.Service {
+	t.Helper()
+	return task.NewService(db, task.NewStore(db), nil) // nil creator: draft CRUD does not use it
+}
+
+func ptr(s string) *string { return &s }
+
+func TestValidateOpenRequirements(t *testing.T) {
+	const minLead = 24
+	crit := "did it"
+
+	if err := task.ValidateOpenRequirements(task.Task{Title: "x"}, minLead); err == nil {
+		t.Fatal("want error: missing due_date/criteria")
+	}
+	soon := time.Now().Add(1 * time.Hour)
+	if err := task.ValidateOpenRequirements(task.Task{Title: "x", DueDate: &soon, Criteria: &crit}, minLead); err == nil {
+		t.Fatalf("want error: due_date within %dh lead", minLead)
+	}
+	blank := "   "
+	future := time.Now().Add(48 * time.Hour)
+	if err := task.ValidateOpenRequirements(task.Task{Title: "x", DueDate: &future, Criteria: &blank}, minLead); err == nil {
+		t.Fatal("want error: blank criteria")
+	}
+	if err := task.ValidateOpenRequirements(task.Task{Title: "x", DueDate: &future, Criteria: &crit}, minLead); err != nil {
+		t.Fatalf("want valid, got %v", err)
+	}
+}
+
+func TestCreateAndGetDraft(t *testing.T) {
+	db := testsupport.DB(t)
+	svc := newService(t, db)
+	ctx := context.Background()
+	owner := newUser(t, db)
+
+	created, err := svc.CreateDraft(ctx, owner, task.DraftInput{Title: " Wash the car ", Criteria: ptr("shiny")})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if created.Title != "Wash the car" || created.Status != "draft" {
+		t.Fatalf("unexpected draft %+v", created)
+	}
+
+	got, err := svc.GetOwned(ctx, owner, created.ID)
+	if err != nil || got.ID != created.ID {
+		t.Fatalf("get owned: %v %+v", err, got)
+	}
+
+	// A different user cannot fetch it as owner.
+	other := newUser(t, db)
+	if _, err := svc.GetOwned(ctx, other, created.ID); !errors.Is(err, task.ErrNotFound) {
+		t.Fatalf("cross-user get: want ErrNotFound, got %v", err)
+	}
+}
+
+func TestCreateRejectsEmptyTitle(t *testing.T) {
+	db := testsupport.DB(t)
+	svc := newService(t, db)
+	owner := newUser(t, db)
+	if _, err := svc.CreateDraft(context.Background(), owner, task.DraftInput{Title: "   "}); !errors.Is(err, task.ErrValidation) {
+		t.Fatalf("want ErrValidation, got %v", err)
+	}
+}
+
+func TestUpdateDraft(t *testing.T) {
+	db := testsupport.DB(t)
+	svc := newService(t, db)
+	ctx := context.Background()
+	owner := newUser(t, db)
+	created, _ := svc.CreateDraft(ctx, owner, task.DraftInput{Title: "draft"})
+
+	updated, err := svc.UpdateDraft(ctx, owner, created.ID, task.DraftInput{Title: "edited", Criteria: ptr("done")})
+	if err != nil {
+		t.Fatalf("update: %v", err)
+	}
+	if updated.Title != "edited" || updated.Criteria == nil || *updated.Criteria != "done" {
+		t.Fatalf("unexpected update %+v", updated)
+	}
+
+	// Non-owner update is not found.
+	other := newUser(t, db)
+	if _, err := svc.UpdateDraft(ctx, other, created.ID, task.DraftInput{Title: "x"}); !errors.Is(err, task.ErrNotFound) {
+		t.Fatalf("cross-user update: want ErrNotFound, got %v", err)
+	}
+
+	// An opened task cannot be edited as a draft.
+	if _, err := db.Exec(`UPDATE public.tasks SET status='open' WHERE id=$1`, created.ID); err != nil {
+		t.Fatalf("open task: %v", err)
+	}
+	if _, err := svc.UpdateDraft(ctx, owner, created.ID, task.DraftInput{Title: "x"}); !errors.Is(err, task.ErrConflict) {
+		t.Fatalf("update opened: want ErrConflict, got %v", err)
+	}
+}
+
+func TestDeleteDraft(t *testing.T) {
+	db := testsupport.DB(t)
+	svc := newService(t, db)
+	ctx := context.Background()
+	owner := newUser(t, db)
+	created, _ := svc.CreateDraft(ctx, owner, task.DraftInput{Title: "draft"})
+
+	if err := svc.DeleteDraft(ctx, owner, created.ID); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	if _, err := svc.GetOwned(ctx, owner, created.ID); !errors.Is(err, task.ErrNotFound) {
+		t.Fatalf("after delete: want ErrNotFound, got %v", err)
+	}
+
+	// A non-draft task cannot be deleted through the draft path.
+	other, _ := svc.CreateDraft(ctx, owner, task.DraftInput{Title: "d2"})
+	if _, err := db.Exec(`UPDATE public.tasks SET status='open' WHERE id=$1`, other.ID); err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	if err := svc.DeleteDraft(ctx, owner, other.ID); !errors.Is(err, task.ErrConflict) {
+		t.Fatalf("delete opened: want ErrConflict, got %v", err)
+	}
+}
+
+func TestListOwnedFiltersByStatus(t *testing.T) {
+	db := testsupport.DB(t)
+	svc := newService(t, db)
+	ctx := context.Background()
+	owner := newUser(t, db)
+	d1, _ := svc.CreateDraft(ctx, owner, task.DraftInput{Title: "a"})
+	_, _ = svc.CreateDraft(ctx, owner, task.DraftInput{Title: "b"})
+	if _, err := db.Exec(`UPDATE public.tasks SET status='open' WHERE id=$1`, d1.ID); err != nil {
+		t.Fatalf("open: %v", err)
+	}
+
+	all, err := svc.ListOwned(ctx, owner, task.ListParams{Limit: 50})
+	if err != nil || len(all) != 2 {
+		t.Fatalf("list all: %v len=%d", err, len(all))
+	}
+	drafts, err := svc.ListOwned(ctx, owner, task.ListParams{Status: "draft", Limit: 50})
+	if err != nil || len(drafts) != 1 || drafts[0].Status != "draft" {
+		t.Fatalf("list drafts: %v %+v", err, drafts)
+	}
+}
+
+func TestGetReadableByAssignedReferee(t *testing.T) {
+	db := testsupport.DB(t)
+	svc := newService(t, db)
+	ctx := context.Background()
+	owner := newUser(t, db)
+	created, _ := svc.CreateDraft(ctx, owner, task.DraftInput{Title: "assigned"})
+
+	referee := newUser(t, db)
+	if _, err := db.Exec(
+		`INSERT INTO public.referee_requests (task_id, status, matched_referee_id) VALUES ($1,'accepted',$2)`,
+		created.ID, referee); err != nil {
+		t.Fatalf("seed accepted request: %v", err)
+	}
+
+	if got, err := svc.GetReadable(ctx, referee, created.ID); err != nil || got.ID != created.ID {
+		t.Fatalf("referee read: %v %+v", err, got)
+	}
+	stranger := newUser(t, db)
+	if _, err := svc.GetReadable(ctx, stranger, created.ID); !errors.Is(err, task.ErrNotFound) {
+		t.Fatalf("stranger read: want ErrNotFound, got %v", err)
+	}
+}

--- a/backend/internal/task/store.go
+++ b/backend/internal/task/store.go
@@ -151,11 +151,15 @@ func (s *Store) DeleteInTx(ctx context.Context, q database.Querier, taskID strin
 }
 
 // SetStatusInTx sets a task's status (the caller has validated the transition
-// under the row lock).
-func (s *Store) SetStatusInTx(ctx context.Context, q database.Querier, taskID, status string) error {
-	if _, err := q.ExecContext(ctx,
-		`UPDATE public.tasks SET status = $2, updated_at = now() WHERE id = $1`, taskID, status); err != nil {
-		return fmt.Errorf("set task status: %w", err)
+// under the row lock) and returns the updated row, so the caller reports the
+// persisted status AND the refreshed updated_at rather than a stale copy.
+func (s *Store) SetStatusInTx(ctx context.Context, q database.Querier, taskID, status string) (Task, error) {
+	row := q.QueryRowContext(ctx,
+		`UPDATE public.tasks SET status = $2, updated_at = now() WHERE id = $1
+		 RETURNING `+taskColumns, taskID, status)
+	t, err := scanTask(row)
+	if err != nil {
+		return Task{}, fmt.Errorf("set task status: %w", err)
 	}
-	return nil
+	return t, nil
 }

--- a/backend/internal/task/store.go
+++ b/backend/internal/task/store.go
@@ -1,0 +1,161 @@
+package task
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"time"
+
+	"github.com/cloveclovedev/peppercheck/backend/internal/core/database"
+)
+
+// Store issues the SQL over the tasks table. All read/write helpers are
+// caller-scoped by tasker_id (ownership) except GetReadable, which also admits
+// the assigned referee.
+type Store struct {
+	db *database.Handle
+}
+
+// NewStore builds a Store over an open database handle.
+func NewStore(db *database.Handle) *Store { return &Store{db: db} }
+
+const taskColumns = `id, tasker_id, title, description, criteria, due_date, status, created_at, updated_at`
+
+func scanTask(s interface {
+	Scan(...any) error
+}) (Task, error) {
+	var t Task
+	var tasker sql.NullString
+	var desc, crit sql.NullString
+	var due sql.NullTime
+	if err := s.Scan(&t.ID, &tasker, &t.Title, &desc, &crit, &due, &t.Status, &t.CreatedAt, &t.UpdatedAt); err != nil {
+		return Task{}, err
+	}
+	t.TaskerID = tasker.String
+	if desc.Valid {
+		t.Description = &desc.String
+	}
+	if crit.Valid {
+		t.Criteria = &crit.String
+	}
+	if due.Valid {
+		t.DueDate = &due.Time
+	}
+	return t, nil
+}
+
+// InsertDraft creates a draft owned by taskerID.
+func (s *Store) InsertDraft(ctx context.Context, taskerID, title string, description, criteria *string, due *time.Time) (Task, error) {
+	row := s.db.QueryRowContext(ctx,
+		`INSERT INTO public.tasks (tasker_id, title, description, criteria, due_date, status)
+		 VALUES ($1, $2, $3, $4, $5, 'draft')
+		 RETURNING `+taskColumns,
+		taskerID, title, description, criteria, due)
+	return scanTask(row)
+}
+
+// GetOwned loads a task the caller owns; a missing/foreign id is ErrNotFound.
+func (s *Store) GetOwned(ctx context.Context, taskID, taskerID string) (Task, error) {
+	row := s.db.QueryRowContext(ctx,
+		`SELECT `+taskColumns+` FROM public.tasks WHERE id = $1 AND tasker_id = $2`, taskID, taskerID)
+	t, err := scanTask(row)
+	if err == sql.ErrNoRows {
+		return Task{}, ErrNotFound
+	}
+	if err != nil {
+		return Task{}, fmt.Errorf("get owned task: %w", err)
+	}
+	return t, nil
+}
+
+// GetReadable loads a task the caller may read: its owner or a referee assigned
+// to it (any non-terminal request). A missing/unauthorized id is ErrNotFound.
+func (s *Store) GetReadable(ctx context.Context, taskID, userID string) (Task, error) {
+	row := s.db.QueryRowContext(ctx,
+		`SELECT `+taskColumns+` FROM public.tasks t
+		 WHERE t.id = $1 AND (
+		     t.tasker_id = $2
+		     OR EXISTS (SELECT 1 FROM public.referee_requests r
+		                WHERE r.task_id = t.id AND r.matched_referee_id = $2
+		                  AND r.status IN ('accepted', 'closed')))`, taskID, userID)
+	t, err := scanTask(row)
+	if err == sql.ErrNoRows {
+		return Task{}, ErrNotFound
+	}
+	if err != nil {
+		return Task{}, fmt.Errorf("get readable task: %w", err)
+	}
+	return t, nil
+}
+
+// ListOwned returns the caller's tasks, optionally filtered by status, newest
+// first, with limit/offset paging.
+func (s *Store) ListOwned(ctx context.Context, taskerID string, status string, limit, offset int) ([]Task, error) {
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT `+taskColumns+` FROM public.tasks
+		 WHERE tasker_id = $1 AND ($2 = '' OR status::text = $2)
+		 ORDER BY created_at DESC
+		 LIMIT $3 OFFSET $4`, taskerID, status, limit, offset)
+	if err != nil {
+		return nil, fmt.Errorf("list owned tasks: %w", err)
+	}
+	defer rows.Close()
+	var out []Task
+	for rows.Next() {
+		t, err := scanTask(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, t)
+	}
+	return out, rows.Err()
+}
+
+// GetOwnedForUpdateInTx row-locks a task the caller owns so an edit/delete/
+// publish validates and mutates it atomically. A missing/foreign id is ErrNotFound.
+func (s *Store) GetOwnedForUpdateInTx(ctx context.Context, q database.Querier, taskID, taskerID string) (Task, error) {
+	row := q.QueryRowContext(ctx,
+		`SELECT `+taskColumns+` FROM public.tasks WHERE id = $1 AND tasker_id = $2 FOR UPDATE`, taskID, taskerID)
+	t, err := scanTask(row)
+	if err == sql.ErrNoRows {
+		return Task{}, ErrNotFound
+	}
+	if err != nil {
+		return Task{}, fmt.Errorf("lock owned task: %w", err)
+	}
+	return t, nil
+}
+
+// UpdateDraftFieldsInTx replaces the editable fields of a draft the caller has
+// already validated (owned + still draft, under the row lock).
+func (s *Store) UpdateDraftFieldsInTx(ctx context.Context, q database.Querier, taskID, title string, description, criteria *string, due *time.Time) (Task, error) {
+	row := q.QueryRowContext(ctx,
+		`UPDATE public.tasks
+		 SET title = $2, description = $3, criteria = $4, due_date = $5, updated_at = now()
+		 WHERE id = $1
+		 RETURNING `+taskColumns,
+		taskID, title, description, criteria, due)
+	t, err := scanTask(row)
+	if err != nil {
+		return Task{}, fmt.Errorf("update draft: %w", err)
+	}
+	return t, nil
+}
+
+// DeleteInTx removes a task (the caller has validated ownership + draft status).
+func (s *Store) DeleteInTx(ctx context.Context, q database.Querier, taskID string) error {
+	if _, err := q.ExecContext(ctx, `DELETE FROM public.tasks WHERE id = $1`, taskID); err != nil {
+		return fmt.Errorf("delete task: %w", err)
+	}
+	return nil
+}
+
+// SetStatusInTx sets a task's status (the caller has validated the transition
+// under the row lock).
+func (s *Store) SetStatusInTx(ctx context.Context, q database.Querier, taskID, status string) error {
+	if _, err := q.ExecContext(ctx,
+		`UPDATE public.tasks SET status = $2, updated_at = now() WHERE id = $1`, taskID, status); err != nil {
+		return fmt.Errorf("set task status: %w", err)
+	}
+	return nil
+}

--- a/backend/internal/task/store.go
+++ b/backend/internal/task/store.go
@@ -9,9 +9,11 @@ import (
 	"github.com/cloveclovedev/peppercheck/backend/internal/core/database"
 )
 
-// Store issues the SQL over the tasks table. All read/write helpers are
-// caller-scoped by tasker_id (ownership) except GetReadable, which also admits
-// the assigned referee.
+// Store issues the SQL over the tasks table and assembles the Task read-model
+// (§7.1): the task row plus the tasker's embedded public profile and the task's
+// referee requests (each with the matched referee's public profile). Reading
+// referee_requests + profiles here is the one cross-feature read the task
+// handlers perform, pinned by the wire contract.
 type Store struct {
 	db *database.Handle
 }
@@ -21,12 +23,9 @@ func NewStore(db *database.Handle) *Store { return &Store{db: db} }
 
 const taskColumns = `id, tasker_id, title, description, criteria, due_date, status, created_at, updated_at`
 
-func scanTask(s interface {
-	Scan(...any) error
-}) (Task, error) {
+func scanTask(s interface{ Scan(...any) error }) (Task, error) {
 	var t Task
-	var tasker sql.NullString
-	var desc, crit sql.NullString
+	var tasker, desc, crit sql.NullString
 	var due sql.NullTime
 	if err := s.Scan(&t.ID, &tasker, &t.Title, &desc, &crit, &due, &t.Status, &t.CreatedAt, &t.UpdatedAt); err != nil {
 		return Task{}, err
@@ -44,7 +43,9 @@ func scanTask(s interface {
 	return t, nil
 }
 
-// InsertDraft creates a draft owned by taskerID.
+// --- mutations (bare rows; the caller loads the aggregate for the response) ---
+
+// InsertDraft creates a draft owned by taskerID, returning its bare row.
 func (s *Store) InsertDraft(ctx context.Context, taskerID, title string, description, criteria *string, due *time.Time) (Task, error) {
 	row := s.db.QueryRowContext(ctx,
 		`INSERT INTO public.tasks (tasker_id, title, description, criteria, due_date, status)
@@ -54,7 +55,8 @@ func (s *Store) InsertDraft(ctx context.Context, taskerID, title string, descrip
 	return scanTask(row)
 }
 
-// GetOwned loads a task the caller owns; a missing/foreign id is ErrNotFound.
+// GetOwned loads the bare row of a task the caller owns; a missing/foreign id is
+// ErrNotFound.
 func (s *Store) GetOwned(ctx context.Context, taskID, taskerID string) (Task, error) {
 	row := s.db.QueryRowContext(ctx,
 		`SELECT `+taskColumns+` FROM public.tasks WHERE id = $1 AND tasker_id = $2`, taskID, taskerID)
@@ -66,49 +68,6 @@ func (s *Store) GetOwned(ctx context.Context, taskID, taskerID string) (Task, er
 		return Task{}, fmt.Errorf("get owned task: %w", err)
 	}
 	return t, nil
-}
-
-// GetReadable loads a task the caller may read: its owner or a referee assigned
-// to it (any non-terminal request). A missing/unauthorized id is ErrNotFound.
-func (s *Store) GetReadable(ctx context.Context, taskID, userID string) (Task, error) {
-	row := s.db.QueryRowContext(ctx,
-		`SELECT `+taskColumns+` FROM public.tasks t
-		 WHERE t.id = $1 AND (
-		     t.tasker_id = $2
-		     OR EXISTS (SELECT 1 FROM public.referee_requests r
-		                WHERE r.task_id = t.id AND r.matched_referee_id = $2
-		                  AND r.status IN ('accepted', 'closed')))`, taskID, userID)
-	t, err := scanTask(row)
-	if err == sql.ErrNoRows {
-		return Task{}, ErrNotFound
-	}
-	if err != nil {
-		return Task{}, fmt.Errorf("get readable task: %w", err)
-	}
-	return t, nil
-}
-
-// ListOwned returns the caller's tasks, optionally filtered by status, newest
-// first, with limit/offset paging.
-func (s *Store) ListOwned(ctx context.Context, taskerID string, status string, limit, offset int) ([]Task, error) {
-	rows, err := s.db.QueryContext(ctx,
-		`SELECT `+taskColumns+` FROM public.tasks
-		 WHERE tasker_id = $1 AND ($2 = '' OR status::text = $2)
-		 ORDER BY created_at DESC
-		 LIMIT $3 OFFSET $4`, taskerID, status, limit, offset)
-	if err != nil {
-		return nil, fmt.Errorf("list owned tasks: %w", err)
-	}
-	defer rows.Close()
-	var out []Task
-	for rows.Next() {
-		t, err := scanTask(rows)
-		if err != nil {
-			return nil, err
-		}
-		out = append(out, t)
-	}
-	return out, rows.Err()
 }
 
 // GetOwnedForUpdateInTx row-locks a task the caller owns so an edit/delete/
@@ -128,18 +87,15 @@ func (s *Store) GetOwnedForUpdateInTx(ctx context.Context, q database.Querier, t
 
 // UpdateDraftFieldsInTx replaces the editable fields of a draft the caller has
 // already validated (owned + still draft, under the row lock).
-func (s *Store) UpdateDraftFieldsInTx(ctx context.Context, q database.Querier, taskID, title string, description, criteria *string, due *time.Time) (Task, error) {
-	row := q.QueryRowContext(ctx,
+func (s *Store) UpdateDraftFieldsInTx(ctx context.Context, q database.Querier, taskID, title string, description, criteria *string, due *time.Time) error {
+	if _, err := q.ExecContext(ctx,
 		`UPDATE public.tasks
 		 SET title = $2, description = $3, criteria = $4, due_date = $5, updated_at = now()
-		 WHERE id = $1
-		 RETURNING `+taskColumns,
-		taskID, title, description, criteria, due)
-	t, err := scanTask(row)
-	if err != nil {
-		return Task{}, fmt.Errorf("update draft: %w", err)
+		 WHERE id = $1`,
+		taskID, title, description, criteria, due); err != nil {
+		return fmt.Errorf("update draft: %w", err)
 	}
-	return t, nil
+	return nil
 }
 
 // DeleteInTx removes a task (the caller has validated ownership + draft status).
@@ -151,15 +107,243 @@ func (s *Store) DeleteInTx(ctx context.Context, q database.Querier, taskID strin
 }
 
 // SetStatusInTx sets a task's status (the caller has validated the transition
-// under the row lock) and returns the updated row, so the caller reports the
-// persisted status AND the refreshed updated_at rather than a stale copy.
-func (s *Store) SetStatusInTx(ctx context.Context, q database.Querier, taskID, status string) (Task, error) {
-	row := q.QueryRowContext(ctx,
-		`UPDATE public.tasks SET status = $2, updated_at = now() WHERE id = $1
-		 RETURNING `+taskColumns, taskID, status)
+// under the row lock).
+func (s *Store) SetStatusInTx(ctx context.Context, q database.Querier, taskID, status string) error {
+	if _, err := q.ExecContext(ctx,
+		`UPDATE public.tasks SET status = $2, updated_at = now() WHERE id = $1`, taskID, status); err != nil {
+		return fmt.Errorf("set task status: %w", err)
+	}
+	return nil
+}
+
+// --- aggregate reads (the §7.1 Task read-model) ---------------------------
+
+// LoadAggregate loads the full Task read-model by id with no authorization check
+// — for building the response to an action the caller just performed (publish,
+// cancel). A missing id is ErrNotFound.
+func (s *Store) LoadAggregate(ctx context.Context, taskID string) (Task, error) {
+	row := s.db.QueryRowContext(ctx, `SELECT `+taskColumns+` FROM public.tasks WHERE id = $1`, taskID)
 	t, err := scanTask(row)
+	if err == sql.ErrNoRows {
+		return Task{}, ErrNotFound
+	}
 	if err != nil {
-		return Task{}, fmt.Errorf("set task status: %w", err)
+		return Task{}, fmt.Errorf("load task: %w", err)
+	}
+	if err := s.attachAll(ctx, []*Task{&t}); err != nil {
+		return Task{}, err
 	}
 	return t, nil
+}
+
+// GetReadableAggregate loads the full Task read-model for a task the caller may
+// read (its owner, or a referee assigned to it). A missing/unauthorized id is
+// ErrNotFound.
+func (s *Store) GetReadableAggregate(ctx context.Context, taskID, viewerID string) (Task, error) {
+	row := s.db.QueryRowContext(ctx,
+		`SELECT `+taskColumns+` FROM public.tasks t
+		 WHERE t.id = $1 AND (
+		     t.tasker_id = $2
+		     OR EXISTS (SELECT 1 FROM public.referee_requests r
+		                WHERE r.task_id = t.id AND r.matched_referee_id = $2
+		                  AND r.status IN ('accepted', 'closed')))`, taskID, viewerID)
+	t, err := scanTask(row)
+	if err == sql.ErrNoRows {
+		return Task{}, ErrNotFound
+	}
+	if err != nil {
+		return Task{}, fmt.Errorf("get readable task: %w", err)
+	}
+	if err := s.attachAll(ctx, []*Task{&t}); err != nil {
+		return Task{}, err
+	}
+	return t, nil
+}
+
+// ListOwnedPage returns a cursor page of the caller's tasks (newest first),
+// optionally filtered by status, and the next cursor ("" when exhausted).
+func (s *Store) ListOwnedPage(ctx context.Context, taskerID, status, cursorTok string, limit int) ([]Task, string, error) {
+	c, hasCursor, err := decodeCursor(cursorTok)
+	if err != nil {
+		return nil, "", err
+	}
+	q := `SELECT ` + taskColumns + ` FROM public.tasks
+	      WHERE tasker_id = $1 AND ($2 = '' OR status::text = $2)`
+	args := []any{taskerID, status}
+	if hasCursor {
+		q += ` AND (created_at, id) < ($3, $4)`
+		args = append(args, c.CreatedAt, c.ID)
+	}
+	q += fmt.Sprintf(` ORDER BY created_at DESC, id DESC LIMIT %d`, limit+1)
+	return s.queryPage(ctx, q, args, limit)
+}
+
+// ListAssignmentsPage returns a cursor page of the tasks the caller currently
+// referees (an accepted/closed request), newest task first.
+func (s *Store) ListAssignmentsPage(ctx context.Context, refereeID, cursorTok string, limit int) ([]Task, string, error) {
+	c, hasCursor, err := decodeCursor(cursorTok)
+	if err != nil {
+		return nil, "", err
+	}
+	q := `SELECT DISTINCT ` + taskColumnsPrefixed("t") + ` FROM public.tasks t
+	      JOIN public.referee_requests r ON r.task_id = t.id
+	      WHERE r.matched_referee_id = $1 AND r.status IN ('accepted', 'closed')`
+	args := []any{refereeID}
+	if hasCursor {
+		q += ` AND (t.created_at, t.id) < ($2, $3)`
+		args = append(args, c.CreatedAt, c.ID)
+	}
+	q += fmt.Sprintf(` ORDER BY t.created_at DESC, t.id DESC LIMIT %d`, limit+1)
+	return s.queryPage(ctx, q, args, limit)
+}
+
+func taskColumnsPrefixed(alias string) string {
+	return alias + ".id, " + alias + ".tasker_id, " + alias + ".title, " + alias + ".description, " +
+		alias + ".criteria, " + alias + ".due_date, " + alias + ".status, " + alias + ".created_at, " + alias + ".updated_at"
+}
+
+// queryPage runs a limit+1 page query, attaches the aggregate to each row, and
+// derives the next cursor (empty when the page is the last).
+func (s *Store) queryPage(ctx context.Context, query string, args []any, limit int) ([]Task, string, error) {
+	rows, err := s.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, "", fmt.Errorf("list tasks: %w", err)
+	}
+	defer rows.Close()
+	var tasks []Task
+	for rows.Next() {
+		t, err := scanTask(rows)
+		if err != nil {
+			return nil, "", err
+		}
+		tasks = append(tasks, t)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, "", err
+	}
+	next := ""
+	if len(tasks) > limit {
+		last := tasks[limit-1]
+		next = encodeCursor(cursor{CreatedAt: last.CreatedAt, ID: last.ID})
+		tasks = tasks[:limit]
+	}
+	ptrs := make([]*Task, len(tasks))
+	for i := range tasks {
+		ptrs[i] = &tasks[i]
+	}
+	if err := s.attachAll(ctx, ptrs); err != nil {
+		return nil, "", err
+	}
+	return tasks, next, nil
+}
+
+// attachAll batch-loads each task's tasker profile and referee requests (with
+// referee profiles), avoiding N+1: one query for all tasker profiles and one for
+// all referee requests across the given tasks.
+func (s *Store) attachAll(ctx context.Context, tasks []*Task) error {
+	if len(tasks) == 0 {
+		return nil
+	}
+	taskIDs := make([]string, 0, len(tasks))
+	taskerIDs := make([]string, 0, len(tasks))
+	for _, t := range tasks {
+		taskIDs = append(taskIDs, t.ID)
+		if t.TaskerID != "" {
+			taskerIDs = append(taskerIDs, t.TaskerID)
+		}
+	}
+	profiles, err := s.publicProfiles(ctx, taskerIDs)
+	if err != nil {
+		return err
+	}
+	reqs, err := s.refereeRequestsByTask(ctx, taskIDs)
+	if err != nil {
+		return err
+	}
+	for _, t := range tasks {
+		t.Tasker = profiles[t.TaskerID]
+		if rr, ok := reqs[t.ID]; ok {
+			t.RefereeRequests = rr
+		} else {
+			t.RefereeRequests = []RefereeRequest{}
+		}
+	}
+	return nil
+}
+
+// publicProfiles reads the minimal public projection (username + avatar) for the
+// given user ids.
+func (s *Store) publicProfiles(ctx context.Context, ids []string) (map[string]*PublicProfile, error) {
+	out := map[string]*PublicProfile{}
+	if len(ids) == 0 {
+		return out, nil
+	}
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT id, username, avatar_url FROM public.profiles WHERE id = ANY($1)`, ids)
+	if err != nil {
+		return nil, fmt.Errorf("load public profiles: %w", err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var p PublicProfile
+		var avatar sql.NullString
+		if err := rows.Scan(&p.UserID, &p.Username, &avatar); err != nil {
+			return nil, err
+		}
+		if avatar.Valid {
+			p.AvatarURL = &avatar.String
+		}
+		pp := p
+		out[p.UserID] = &pp
+	}
+	return out, rows.Err()
+}
+
+// refereeRequestsByTask loads all referee requests for the given tasks, grouped
+// by task id, each with the matched referee's public profile (nil while pending).
+func (s *Store) refereeRequestsByTask(ctx context.Context, taskIDs []string) (map[string][]RefereeRequest, error) {
+	out := map[string][]RefereeRequest{}
+	if len(taskIDs) == 0 {
+		return out, nil
+	}
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT r.id, r.task_id, r.status, r.matched_referee_id, r.responded_at,
+		       r.point_source, r.is_obligation, r.created_at, r.updated_at,
+		       p.id, p.username, p.avatar_url
+		FROM public.referee_requests r
+		LEFT JOIN public.profiles p ON p.id = r.matched_referee_id
+		WHERE r.task_id = ANY($1)
+		ORDER BY r.created_at`, taskIDs)
+	if err != nil {
+		return nil, fmt.Errorf("load referee requests: %w", err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var rr RefereeRequest
+		var matched, pointSource, pid, puser, pavatar sql.NullString
+		var responded sql.NullTime
+		if err := rows.Scan(&rr.ID, &rr.TaskID, &rr.Status, &matched, &responded,
+			&pointSource, &rr.IsObligation, &rr.CreatedAt, &rr.UpdatedAt,
+			&pid, &puser, &pavatar); err != nil {
+			return nil, err
+		}
+		if matched.Valid {
+			rr.MatchedRefereeID = &matched.String
+		}
+		if responded.Valid {
+			rr.RespondedAt = &responded.Time
+		}
+		if pointSource.Valid {
+			rr.PointSource = &pointSource.String
+		}
+		if pid.Valid {
+			prof := PublicProfile{UserID: pid.String, Username: puser.String}
+			if pavatar.Valid {
+				prof.AvatarURL = &pavatar.String
+			}
+			rr.Referee = &prof
+		}
+		out[rr.TaskID] = append(out[rr.TaskID], rr)
+	}
+	return out, rows.Err()
 }

--- a/backend/internal/worker/worker.go
+++ b/backend/internal/worker/worker.go
@@ -171,10 +171,19 @@ func (w *Worker) Loop(ctx context.Context) error {
 	}
 }
 
-// Run wires the built-in handlers and loops until ctx is cancelled.
-func Run(ctx context.Context, cfg config.Config, logger *slog.Logger, db *sql.DB) error {
+// Run builds the worker, registers the always-present noop handler, lets the
+// caller register feature handlers and run any one-time startup (via configure),
+// then loops until ctx is cancelled. Keeping feature wiring in the caller's
+// configure callback leaves this package free of feature imports (the
+// composition root owns which handlers exist).
+func Run(ctx context.Context, cfg config.Config, logger *slog.Logger, db *sql.DB, configure func(context.Context, *Worker) error) error {
 	w := New(db, logger)
 	w.SetHeartbeatURL(cfg.HeartbeatURLWorker)
 	w.Register("noop", func(context.Context, *jobs.Job) error { return nil })
+	if configure != nil {
+		if err := configure(ctx, w); err != nil {
+			return err
+		}
+	}
 	return w.Loop(ctx)
 }

--- a/backend/scripts/assert-prod-config.sh
+++ b/backend/scripts/assert-prod-config.sh
@@ -64,6 +64,7 @@ readonly SECRET_NAMES=(
   database_url
   migrator_database_url
   web_form_signing_key
+  firebase_service_account
 )
 mkdir -p "$SECRETS_DIR"
 for name in "${SECRET_NAMES[@]}"; do
@@ -81,6 +82,19 @@ echo "$config_json" | jq -e '(.services.api.depends_on // {}) | has("migrate") |
 
 echo "==> asserting postgres publishes no host ports"
 echo "$config_json" | jq -e '(.services.postgres.ports // []) | length == 0' >/dev/null
+
+# The worker sends FCM (P4a-D18): it must mount the firebase_service_account
+# secret and point GOOGLE_APPLICATION_CREDENTIALS at it, with FIREBASE_PROJECT_ID
+# set. The api must NOT mount that secret -- it never sends FCM.
+echo "==> asserting worker mounts firebase_service_account + FCM env"
+echo "$config_json" | jq -e '
+  (.services.worker.secrets | map(if type=="object" then .source else . end) | index("firebase_service_account")) != null
+  and (.services.worker.environment.GOOGLE_APPLICATION_CREDENTIALS == "/run/secrets/firebase_service_account")
+  and (.services.worker.environment | has("FIREBASE_PROJECT_ID"))' >/dev/null
+
+echo "==> asserting api does NOT mount firebase_service_account"
+echo "$config_json" | jq -e '
+  (.services.api.secrets // [] | map(if type=="object" then .source else . end) | index("firebase_service_account")) == null' >/dev/null
 
 # `migrate` is `profiles: ["deploy"]`-only, so the default `config` resolution
 # above never includes it -- a `build:` added to that service later would

--- a/backend/scripts/deployment.bats
+++ b/backend/scripts/deployment.bats
@@ -86,7 +86,8 @@ teardown() {
 @test "write-secret: accepts every allowlisted name" {
   export DEPLOY_SECRET_DIR="$WORKDIR/secrets"
   for name in database_url postgres_superuser_pw postgres_app_pw postgres_migrator_pw \
-    postgres_backup_pw migrator_database_url pgbackrest_cipher b2_key_id b2_key_secret ghcr_token; do
+    postgres_backup_pw migrator_database_url pgbackrest_cipher b2_key_id b2_key_secret \
+    web_form_signing_key firebase_service_account ghcr_token; do
     run bash -c "printf %s 'x' | '$SCRIPT_DIR/write-secret.sh' '$name'"
     [ "$status" -eq 0 ]
     [ -f "$DEPLOY_SECRET_DIR/$name" ]

--- a/backend/scripts/remote-deploy.sh
+++ b/backend/scripts/remote-deploy.sh
@@ -73,14 +73,14 @@ compose --profile deploy pull
 # are mounted.
 #
 # UID mapping (matches compose.prod.yaml's consumers and the secret allowlist):
-#   database_url / web_form_signing_key                     -> 65532 (Go `nonroot`, api/worker)
+#   database_url / web_form_signing_key / firebase_service_account -> 65532 (Go `nonroot`, api/worker)
 #   postgres_* / pgbackrest_cipher / b2_key_id / b2_key_secret -> 999 (postgres image's `postgres` user)
 #   migrator_database_url                                   -> 0 (root -- the Atlas one-shot image runs as root by default)
 #   ghcr_token is left alone -- it stays deploy-owned, already consumed by the login above, not read by any container.
 docker run --rm --network none --pull never --entrypoint sh \
   -v "$d/secrets":/s \
   "$IMAGE_POSTGRES" -c '
-    chown 65532 /s/database_url /s/web_form_signing_key
+    chown 65532 /s/database_url /s/web_form_signing_key /s/firebase_service_account
     chown 999 /s/postgres_* /s/pgbackrest_cipher /s/b2_*
     chown 0 /s/migrator_database_url
     chmod 0400 /s/*

--- a/backend/scripts/ship-deployment.sh
+++ b/backend/scripts/ship-deployment.sh
@@ -91,7 +91,7 @@ rsync -a -e "${ssh_cmd[*]}" backend/ "deploy@${ssh_host}:${d}/"
 # writes deploy-owned, 0600 files via write-secret.sh.
 for k in database_url postgres_superuser_pw postgres_app_pw postgres_migrator_pw \
   postgres_backup_pw migrator_database_url pgbackrest_cipher b2_key_id b2_key_secret \
-  web_form_signing_key ghcr_token; do
+  web_form_signing_key firebase_service_account ghcr_token; do
   printf '%s' "${!k:?missing $k}" |
     "${ssh_cmd[@]}" "deploy@${ssh_host}" "DEPLOY_SECRET_DIR='${d}/secrets' /opt/peppercheck/scripts/write-secret.sh '$k'"
 done

--- a/backend/scripts/write-secret.sh
+++ b/backend/scripts/write-secret.sh
@@ -33,6 +33,7 @@ case "$name" in
   b2_key_id | \
   b2_key_secret | \
   web_form_signing_key | \
+  firebase_service_account | \
   ghcr_token)
     ;;
   *)


### PR DESCRIPTION
Phase 4a backend, **PR3 of 3** — the API surface + composition root that finishes Phase 4a's backend. Part of the Supabase → Go API/VPS refactor (parent #477); closes the backend half of #519. Builds on PR1 (#521, T1–T6) and PR2 (#527, T7–T9). Base branch: `refactor/go-api-vps`.

## Scope — T10–T12

- **T10 — referee handlers** (`internal/matching`)
  - `Service.Cancel`: the assigned referee drops an accepted request before the cancel deadline — marks it cancelled, deletes the awaiting_evidence judgement, inserts a fresh pending replacement carrying the original funding source (P4a-D17), and enqueues a match, all atomically (`FOR UPDATE` guarded).
  - Availability CRUD store methods + handler: `GET/POST/PUT/DELETE /me/availability/time-slots` and `.../blocked-dates` (user-scoped, range-validated), `GET /me/assignments`, `POST /referee-requests/{id}/cancel`.
- **T11 — task feature** (new `internal/task`)
  - `ValidateOpenRequirements` (pure), draft CRUD (`CreateDraft`/`UpdateDraft`/`DeleteDraft`/`GetOwned`/`GetReadable`/`ListOwned`), all owner-scoped with a draft-status guard; `GetReadable` also admits the assigned referee.
  - Handlers: `POST /tasks`, `GET /tasks/{id}`, `PATCH /tasks/{id}`, `DELETE /tasks/{id}`, `GET /me/tasks`.
- **T12 — publish orchestration + wiring**
  - `task.Service.Publish`: validate open requirements, flip draft→open, and create N referee requests + N match jobs in one transaction. `matching.Service` implements the consumer-declared `task.RefereeRequestCreator` (`CreateInTx` + `PublishBounds`), so `task` stays independent of `matching`.
  - Composition root: `api.Deps` mounts the task + referee routes behind the auth/CurrentUser chain; the worker registers `match_referee_request`, `sweep_pending_requests`, and `send_notification`, and bootstraps the recurring sweep (`worker.Run` now takes a `configure` callback, keeping the worker package free of feature imports).
  - FCM: the worker builds a real `fcm.New` client (fatal in production when misconfigured); other environments fall back to a new no-op client (`fcm.NewNoop`) so a local worker runs without Firebase. The api never sends FCM.
  - Deploy: `compose.prod.yaml`'s worker gains `FIREBASE_PROJECT_ID` + `GOOGLE_APPLICATION_CREDENTIALS` + the `firebase_service_account` file-secret (P4a-D18); `assert-prod-config.sh` asserts the worker mounts it and the api does not; the secret is added to the deploy render/allowlist path (`ship-deployment.sh`, `write-secret.sh`, `remote-deploy.sh` chown, `deployment.bats`).

The Phase 5 point/obligation seams stay no-ops; IDs remain `string` (#520 deferred).

## Tests

TDD throughout; full `make test` green on a throwaway Postgres (`-race -p 1`), plus `assert-prod-config.sh` green. New coverage: cancel (re-match, non-assigned 403, point-source carry-over, past-deadline), availability CRUD + cross-user scoping, active assignments, draft CRUD + ownership/draft guards, `GetReadable` by assigned referee, `ValidateOpenRequirements`, publish (atomic open + N requests + N jobs, creator-failure rollback, invalid count, missing criteria, non-owner/non-draft), and api integration tests (create→publish flow, cross-owner edit 404, publish validation 400, time-slot validation, cancel 403/404) through the real middleware chain.

## Self-review

A pre-merge `/code-review` pass fixed: BootstrapSweep failure made non-fatal (a startup DB blip must not take down match/notify processing); the task DTO made idless (was leaking the tasker's internal UUID to readers); and a redundant `maxInt` helper replaced with the built-in `max`.

## Operator follow-up (P4a-D18)

Before the next staging/production deploy, provision a worker-only least-privilege Firebase service account and add it to the deploy secret store as `firebase_service_account`. The ship step now requires it (`${firebase_service_account:?}`), so a deploy without it fails fast with a clear message rather than the worker silently dropping notifications.

## Follow-up tracked

- #528 — enforce `max_concurrent_assignments` transactionally at accept time (deferred to the availability-cap feature; unreachable at the 4a default, no cap setter yet).

## Docs

No documentation change needed: this PR adds internal API handlers + composition wiring with no new public setup steps beyond the operator FCM secret noted above (which lives in the deploy scripts/compose, self-documenting).

Part of #519.
